### PR TITLE
Fix conflicts in activesupport and time

### DIFF
--- a/gems/activesupport/6.0/_script/test
+++ b/gems/activesupport/6.0/_script/test
@@ -4,5 +4,5 @@ set -xe
 
 REPO=$(git rev-parse --show-toplevel)/gems
 rbs --repo=$REPO \
-  -rmonitor -rdate -rsingleton -rlogger -rmutex_m \
+  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime \
   -ractivesupport validate

--- a/gems/activesupport/6.0/patch.rbs
+++ b/gems/activesupport/6.0/patch.rbs
@@ -4,12 +4,6 @@ class Object
   def sum: () -> untyped
 end
 
-class Time
-  # It is necessary to satisfy alias target.
-  # TODO: Define this method to correct place.
-  def xmlschema: (?::Integer fraction_digits) -> ::String
-end
-
 module ActiveSupport
   class TestCase < ::Minitest::Test
     # It is necessary to satisfy alias target.


### PR DESCRIPTION
When using `activesupport` and `time` library at the same time, the following error occurs in all methods of the time class.

```
UnexpectedError: /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/stdlib/time/0/time.rbs:324:2...324:53: ::Time#xmlschema has duplicated definitions in /Users/ksss/src/github.com/micin-jp/bluelight-api/vendor/rbs/gem_rbs_collection/gems/activesupport/6.0/patch.rbs:10:2...10:57(Ruby::UnexpectedError)
```

`Time#xmlschema` declared in time stdlib.

https://github.com/ruby/rbs/blob/d7566b32edf6c413d06d24052ab132e6adaa2089/stdlib/time/0/time.rbs#L324

In Rails, also use `time` stdlib.

https://github.com/rails/rails/blob/f1229b8fbc74716b35f452978aa0ce33e89c38e4/activesupport/lib/active_support/core_ext/time/conversions.rb#L3

Therefore, I think the definition of `Time#xmlschema` should be from the `time` library.