### PR TITLE
Remove #as_json defined by Active Support

### DIFF
--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -4838,11 +4838,6 @@ class Object
   def as_json: (?untyped? options) -> untyped
 end
 
-class Struct[Elem]
-  # nodoc:
-  def as_json: (?untyped? options) -> untyped
-end
-
 class TrueClass
   def as_json: (?untyped? options) -> untyped
 end
@@ -4859,23 +4854,11 @@ class String
   def as_json: (?untyped? options) -> untyped
 end
 
-class Symbol
-  def as_json: (?untyped? options) -> untyped
-end
-
 class Numeric
   def as_json: (?untyped? options) -> untyped
 end
 
 class Float
-  def as_json: (?untyped? options) -> untyped
-end
-
-class BigDecimal
-  def as_json: (?untyped? options) -> untyped
-end
-
-class Regexp
   def as_json: (?untyped? options) -> untyped
 end
 
@@ -4887,27 +4870,11 @@ class IO
   def as_json: (?untyped? options) -> untyped
 end
 
-class Range[out Elem]
-  def as_json: (?untyped? options) -> untyped
-end
-
 class Array[unchecked out Elem]
   def as_json: (?untyped? options) -> untyped
 end
 
 class Hash[unchecked out K, unchecked out V]
-  def as_json: (?untyped? options) -> untyped
-end
-
-class Time
-  def as_json: (?untyped? options) -> untyped
-end
-
-class Date
-  def as_json: (?untyped? options) -> untyped
-end
-
-class DateTime
   def as_json: (?untyped? options) -> untyped
 end
 
@@ -4924,10 +4891,6 @@ end
 class Process::Status
   # nodoc:
   def as_json: (?untyped? options) -> { exitstatus: untyped, pid: untyped }
-end
-
-class Exception
-  def as_json: (?untyped? options) -> untyped
 end
 
 class Object


### PR DESCRIPTION
Because they are defined by json.rbs
https://github.com/ruby/rbs/blob/7ac070a8f47d39e13b45b6f30a2fe2e2a1683128/stdlib/json/0/json.rbs