### PR TITLE
[rails] Add AR::Base.has_and_belongs_to_many signature explicitly

### DIFF
--- a/gems/activerecord/6.0.3.2/activerecord.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord.rbs
@@ -6,6 +6,7 @@ module ActiveRecord
     def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
+    def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped
     def self.transaction: [T] () { () -> T } -> T
     def self.create!: (**untyped) -> instance
     def self.validate: (*untyped) -> void


### PR DESCRIPTION
It has been added by #23 but the generated type signature is not enough
because it requires the block parameter. So solve it by overriding the
method