### PR TITLE
Add block signature to `_ActiveRecord_Relation#find`

### DIFF
--- a/gems/activerecord/6.0.3.2/activerecord.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord.rbs
@@ -84,6 +84,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def find: (PrimaryKey id) -> Model
           | (Array[PrimaryKey]) -> Array[Model]
           | (*PrimaryKey) -> Array[Model]
+          | () { (Model) -> boolish } -> Model
   def first: () -> Model
            | (Integer count) -> Array[Model]
   def last: () -> Model

--- a/gems/activerecord/6.0.3.2/activerecord.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord.rbs
@@ -84,7 +84,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def find: (PrimaryKey id) -> Model
           | (Array[PrimaryKey]) -> Array[Model]
           | (*PrimaryKey) -> Array[Model]
-          | () { (Model) -> boolish } -> Model
+          | () { (Model) -> boolish } -> Model?
   def first: () -> Model
            | (Integer count) -> Array[Model]
   def last: () -> Model


### PR DESCRIPTION
When `find` is called with a block, ActiveRecord relations defer
to the underlying `Enumerable` implementation.