### PR TITLE
Add graphql gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "gems/httpclient/2.8/_src"]
 	path = gems/httpclient/2.8/_src
 	url = https://github.com/nahi/httpclient.git
+[submodule "gems/graphql/1.12/_src"]
+	path = gems/graphql/1.12/_src
+	url = https://github.com/rmosolgo/graphql-ruby.git

--- a/gems/graphql/1.12/_test/Steepfile
+++ b/gems/graphql/1.12/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "graphql"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/graphql/1.12/_test/test.rb
+++ b/gems/graphql/1.12/_test/test.rb
@@ -1,0 +1,78 @@
+require "graphql"
+
+# generated codes
+module Types
+  class BaseObject < GraphQL::Schema::Object
+  end
+  class BaseEdge < Types::BaseObject
+  end
+  class BaseConnection < Types::BaseObject
+    include GraphQL::Types::Relay::ConnectionBehaviors
+  end
+  class BaseArgument < GraphQL::Schema::Argument
+  end
+  class BaseField < GraphQL::Schema::Field
+    argument_class Types::BaseArgument
+  end
+  class BaseObject < GraphQL::Schema::Object
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+    field_class Types::BaseField
+  end
+  class BaseEdge < Types::BaseObject
+    include GraphQL::Types::Relay::EdgeBehaviors
+  end
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+  class BaseInputObject < GraphQL::Schema::InputObject
+    argument_class Types::BaseArgument
+  end
+  module BaseInterface
+    include GraphQL::Schema::Interface
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+
+    field_class Types::BaseField
+  end
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+  class BaseUnion < GraphQL::Schema::Union
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+  end
+  module NodeType
+    include Types::BaseInterface
+    include GraphQL::Types::Relay::NodeBehaviors
+  end
+
+  # sample query
+  class QueryType < Types::BaseObject
+    include GraphQL::Types::Relay::HasNodeField
+    include GraphQL::Types::Relay::HasNodesField
+    field :ping, String, null: false, description: "ping"
+    def ping = context[:ping].pong
+  end
+end
+
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    input_object_class Types::BaseInputObject
+    object_class Types::BaseObject
+  end
+
+  # sample mutation
+  class Ping < BaseMutation
+    description "ping"
+    argument :arg1, String, required: true, description: "arg1"
+    argument :arg2, Boolean, required: true, description: "arg2"
+  end
+end
+
+# sample schema
+class MySchema < GraphQL::Schema
+  rescue_from(StandardError) do |err|
+    raise "error!"
+  end
+end

--- a/gems/graphql/1.12/_test/test.rbs
+++ b/gems/graphql/1.12/_test/test.rbs
@@ -1,0 +1,66 @@
+module GraphQL
+  class Schema
+    class Object < Member
+    end
+  end
+end
+
+module Types
+  class BaseArgument < GraphQL::Schema::Argument
+  end
+
+  class BaseConnection
+    include GraphQL::Types::Relay::ConnectionBehaviors
+  end
+
+  class BaseEdge
+    include GraphQL::Types::Relay::EdgeBehaviors
+  end
+
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+
+  class BaseField < GraphQL::Schema::Field
+  end
+
+  class BaseInputObject < GraphQL::Schema::InputObject
+  end
+
+  module BaseInterface
+    include GraphQL::Schema::Interface
+    # see graphql/schema/interface.rb def included
+    extend GraphQL::Schema::Interface::DefinitionMethods
+  end
+
+  class BaseObject < GraphQL::Schema::Object
+  end
+
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+
+  class BaseUnion < GraphQL::Schema::Union
+  end
+
+  module NodeType
+    include GraphQL::Types::Relay::NodeBehaviors
+    include BaseInterface
+  end
+
+  class QueryType < BaseObject
+    include GraphQL::Types::Relay::HasNodesField
+    include GraphQL::Types::Relay::HasNodeField
+
+    def ping: -> untyped
+  end
+end
+
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+  end
+
+  class Ping < BaseMutation
+  end
+end
+
+class MySchema < GraphQL::Schema
+end

