### PR TITLE
Remove `Hash#except` from `ActiveSupport` signatures

### DIFF
--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -3325,16 +3325,6 @@ class Hash[unchecked out K, unchecked out V]
 end
 
 class Hash[unchecked out K, unchecked out V]
-  # Returns a hash that includes everything except given keys.
-  #   hash = { a: true, b: false, c: nil }
-  #   hash.except(:c)     # => { a: true, b: false }
-  #   hash.except(:a, :b) # => { c: nil }
-  #   hash                # => { a: true, b: false, c: nil }
-  #
-  # This is useful for limiting a set of parameters to everything but a few known toggles:
-  #   @person.update(params[:person].except(:admin))
-  def except: (*untyped keys) -> untyped
-
   # Removes the given keys from hash and returns it.
   #   hash = { a: true, b: false, c: nil }
   #   hash.except!(:c) # => { a: true, b: false }


### PR DESCRIPTION
This method is provided by core RBS signatures, as it was added in
Ruby 3. Retaining both produces a duplicate definition error in
Steep