### PR TITLE
Refactor for `find` and `ids` methods

### DIFF
--- a/gems/activerecord/6.0.3.2/activerecord.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord.rbs
@@ -51,9 +51,9 @@ module ActiveRecord
   end
 end
 
-interface _ActiveRecord_Relation[Model]
+interface _ActiveRecord_Relation[Model, PrimaryKey]
   def all: () -> self
-  def ids: () -> Array[Integer]
+  def ids: () -> Array[PrimaryKey]
   def none: () -> self
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
@@ -79,7 +79,7 @@ interface _ActiveRecord_Relation[Model]
              | (Hash[untyped, untyped]) -> self
   def find_by: (*untyped) -> Model?
   def find_by!: (*untyped) -> Model
-  def find: (Integer id) -> Model
+  def find: (PrimaryKey id) -> Model
   def first: () -> Model
            | (Integer count) -> Array[Model]
   def last: () -> Model
@@ -94,9 +94,9 @@ interface _ActiveRecord_Relation[Model]
             | () { (Model) -> boolish } -> Array[Model]
 end
 
-interface _ActiveRecord_Relation_ClassMethods[Model, Relation]
+interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def all: () -> Relation
-  def ids: () -> Array[Integer]
+  def ids: () -> Array[PrimaryKey]
   def none: () -> Relation
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
@@ -121,7 +121,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation]
              | (Hash[untyped, untyped]) -> self
   def find_by: (*untyped) -> Model?
   def find_by!: (*untyped) -> Model
-  def find: (Integer id) -> Model
+  def find: (PrimaryKey id) -> Model
   def first: () -> Model
            | (Integer count) -> Array[Model]
   def last: () -> Model


### PR DESCRIPTION
This is for https://github.com/pocke/rbs_rails/pull/105.

Adding `PrimaryKey` type parameter allows supporting AR models with non-integer primary key.