### PR TITLE
Enable ActiveSupport::NumericWithFormat mix-in

### DIFF
--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -175,3 +175,15 @@ class Module
   def mattr_accessor: (*untyped syms, ?default: untyped? default, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> untyped
                     | ...
 end
+
+class Integer
+  include ActiveSupport::NumericWithFormat
+end
+
+class Float
+  include ActiveSupport::NumericWithFormat
+end
+
+class BigDecimal
+  include ActiveSupport::NumericWithFormat
+end


### PR DESCRIPTION
Fix  #96

`AS::NumericWithFormat#to_s` still accepts untyped as arguments, but I think it is acceptable for now. If someone want to make the type stricter, open a pull request. 