--- a/gems/graphql/1.12/graphql.rbs
+++ b/gems/graphql/1.12/graphql.rbs
@@ -1,0 +1,169 @@
+module GraphQL
+  class Query
+    class Context
+      def []: (Symbol key) -> untyped
+    end
+  end
+  class Schema
+    interface _Argument
+      def argument: (
+        ?Symbol? arg_name,
+        ?untyped? type_expr,
+        ?String? desc,
+        required: bool,
+        ?type: untyped,
+        ?default_value: untyped,
+        ?description: String,
+        ?validates: Hash[untyped, untyped],
+      ) ?{ (*untyped) -> void } -> void
+    end
+
+    class Argument
+    end
+    class EnumValue < Member
+    end
+    class Enum < Member
+      def self.value: (String graphql_name, ?String? desc, ?ast_node: untyped, ?directives: untyped, ?description: untyped, ?value: untyped, ?deprecation_reason: untyped) ?{ () -> void } -> void
+    end
+    class Field
+      include Member::HasArguments
+      extend Member::HasArguments::ArgumentClassAccessor
+    end
+    class InputObject < Member
+      extend Member::HasArguments
+      extend Member::HasArguments::ArgumentClassAccessor
+      extend _Argument
+    end
+    module Interface
+      module DefinitionMethods
+        include Member::BaseDSLMethods
+        include Member::HasFields
+        include Member::RelayShortcuts
+      end
+      extend DefinitionMethods
+      include Member::GraphQLTypeNames
+    end
+    class Member
+      module BaseDSLMethods
+        def description: (?String? new_description) -> String?
+        def graphql_name: (?String? new_name) -> String
+      end
+      extend BaseDSLMethods
+
+      module GraphQLTypeNames
+        Boolean: "Boolean"
+        ID: "ID"
+        Int: "Int"
+      end
+      include GraphQLTypeNames
+
+      module HasArguments
+        module ArgumentClassAccessor
+          def argument_class: (?Class? new_arg_class) -> void
+        end
+      end
+
+      module HasFields
+        def field: (
+          ?Symbol name,
+          ?untyped `type`,
+          ?String desc,
+          ?name: Symbol,
+          ?null: bool,
+          ?type: untyped,
+          ?description: String,
+          ?resolver_method: Symbol,
+          ?resolver: Class,
+          ?mutation: Class,
+        ) ?{ (untyped) -> void } -> void
+        def field_class: (?Class? new_field_class) -> void
+        def global_id_field: (Symbol field_name, **untyped kwargs) -> void
+      end
+
+      module RelayShortcuts
+        def connection_type: () -> Class
+        def connection_type_class: (?Class? new_connection_type_class) -> void
+        def edge_type_class: (?Class? new_edge_type_class) -> void
+      end
+      extend RelayShortcuts
+    end
+    class Mutation < Resolver
+      extend Member::HasFields
+      extend Resolver::HasPayloadType
+    end
+    class Object < Member
+      extend Member::HasFields
+      attr_reader object: untyped
+      attr_reader context: GraphQL::Query::Context
+    end
+    class Resolver
+      module HasPayloadType
+        def payload_type: (?Class? new_payload_type) -> Class
+        alias type payload_type
+        alias type_expr payload_type
+        def field_class: (?Class? new_class) -> void
+        def object_class: (?Class? new_class) -> void
+      end
+      extend Member::BaseDSLMethods
+      include Member::GraphQLTypeNames
+      extend Member::HasArguments
+      extend Member::HasArguments::ArgumentClassAccessor
+      extend _Argument
+      def self.type: (?(Class | Array[Class] | nil) new_type, ?null: bool null) -> void
+
+      attr_reader object: untyped
+      attr_reader context: GraphQL::Query::Context
+    end
+    class RelayClassicMutation < Mutation
+      def self.input_object_class: (?Class? new_class) -> void
+    end
+    class Scalar < Member
+      def self.coerce_input: (untyped val, untyped ctx) -> untyped
+      def self.coerce_result: (untyped val, untyped ctx) -> untyped
+    end
+    class Union < Member
+    end
+    module UniqueWithinType
+      def self.encode: (String type_name, _ToS object_value, ?separator: String separator) -> String
+      def self.decode: (String, ?separator: String separator) -> [String, String]
+    end
+    def self.rescue_from: (*untyped err_classes) { (untyped err) -> void } -> void
+    def self.mutation: (?Class? new_mutation_object) -> void
+    def self.query: (?Class? new_query_object) -> void
+  end
+  module Types
+    class Boolean < GraphQL::Schema::Scalar
+    end
+    class Float < GraphQL::Schema::Scalar
+    end
+    class Int < GraphQL::Schema::Scalar
+    end
+    class ISO8601Date < GraphQL::Schema::Scalar
+    end
+    class ISO8601DateTime < GraphQL::Schema::Scalar
+      def self.time_precision: () -> Integer
+      def self.time_precision=: (Integer) -> Integer
+    end
+    class JSON < GraphQL::Schema::Scalar
+    end
+    module Relay
+      module HasNodeField
+      end
+      module HasNodesField
+      end
+      module NodeBehaviors
+      end
+      module ConnectionBehaviors
+      end
+      module EdgeBehaviors
+      end
+    end
+    class String < GraphQL::Schema::Scalar
+    end
+  end
+  class Error < StandardError
+  end
+  class ExecutionError < Error
+    def to_h: () -> Hash[String, untyped]
+  end
+end


### PR DESCRIPTION
I wrote the rbs for the [graphql](https://github.com/rmosolgo/graphql-ruby) gem.

I would like to use rbs for coding that uses the graphql gem, but it is noisy with many errors.

The rbs to be added in this PR aims to reduce this noise errors as much as possible and focus on the application part.

The graphql gem is a lot of code, but I extracted the code that is actually used, focusing on the generated code.