### PR TITLE
Fix Redis#initialize parameter name

### DIFF
--- a/gems/redis/4.2/redis.rbs
+++ b/gems/redis/4.2/redis.rbs
@@ -34,7 +34,7 @@ class Redis
   #
   # @return [Redis] a new client instance
   def initialize: (?url: String,
-                   ?path: String,
+                   ?scheme: String,
                    ?host: String,
                    ?port: Integer,
                    ?db: Integer,


### PR DESCRIPTION
Currently, `Redis#initialize`'s signature has two `path` parameters. This breaks tools like RubyMine, which (rightly) expects no duplicates in parameter names. Looking at `Redis::Client`'s options, it appears that the parameter preceding `host` is `scheme`, which is absent in the current RBS file.