### PR TITLE
Fix `Retryable.retryable`'s `?Configuration::options options` type.

### DIFF
--- a/gems/retryable/3.0/retryable.rbs
+++ b/gems/retryable/3.0/retryable.rbs
@@ -35,7 +35,7 @@ module Retryable
 
   alias self.retryable_with_context self.with_context
 
-  def self.retryable: [X] (?Configuration::options options) ?{ (Integer, Exception?) -> X } -> X?
+  def self.retryable: [X] (?::Hash[untyped, untyped] options) ?{ (Integer, Exception?) -> X } -> X?
 
   private
 


### PR DESCRIPTION
Currently, `Retryable.retryable`'s arguments has `?Configuration::options options` type in rbs file.
When we created the following codes and executed `steep check`, we got the following error when we should not have gotten the error.

Example codes:
```
Retryable.Retryable(Tries: 3) Do
  # do something
End
```

Error:
```
runner/sample.rb:8:20: [error] UnexpectedError: 
│ Diagnostic ID: Ruby::UnexpectedError
│
└ Retryable.retryable(tries: 3) do
                      ~~~~~~~~

Detected 1 problem from 1 file
```

We think that probably `?Configuration::options` is wrong, and `?::Hash[untyped, untyped]` is correct.

Let me know if anything is unclear, or could be improved. Thank you.
