### PR TITLE
Use prepend instead of include for AS::NumericWithFormat

### DIFF
--- a/gems/activesupport/6.0/_scripts/test
+++ b/gems/activesupport/6.0/_scripts/test
@@ -1,8 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -xe
+# set -eou => Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
 
-REPO=$(git rev-parse --show-toplevel)/gems
-rbs --repo=$REPO \
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo=$REPO_DIR \
   -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime \
   -ractivesupport validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/activesupport/6.0/_test/Steepfile
+++ b/gems/activesupport/6.0/_test/Steepfile
@@ -1,0 +1,22 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+
+  repo_path "../../../"
+
+  library "pathname"
+  library "logger"
+  library "mutex_m"
+  library "date"
+  library "monitor"
+  library "singleton"
+  library "tsort"
+  library 'rack'
+  library 'time'
+
+  library "activesupport:6.0"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -1,0 +1,5 @@
+require 'active_support/all'
+
+# Test ActiveSupport::NumericWithFormat
+42.to_s
+42.to_s(:phone)

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -177,13 +177,13 @@ class Module
 end
 
 class Integer
-  include ActiveSupport::NumericWithFormat
+  prepend ActiveSupport::NumericWithFormat
 end
 
 class Float
-  include ActiveSupport::NumericWithFormat
+  prepend ActiveSupport::NumericWithFormat
 end
 
 class BigDecimal
-  include ActiveSupport::NumericWithFormat
+  prepend ActiveSupport::NumericWithFormat
 end


### PR DESCRIPTION
Follow up #104 and fix #96

RBS has `prepend` but I didn't know that :see_no_evil: 