### PR TITLE
Extend ClassMethods for ActiveRecord::Base

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -13766,7 +13766,7 @@ module ActiveRecord
       # Determines if one of the attributes passed in is the inheritance column,
       # and if the inheritance column is attr accessible, it initializes an
       # instance of the given subclass instead of the base class.
-      def new: (?untyped? attributes) { () -> untyped } -> untyped
+      def new: (?untyped? attributes) ?{ () -> untyped } -> untyped
 
       # Returns +true+ if this does not need STI type condition. Returns
       # +false+ if STI type condition needs to be applied.

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -6,7 +6,6 @@ module ActiveRecord
     extend ::ActiveModel::SecurePassword::ClassMethods
     extend ::ActiveModel::Validations::Callbacks::ClassMethods
     extend ::ActiveModel::Validations::ClassMethods
-    extend ::ActiveRecord::Aggregations::ClassMethods
     extend ::ActiveRecord::Associations::ClassMethods
     extend ::ActiveRecord::AttributeMethods::ClassMethods
     extend ::ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods
@@ -25,7 +24,6 @@ module ActiveRecord
     extend ::ActiveRecord::NestedAttributes::ClassMethods
     extend ::ActiveRecord::NoTouching::ClassMethods
     extend ::ActiveRecord::Persistence::ClassMethods
-    extend ::ActiveRecord::QueryCache::ClassMethods
     extend ::ActiveRecord::ReadonlyAttributes::ClassMethods
     extend ::ActiveRecord::Reflection::ClassMethods
     extend ::ActiveRecord::Sanitization::ClassMethods

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -1,5 +1,45 @@
 module ActiveRecord
   class Base
+    # puts ActiveRecord::Base.singleton_class.ancestors.map(&:to_s).select { |s| /ClassMethods$/.match?(s) }.map{ |s| "extend ::#{s}" }.sort
+    extend ::ActiveModel::AttributeMethods::ClassMethods
+    extend ::ActiveModel::Conversion::ClassMethods
+    extend ::ActiveModel::SecurePassword::ClassMethods
+    extend ::ActiveModel::Validations::Callbacks::ClassMethods
+    extend ::ActiveModel::Validations::ClassMethods
+    extend ::ActiveRecord::Aggregations::ClassMethods
+    extend ::ActiveRecord::Associations::ClassMethods
+    extend ::ActiveRecord::AttributeMethods::ClassMethods
+    extend ::ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods
+    extend ::ActiveRecord::AttributeMethods::Read::ClassMethods
+    extend ::ActiveRecord::AttributeMethods::Serialization::ClassMethods
+    extend ::ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods
+    extend ::ActiveRecord::AttributeMethods::Write::ClassMethods
+    extend ::ActiveRecord::Attributes::ClassMethods
+    extend ::ActiveRecord::AutosaveAssociation::ClassMethods
+    extend ::ActiveRecord::Core::ClassMethods
+    extend ::ActiveRecord::CounterCache::ClassMethods
+    extend ::ActiveRecord::Inheritance::ClassMethods
+    extend ::ActiveRecord::Integration::ClassMethods
+    extend ::ActiveRecord::Locking::Optimistic::ClassMethods
+    extend ::ActiveRecord::ModelSchema::ClassMethods
+    extend ::ActiveRecord::NestedAttributes::ClassMethods
+    extend ::ActiveRecord::NoTouching::ClassMethods
+    extend ::ActiveRecord::Persistence::ClassMethods
+    extend ::ActiveRecord::QueryCache::ClassMethods
+    extend ::ActiveRecord::ReadonlyAttributes::ClassMethods
+    extend ::ActiveRecord::Reflection::ClassMethods
+    extend ::ActiveRecord::Sanitization::ClassMethods
+    extend ::ActiveRecord::Scoping::ClassMethods
+    extend ::ActiveRecord::Scoping::Default::ClassMethods
+    extend ::ActiveRecord::Scoping::Named::ClassMethods
+    extend ::ActiveRecord::SecureToken::ClassMethods
+    extend ::ActiveRecord::Store::ClassMethods
+    extend ::ActiveRecord::Suppressor::ClassMethods
+    extend ::ActiveRecord::Timestamp::ClassMethods
+    extend ::ActiveRecord::Transactions::ClassMethods
+    extend ::ActiveRecord::Validations::ClassMethods
+    extend ::ActiveSupport::Callbacks::ClassMethods
+
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, ^(*untyped) -> untyped ) -> void
                   | (Symbol) { (*untyped) -> untyped } -> void
@@ -48,8 +88,6 @@ module ActiveRecord
     def errors: () -> untyped
     def []: (Symbol) -> untyped
     def []=: (Symbol, untyped) -> untyped
-
-    extend Sanitization::ClassMethods
   end
 end
 


### PR DESCRIPTION
`extend ActiveSupport::Concern` will automatically extend the `ClassMethods`module.

RBS cannot follow this metaprogramming, so the following code adds the actual ClassMethods that are extended.

```rb
puts ActiveRecord::Base.singleton_class.ancestors.map(&:to_s).select { |s|
  /ClassMethods$/.match?(s)
}.map{ |s|
  "extend ::#{s}"
}.sort
```