### PR TITLE
Syntax check for RBS with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+jobs:
+  syntax_check:
+    runs-on: ubuntu-latest
+    container:
+      image: rubylang/ruby:3.0-focal
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'Install dependencies'
+      run: 'gem install rbs'
+    - name: 'Test syntax check'
+      run: 'rbs parse gems/**/*.rbs'


### PR DESCRIPTION
This PR enables GitHub Actions to syntax check RBS in this repository.

Syntax check is not enough to ensure that RBS is valid semantically, but it is better than nothing.