### PR TITLE
Fix nokogiri type to satisfy module constraint

### DIFF
--- a/gems/nokogiri/1.11/nokogiri.rbs
+++ b/gems/nokogiri/1.11/nokogiri.rbs
@@ -1269,7 +1269,7 @@ class Nokogiri::XML::Node
 
   def dup: (*untyped) -> untyped
 
-  def each: () -> untyped
+  def each: () { (untyped) -> void } -> untyped
 
   alias elem? element?
 
@@ -1958,7 +1958,7 @@ class Nokogiri::XML::Reader
 
   def depth: () -> untyped
 
-  def each: () -> untyped
+  def each: () { (untyped) -> void } -> untyped
 
   def empty_element?: () -> untyped
 


### PR DESCRIPTION
It displayed the following error message with the latest (v0.46.0)
Steep.

```
../nokogiri.rbs:1174:2: [error] Module self type constraint in type `::Nokogiri::XML::Node` doesn't satisfy: `::Nokogiri::XML::Node <: ::_Each[untyped]`
│ Diagnostic ID: RBS::ModuleSelfTypeError
│
└   include Enumerable[untyped]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~

../nokogiri.rbs:1935:2: [error] Module self type constraint in type `::Nokogiri::XML::Reader` doesn't satisfy: `::Nokogiri::XML::Reader <: ::_Each[untyped]`
│ Diagnostic ID: RBS::ModuleSelfTypeError
│
└   include Enumerable[untyped]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~

Detected 2 problems from 1 file
```