### PR TITLE
Fix AR where opts type.

### DIFF
--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -19059,7 +19059,7 @@ module ActiveRecord
     #
     # If the condition is any blank-ish object, then #where is a no-op and returns
     # the current relation.
-    def where: (?::Symbol opts, *untyped rest) -> untyped
+    def where: (?untyped opts, *untyped rest) -> untyped
 
     def where!: (untyped opts, *untyped rest) -> untyped
 


### PR DESCRIPTION
According to the docs, you could pass String, Array, Hash, or nothing (for `where.not`) as an argument.