### PR TITLE
Add manifest yaml

### DIFF
--- a/gems/activestorage/6.0/manifest.yaml
+++ b/gems/activestorage/6.0/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: tempfile

--- a/gems/activestorage/6.1/manifest.yaml
+++ b/gems/activestorage/6.1/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: tempfile

--- a/gems/activesupport/6.0/manifest.yaml
+++ b/gems/activesupport/6.0/manifest.yaml
@@ -5,3 +5,4 @@ dependencies:
   - name: logger
   - name: mutex_m
   - name: time
+  - name: pathname

--- a/gems/httparty/0.18/manifest.yaml
+++ b/gems/httparty/0.18/manifest.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - name: uri
+  - name: net-http

--- a/gems/httpclient/2.8/manifest.yaml
+++ b/gems/httpclient/2.8/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: uri

--- a/gems/railties/6.0/manifest.yaml
+++ b/gems/railties/6.0/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: tsort

--- a/gems/retryable/3.0/manifest.yaml
+++ b/gems/retryable/3.0/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: forwardable

--- a/gems/sidekiq/6.2/manifest.yaml
+++ b/gems/sidekiq/6.2/manifest.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - name: logger
+  - name: monitor


### PR DESCRIPTION
This PR adds `manifest.yaml`s.

`manifest.yaml` describes stdlibs dependencies. See https://github.com/ruby/rbs/pull/808 for more information.


By the way, this patch doesn't remove `library` sections in Steepfile and `-r` options for `rbs validate` in the test scripts.
I'd like to remove them finally due to duplication, but currently they're necessary because the tests don't use `rbs collection` feature.
I'm updating the test script to use `rbs collection` in tests. See #95

