### PR TITLE
Add methods generated by class_attributes for ActiveRecord::Base

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -87,6 +87,142 @@ module ActiveRecord
     def errors: () -> untyped
     def []: (Symbol) -> untyped
     def []=: (Symbol, untyped) -> untyped
+
+    # class_attributes
+    def self.defined_enums: () -> untyped
+    def self.defined_enums?: () -> bool
+    def self.defined_enums=: (untyped) -> untyped
+    def defined_enums: () -> untyped
+    def defined_enums?: () -> bool
+
+    def self.default_connection_handler: () -> untyped
+    def self.default_connection_handler?: () -> bool
+    def self.default_connection_handler=: (untyped) -> untyped
+    def default_connection_handler: () -> untyped
+    def default_connection_handler?: () -> bool
+
+    def self.table_name_prefix: () -> untyped
+    def self.table_name_prefix?: () -> bool
+    def self.table_name_prefix=: (untyped) -> untyped
+    def table_name_prefix: () -> untyped
+    def table_name_prefix?: () -> bool
+
+    def self.table_name_suffix: () -> untyped
+    def self.table_name_suffix?: () -> bool
+    def self.table_name_suffix=: (untyped) -> untyped
+    def table_name_suffix: () -> untyped
+    def table_name_suffix?: () -> bool
+
+    def self.schema_migrations_table_name: () -> untyped
+    def self.schema_migrations_table_name?: () -> bool
+    def self.schema_migrations_table_name=: (untyped) -> untyped
+
+    def self.internal_metadata_table_name: () -> untyped
+    def self.internal_metadata_table_name?: () -> bool
+    def self.internal_metadata_table_name=: (untyped) -> untyped
+
+    def self.pluralize_table_names: () -> untyped
+    def self.pluralize_table_names?: () -> bool
+    def self.pluralize_table_names=: (untyped) -> untyped
+    def pluralize_table_names: () -> untyped
+    def pluralize_table_names?: () -> bool
+
+    def self.implicit_order_column: () -> untyped
+    def self.implicit_order_column?: () -> bool
+    def self.implicit_order_column=: (untyped) -> untyped
+
+    def self.store_full_sti_class: () -> untyped
+    def self.store_full_sti_class?: () -> bool
+    def self.store_full_sti_class=: (untyped) -> untyped
+    def store_full_sti_class: () -> untyped
+    def store_full_sti_class?: () -> bool
+
+    def self.default_scopes: () -> untyped
+    def self.default_scopes=: (untyped) -> untyped
+    def default_scopes: () -> untyped
+
+    def self.default_scope_override: () -> untyped
+    def self.default_scope_override=: (untyped) -> untyped
+    def default_scope_override: () -> untyped
+
+    def self.cache_timestamp_format: () -> untyped
+    def self.cache_timestamp_format?: () -> bool
+    def self.cache_timestamp_format=: (untyped) -> untyped
+    def cache_timestamp_format: () -> untyped
+    def cache_timestamp_format?: () -> bool
+
+    def self.cache_versioning: () -> untyped
+    def self.cache_versioning?: () -> bool
+    def self.cache_versioning=: (untyped) -> untyped
+    def cache_versioning: () -> untyped
+    def cache_versioning?: () -> bool
+
+    def self.collection_cache_versioning: () -> untyped
+    def self.collection_cache_versioning?: () -> bool
+    def self.collection_cache_versioning=: (untyped) -> untyped
+    def collection_cache_versioning: () -> untyped
+    def collection_cache_versioning?: () -> bool
+
+    def self.lock_optimistically: () -> untyped
+    def self.lock_optimistically?: () -> bool
+    def self.lock_optimistically=: (untyped) -> untyped
+    def lock_optimistically: () -> untyped
+    def lock_optimistically?: () -> bool
+
+    def self.attribute_aliases: () -> untyped
+    def self.attribute_aliases?: () -> bool
+    def self.attribute_aliases=: (untyped) -> untyped
+    def attribute_aliases: () -> untyped
+    def attribute_aliases?: () -> bool
+
+    def self.attribute_method_matchers: () -> untyped
+    def self.attribute_method_matchers?: () -> bool
+    def self.attribute_method_matchers=: (untyped) -> untyped
+    def attribute_method_matchers: () -> untyped
+    def attribute_method_matchers?: () -> bool
+
+    def self.skip_time_zone_conversion_for_attributes: () -> untyped
+    def self.skip_time_zone_conversion_for_attributes?: () -> bool
+    def self.skip_time_zone_conversion_for_attributes=: (untyped) -> untyped
+    def skip_time_zone_conversion_for_attributes: () -> untyped
+    def skip_time_zone_conversion_for_attributes?: () -> bool
+
+    def self.time_zone_aware_types: () -> untyped
+    def self.time_zone_aware_types?: () -> bool
+    def self.time_zone_aware_types=: (untyped) -> untyped
+    def time_zone_aware_types: () -> untyped
+    def time_zone_aware_types?: () -> bool
+
+    def self.partial_writes: () -> untyped
+    def self.partial_writes?: () -> bool
+    def self.partial_writes=: (untyped) -> untyped
+    def partial_writes: () -> untyped
+    def partial_writes?: () -> bool
+
+    def self.record_timestamps: () -> untyped
+    def self.record_timestamps?: () -> bool
+    def self.record_timestamps=: (untyped) -> untyped
+    def record_timestamps: () -> untyped
+    def record_timestamps?: () -> bool
+    def record_timestamps=: (untyped) -> untyped
+
+    def self.nested_attributes_options: () -> untyped
+    def self.nested_attributes_options?: () -> bool
+    def self.nested_attributes_options=: (untyped) -> untyped
+    def nested_attributes_options: () -> untyped
+    def nested_attributes_options?: () -> bool
+
+    def self.aggregate_reflections: () -> untyped
+    def self.aggregate_reflections?: () -> bool
+    def self.aggregate_reflections=: (untyped) -> untyped
+    def aggregate_reflections: () -> untyped
+    def aggregate_reflections?: () -> bool
+
+    def self.include_root_in_json: () -> untyped
+    def self.include_root_in_json?: () -> bool
+    def self.include_root_in_json=: (untyped) -> untyped
+    def include_root_in_json: () -> untyped
+    def include_root_in_json?: () -> bool
   end
 end
 


### PR DESCRIPTION
`Class#class_attributes` generate some methods on `ActiveRecord::Base` also.

I wrote method signature by following hook script.
Then, I extracted only the methods related to `ActiveRecord::Base`.

```rb
class Class
  prepend Module.new {
    def class_attribute(
      *attrs,
      instance_accessor: true,
      instance_reader: instance_accessor,
      instance_writer: instance_accessor,
      instance_predicate: true,
      **
    )
      attrs.each do |name|
        # skip internal attribute
        next if name.to_s.start_with?("_")
        next if name == :attribute_type_decorations
        next if name == :attributes_to_define_after_schema_loads
        puts "[#{self}] def self.#{name}: () -> untyped"
        puts "[#{self}] def self.#{name}?: () -> bool" if instance_predicate
        puts "[#{self}] def self.#{name}=: (untyped) -> untyped"
        if instance_reader
          puts "[#{self}] def #{name}: () -> untyped"
          puts "[#{self}] def #{name}?: () -> bool" if instance_predicate
        end
        if instance_writer
          puts "[#{self}] def #{name}=: (untyped) -> untyped"
        end
      end
      puts
      super
    end
  }
end
```