### PR TITLE
Remove rack rbs polyfill from actionpack rbs

### DIFF
--- a/gems/actionpack/6.0/patch.rbs
+++ b/gems/actionpack/6.0/patch.rbs
@@ -56,37 +56,7 @@ end
 # Remove the fake types for Rack
 # if the real types are available.
 module Rack
-  class Response
-    module Helpers
-      def location: () -> untyped
-    end
-  end
-
-  class Request
-    module Helpers
-    end
-
-    module Env
-    end
-  end
-
   module Session
-    module Abstract
-      class SessionHash
-      end
-
-      class PersistedSecure
-        class SecureSessionHash
-        end
-      end
-
-      class Persisted
-      end
-    end
-
-    class SessionId
-    end
-
     class Dalli
     end
   end

--- a/gems/railties/6.0/_scripts/test
+++ b/gems/railties/6.0/_scripts/test
@@ -2,7 +2,7 @@
 
 require 'pathname'
 
-VERSION = '6.0.3.2'
+VERSION = '6.0'
 
 def sh!(*args, **kwargs)
   system(*args, **kwargs, exception: true)


### PR DESCRIPTION
Because rack RBS has been added since https://github.com/ruby/gem_rbs_collection/pull/36