### PR TITLE
Improve ActiveSupport::TimeWithZone methods

### DIFF
--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -5938,7 +5938,7 @@ class Time
   def self.days_in_year: (?untyped year) -> untyped
 
   # Returns <tt>Time.zone.now</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns <tt>Time.now</tt>.
-  def self.current: () -> untyped
+  def self.current: () -> ActiveSupport::TimeWithZone # strictly `(ActiveSupport::TimeWithZone | Time)` but it's inconvenient
 
   # Layers additional behavior on Time.at so that ActiveSupport::TimeWithZone and DateTime
   # instances can be used when called with a single argument
@@ -6160,7 +6160,7 @@ class Time
 
   # Returns the TimeZone for the current request, if this has been set (via Time.zone=).
   # If <tt>Time.zone</tt> has not been set for the current request, returns the TimeZone specified in <tt>config.time_zone</tt>.
-  def self.zone: () -> untyped
+  def self.zone: () -> ActiveSupport::TimeZone # strictly `ActiveSupport::TimeWithZone?` but it's inconvenient
 
   # Sets <tt>Time.zone</tt> to a TimeZone object for the current request/thread.
   #
@@ -12378,7 +12378,7 @@ module ActiveSupport
     #
     #   Time.zone = 'Hawaii'  # => "Hawaii"
     #   Time.zone.now         # => Wed, 23 Jan 2008 20:24:27 HST -10:00
-    def now: () -> untyped
+    def now: () -> ActiveSupport::TimeWithZone
 
     # Returns the current date in this time zone.
     def today: () -> untyped

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -73,6 +73,83 @@ module ActiveSupport
     end
   end
 
+  class TimeWithZone
+    # class_eval
+    def year: () -> Integer
+    def mon: () -> Integer
+    def month: () -> Integer
+    def day: () -> Integer
+    def mday: () -> Integer
+    def wday: () -> Integer
+    def yday: () -> Integer
+    def hour: () -> Integer
+    def min: () -> Integer
+    def sec: () -> Integer
+    def usec: () -> Integer
+    def nsec: () -> Integer
+    def to_date: () -> Date
+
+    # method_missing
+    def asctime: () -> String
+    alias at_beginning_of_day beginning_of_day
+    alias at_beginning_of_hour beginning_of_hour
+    alias at_beginning_of_minute beginning_of_minute
+    alias at_end_of_day end_of_day
+    alias at_end_of_hour end_of_hour
+    alias at_end_of_minute end_of_minute
+    alias at_midday middle_of_day
+    alias at_middle_of_day middle_of_day
+    alias at_midnight beginning_of_day
+    alias at_noon middle_of_day
+    def beginning_of_day: () -> self
+    def beginning_of_hour: () -> self
+    def beginning_of_minute: () -> self
+    def ceil: (?int ndigits) -> self
+    def compare_with_coercion: (untyped other) -> (-1 | 0 | 1 | nil)
+    def compare_without_coercion: (untyped other) -> (-1 | 0 | 1 | nil)
+    def ctime: () -> String
+    def end_of_day: () -> self
+    def end_of_hour: () -> self
+    def end_of_minute: () -> self
+    def eql_with_coercion: (untyped other) -> bool
+    def eql_without_coercion: (untyped other) -> bool
+    def floor: (?int ndigits) -> self
+    def friday?: () -> bool
+    alias midday middle_of_day
+    def middle_of_day: () -> self
+    alias midnight beginning_of_day
+    def minus_with_coercion: (Time | self arg0) -> Float
+                           | (Numeric arg0) -> self
+    def minus_with_duration: (Time | self arg0) -> Float
+                           | (Numeric arg0) -> self
+    def minus_without_coercion: (Time | self arg0) -> Float
+                           | (Numeric arg0) -> self
+    def minus_without_duration: (Time | self arg0) -> Float
+                           | (Numeric arg0) -> self
+    def monday?: () -> bool
+    def next_day: () -> self
+    def next_month: () -> self
+    def next_year: () -> self
+    alias noon middle_of_day
+    def plus_without_duration: (Time | self arg0) -> Float
+                             | (Numeric arg0) -> self
+    def prev_day: () -> self
+    def prev_month: () -> self
+    def prev_year: () -> self
+    def round: (?int ndigits) -> self
+    def saturday?: () -> bool
+    def seconds_since_midnight: () -> Float
+    def seconds_until_end_of_day: () -> Integer
+    def sec_fraction: () -> (Integer | Rational)
+    def subsec: () -> (Integer | Rational)
+    def sunday?: () -> bool
+    def thursday?: () -> bool
+    def to_default_s: () -> String
+    def tuesday?: () -> bool
+    def tv_nsec: () -> Integer
+    def tv_usec: () -> Integer
+    def wednesday?: () -> bool
+  end
 end
 
 class Hash[unchecked out K, unchecked out V]


### PR DESCRIPTION
Fixed `Time.current` and `Time.zone.now` to return an `ActiveSupport::TimeWithZone` object.

`Time.current` may return a `Time` object, but it is not described.
Because `Time.current` will return a `Time` object in very rare circumstances, and in many cases programmer will expect an `ActiveSupport::TimeWithZone` object to be returned.

And the `ActiveSupport::TimeWithZone` class dynamically creates transfer methods to the methods of the Time class by using `class_eval` and `method_missing` for some of the methods.

This PR have also added these method definitions.