### PR TITLE
Support Duration for {Date,Time}#{+,-}

### DIFF
--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -2454,9 +2454,15 @@ class Date
 
   alias plus_without_duration +
 
+  def +: (ActiveSupport::Duration other) -> self
+       | ...
+
   def minus_with_duration: (untyped other) -> untyped
 
   alias minus_without_duration -
+
+  def -: (ActiveSupport::Duration other) -> self
+       | ...
 
   # Provides precise Date calculations for years, months, and days. The +options+ parameter takes a hash with
   # any of these keys: <tt>:years</tt>, <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>.
@@ -6062,9 +6068,15 @@ class Time
 
   alias plus_without_duration +
 
+  def +: (ActiveSupport::Duration other) -> self
+       | ...
+
   def minus_with_duration: (untyped other) -> untyped
 
   alias minus_without_duration -
+
+  def -: (ActiveSupport::Duration other) -> self
+       | ...
 
   # Time#- can also be used to determine the number of seconds between two Time instances.
   # We're layering on additional behavior so that ActiveSupport::TimeWithZone instances


### PR DESCRIPTION
## Problem

The following code will fail during type checking (steep).

```rb
Date.today - 1.day
#=> (UnresolvedOverloading) Cannot find compatible overloading of method `-` of type `::Date`
```

## Why

Following methods are overwrote by active_support.

- `Date#+`
- `Date#-`
- `Time#+`
- `Time#-`

However, these methods have been omitted from the type definition for the following reasons and processing.

https://github.com/ruby/gem_rbs_collection/blob/88e86e0b67262f9ab6244a356e81dd9ca8c55b37/gems/railties/6.0/_scripts/generate.rb#L84-L85

## Solution

These methods should support `ActiveSupport::Duration` object for argument.
I suggest not using alias and using overload to solve the problem.