### PR TITLE
Update httpclient type

### DIFF
--- a/gems/httpclient/2.8/_test/test.rb
+++ b/gems/httpclient/2.8/_test/test.rb
@@ -1,7 +1,7 @@
 require "httpclient"
 
 client = HTTPClient.new
-res = client.get("http://example.com")
+res = client.get("http://example.com", query: {"q" => "v"})
 if res.status == 200
   puts res.body
 end

--- a/gems/httpclient/2.8/httpclient.rbs
+++ b/gems/httpclient/2.8/httpclient.rbs
@@ -224,13 +224,17 @@
 #   ruby -rhttpclient -e 'p HTTPClient.head(ARGV.shift).header["last-modified"]' http://dev.ctor.org/
 #
 class HTTPClient
-  type query = Array[Hash[String, _ToS | _Reader]]
+  type query = Hash[String, _ToS | _Reader]
              | Array[[String, _ToS | _Reader]]
+             | String
+             | _Reader
   type header = Hash[String, _ToS]
               | Array[[String, _ToS]]
   type body = Hash[String, _ToS | _Reader]
             | Array[[String, _ToS | _Reader]]
             | Array[Hash[String, _ToS | _Reader]]
+            | String
+            | _Reader
 
   module DelegateMethods
     def get_content: (


### PR DESCRIPTION
Some of the patterns were missing and will be corrected.
Strictly, the `| String` part should be `_ToS`, but since most objects have the `to_s` method.
It may induce unintended use.
so it is `| String`.