### PR TITLE
Show help when executing `bin/run` without any arguments

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -8,7 +8,7 @@ require "open3"
 @repos = []
 @rbs_dir = Pathname.pwd
 
-OptionParser.new do |opts|
+parser = OptionParser.new do |opts|
   opts.on("--root=PATH", "Specify repository root given through `$REPO_ROOT`.") do |path|
     @repo_root = Pathname(path)
   end
@@ -30,7 +30,13 @@ Environment variables given to the command:
 
 Options:
 BANNER
-end.parse!(ARGV)
+end
+parser.parse!(ARGV)
+
+if ARGV.empty?
+  puts parser.help
+  exit
+end
 
 env = {
   "REPO_ROOT" => @repo_root.to_s,


### PR DESCRIPTION
Hi. This change aims to make the `bin/run` script a bit useful. 
(I was surprised with the error when I executed `bin/run` without any arguments 😅 )

Before:

```console
$ bin/run
bin/run:41:in `system': wrong number of arguments (given 0, expected 1+) (ArgumentError)
	from bin/run:41:in `<main>'
```

After:

```console
$ bin/run
Usage: bin/run [OPTIONS] COMMAND...

  Execute given `COMMAND` with environment variables.

...
```