### PR TITLE
Make Steep error level stricter

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -66,3 +66,5 @@ dirs.each do |dir|
     end
   end
 end
+
+exit 1 if failed

--- a/gems/activerecord/6.0/_test/Steepfile
+++ b/gems/activerecord/6.0/_test/Steepfile
@@ -25,5 +25,5 @@ target :test do
   library "activerecord:6.0.3.2"
   library "railties:6.0.3.2"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/activerecord/6.1/_test/Steepfile
+++ b/gems/activerecord/6.1/_test/Steepfile
@@ -24,5 +24,5 @@ target :test do
   library "actionview:6.1.4.1"
   library "railties:6.1.4.1"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/ast/2.4/_test/Steepfile
+++ b/gems/ast/2.4/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "ast"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/chronic/0.10/_test/Steepfile
+++ b/gems/chronic/0.10/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "chronic"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/chunky_png/1.4.0/_test/Steepfile
+++ b/gems/chunky_png/1.4.0/_test/Steepfile
@@ -8,5 +8,5 @@ target :test do
   library "zlib"
   library "set"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/httparty/0.18/_test/Steepfile
+++ b/gems/httparty/0.18/_test/Steepfile
@@ -9,5 +9,5 @@ target :test do
   library "net-http"
   signature "."
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/httpclient/2.8/_test/Steepfile
+++ b/gems/httpclient/2.8/_test/Steepfile
@@ -9,5 +9,5 @@ target :test do
   repo_path "../../../"
   library "httpclient"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/listen/3.2/_test/Steepfile
+++ b/gems/listen/3.2/_test/Steepfile
@@ -6,5 +6,5 @@ target :test do
   repo_path "../../../"
   library "listen"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/nokogiri/1.11/_test/Steepfile
+++ b/gems/nokogiri/1.11/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "nokogiri"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/rack/2.2.2/_test/Steepfile
+++ b/gems/rack/2.2.2/_test/Steepfile
@@ -1,6 +1,9 @@
+D = Steep::Diagnostic
 target :test do
   check "."
 
   repo_path "../../../"
   library "rack"
+
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/rainbow/3.0/_test/Steepfile
+++ b/gems/rainbow/3.0/_test/Steepfile
@@ -1,6 +1,10 @@
+D = Steep::Diagnostic
+
 target :test do
   check "."
 
   repo_path "../../../"
   library "rainbow"
+
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/redis/4.2/_test/Steepfile
+++ b/gems/redis/4.2/_test/Steepfile
@@ -6,5 +6,5 @@ target :test do
   repo_path "../../../"
   library "redis:4.2.0"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/regexp_trie/1.0/_test/Steepfile
+++ b/gems/regexp_trie/1.0/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "regexp_trie"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/scanf/1.0/_test/Steepfile
+++ b/gems/scanf/1.0/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "scanf"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/sidekiq/6.2/_test/Steepfile
+++ b/gems/sidekiq/6.2/_test/Steepfile
@@ -10,5 +10,5 @@ target :test do
   library "monitor:0"
   signature "."
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/ulid/1.3/_test/Steepfile
+++ b/gems/ulid/1.3/_test/Steepfile
@@ -6,5 +6,5 @@ target :test do
   repo_path "../../../"
   library "ulid"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/wavedash/0.1/_test/Steepfile
+++ b/gems/wavedash/0.1/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "wavedash"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/woothee/1.11/_test/Steepfile
+++ b/gems/woothee/1.11/_test/Steepfile
@@ -7,5 +7,5 @@ target :test do
   repo_path "../../../"
   library "woothee"
 
-  configure_code_diagnostics(D::Ruby.strict)
+  configure_code_diagnostics(D::Ruby.all_error)
 end


### PR DESCRIPTION
This PR makes type checking by Steep stricter. `all_error` is stricter than `strict`, and `strict` is not strict enough.



Note that it remains the following gems because they have type errors with `all_error` configuration. I'll update them soon.

* delayed_job
* parallel
* protobuf
* retryable
* zengin_code
