### PR TITLE
Add methods generated by `matter_accessor`

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -39,7 +39,6 @@ module ActiveRecord
     extend ::ActiveSupport::Callbacks::ClassMethods
 
     def self.abstract_class=: (bool) -> void
-    def self.default_timezone=: (untyped) -> untyped
     def self.scope: (Symbol, ^(*untyped) -> untyped ) -> void
                   | (Symbol) { (*untyped) -> untyped } -> void
     def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
@@ -87,6 +86,56 @@ module ActiveRecord
     def errors: () -> untyped
     def []: (Symbol) -> untyped
     def []=: (Symbol, untyped) -> untyped
+
+    # mattr_accessor
+    attr_accessor self.logger: untyped
+    def logger: () -> untyped
+
+    attr_accessor self.verbose_query_logs: untyped
+    def verbose_query_logs: () -> untyped
+
+    attr_accessor self.default_timezone: untyped
+    def default_timezone: () -> untyped
+
+    attr_accessor self.schema_format: untyped
+    def schema_format: () -> untyped
+
+    attr_accessor self.error_on_ignored_order: untyped
+    def error_on_ignored_order: () -> untyped
+
+    attr_accessor self.allow_unsafe_raw_sql: untyped
+    def allow_unsafe_raw_sql: () -> untyped
+
+    attr_accessor self.timestamped_migrations: untyped
+    def timestamped_migrations: () -> untyped
+
+    attr_accessor self.dump_schema_after_migration: untyped
+    def dump_schema_after_migration: () -> untyped
+
+    attr_accessor self.dump_schemas: untyped
+    def dump_schemas: () -> untyped
+
+    attr_accessor self.warn_on_records_fetched_greater_than: untyped
+    def warn_on_records_fetched_greater_than: () -> untyped
+
+    attr_accessor self.maintain_test_schema: untyped
+
+    attr_accessor self.belongs_to_required_by_default: untyped
+
+    attr_accessor self.connection_handlers: untyped
+
+    attr_accessor self.writing_role: untyped
+
+    attr_accessor self.reading_role: untyped
+
+    attr_accessor self.primary_key_prefix_type: untyped
+    def primary_key_prefix_type: () -> untyped
+
+    attr_accessor self.time_zone_aware_attributes: untyped
+    def time_zone_aware_attributes: () -> untyped
+
+    attr_accessor self.index_nested_attribute_errors: untyped
+    def index_nested_attribute_errors: () -> untyped
   end
 end
 


### PR DESCRIPTION
## Problem

`matter_accessor` https://github.com/rails/rails/blob/c7a6ec51bf097eb3f307001c1142a8565e7a1450/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb#L207
generate accessor method.

However in activerecord-generated.rb, methods defined by `mattr_accessor` did not generate a type definition.

## Solution

I generated the type definition for the methods defined by `mattr_accessor` with the following code.

```rb
class Module
  prepend Module.new {
    def mattr_accessor(*syms, instance_reader: true, instance_writer: true, instance_accessor: true, **key)
      syms.each do |sym|
        puts "[#{self}] attr_accessor self.#{sym}: untyped"
        if instance_accessor
          if instance_reader
            puts "[#{self}] def #{sym}: () -> untyped"
          end
          if instance_writer
            puts "[#{self}] def #{sym}=: (untyped) -> untyped"
          end
        end
      end
      super
    end
  }
end
```