### PR TITLE
Nokogiri: Make block arguments optional

### DIFF
--- a/gems/nokogiri/1.11/_test/test.rb
+++ b/gems/nokogiri/1.11/_test/test.rb
@@ -31,3 +31,15 @@ end
 doc.search('nav ul.menu li a', '//article//h2').each do |link|
   puts link.content
 end
+
+# Create nodes
+doc.create_element('h1', 'hello') { |e| puts e }
+doc.create_text_node('hello') { |e| puts e }
+doc.create_comment('hello') { |e| puts e }
+doc.create_cdata('<hello>') { |e| puts e }
+
+# Create nodes without using blocks
+puts doc.create_element('h1', 'hello')
+puts doc.create_text_node('hello')
+puts doc.create_comment('hello')
+puts doc.create_cdata('<hello>')

--- a/gems/nokogiri/1.11/nokogiri.rbs
+++ b/gems/nokogiri/1.11/nokogiri.rbs
@@ -958,15 +958,15 @@ class Nokogiri::XML::Document < Nokogiri::XML::Node
 
   def collect_namespaces: () -> untyped
 
-  def create_cdata: (untyped string) { (*untyped) -> untyped } -> untyped
+  def create_cdata: (untyped string) ?{ (*untyped) -> untyped } -> untyped
 
-  def create_comment: (untyped string) { (*untyped) -> untyped } -> untyped
+  def create_comment: (untyped string) ?{ (*untyped) -> untyped } -> untyped
 
-  def create_element: (untyped name, *untyped args) { (*untyped) -> untyped } -> untyped
+  def create_element: (untyped name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
   def create_entity: (*untyped) -> untyped
 
-  def create_text_node: (untyped string) { (*untyped) -> untyped } -> untyped
+  def create_text_node: (untyped string) ?{ (*untyped) -> untyped } -> untyped
 
   def decorate: (untyped node) -> untyped
 


### PR DESCRIPTION
Nokogiri::XML::Document has several methods to create nodes:

- [#create_element](https://github.com/sparklemotion/nokogiri/blob/v1.11.1/lib/nokogiri/xml/document.rb#L90-L121)
- [#create_text_node](https://github.com/sparklemotion/nokogiri/blob/v1.11.1/lib/nokogiri/xml/document.rb#L123-L126)
- [#create_cdata](https://github.com/sparklemotion/nokogiri/blob/v1.11.1/lib/nokogiri/xml/document.rb#L128-L131)
- [#create_comment](https://github.com/sparklemotion/nokogiri/blob/7be6f04aa2700e818f8a3bfe82801b5bd6e8c4f4/lib/nokogiri/xml/document.rb#L133-L136)

Those methods can be passed a block but it is not required, so those
requirements should be relaxed.