### PR TITLE
Fix optional block in ActiveRecord::Base initialize

### DIFF
--- a/gems/activerecord/6.0.3.2/_test/Steepfile
+++ b/gems/activerecord/6.0.3.2/_test/Steepfile
@@ -1,0 +1,25 @@
+target :test do
+  signature "."
+  check "."
+
+  repo_path "../../../"
+
+  library "pathname"
+  library "logger"
+  library "mutex_m"
+  library "date"
+  library "monitor"
+  library "singleton"
+  library "tsort"
+
+  library "activerecord:6.0.3.2"
+  library "activesupport:6.0.3.2"
+  library "actionpack:6.0.3.2"
+  library "activejob:6.0.3.2"
+  library "activemodel:6.0.3.2"
+  library "actionview:6.0.3.2"
+  library "activerecord:6.0.3.2"
+  library "railties:6.0.3.2"
+
+  typing_options :strict
+end

--- a/gems/activerecord/6.0.3.2/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0.3.2/_test/activerecord-generated.rb
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+end
+
+user = User.new

--- a/gems/activerecord/6.0.3.2/_test/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/_test/activerecord-generated.rbs
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -12066,7 +12066,7 @@ module ActiveRecord
     # ==== Example:
     #   # Instantiates a single new object
     #   User.new(first_name: 'Jamie')
-    def initialize: (?untyped? attributes) { (untyped) -> untyped } -> untyped
+    def initialize: (?untyped? attributes) ?{ (untyped) -> untyped } -> untyped
 
     # Initialize an empty model object from +coder+. +coder+ should be
     # the result of previously encoding an Active Record model, using


### PR DESCRIPTION
Annotates the block in ActiveRecord::Base#initialize to provide type parity with the underlying library since the block is optional.

### Example of issue
```
# activerecord-generated.rb:4:12: [error] The method cannot be called without a block
# │ Diagnostic ID: Ruby::RequiredBlockMissing
# │
# └ user = User.new
#               ~~~

# Detected 1 problem from 1 file
```