### PR TITLE
Support nested input argument for aws-sdk-*

### DIFF
--- a/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs
+++ b/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs
@@ -107,348 +107,112 @@ module Aws
       def write_get_object_response: (request_route: Types::request_route, request_token: Types::request_token, ?body: Types::body, ?status_code: Types::get_object_response_status_code, ?error_code: Types::error_code, ?error_message: Types::error_message, ?accept_ranges: Types::accept_ranges, ?cache_control: Types::cache_control, ?content_disposition: Types::content_disposition, ?content_encoding: Types::content_encoding, ?content_language: Types::content_language, ?content_length: Types::content_length, ?content_range: Types::content_range, ?content_type: Types::content_type, ?delete_marker: Types::delete_marker, ?etag: Types::etag, ?expires: Types::expires, ?expiration: Types::expiration, ?last_modified: Types::last_modified, ?missing_meta: Types::missing_meta, ?metadata: Types::metadata, ?object_lock_mode: Types::object_lock_mode, ?object_lock_legal_hold_status: Types::object_lock_legal_hold_status, ?object_lock_retain_until_date: Types::object_lock_retain_until_date, ?parts_count: Types::parts_count, ?replication_status: Types::replication_status, ?request_charged: Types::request_charged, ?restore: Types::restore, ?server_side_encryption: Types::server_side_encryption, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?ssekms_key_id: Types::ssekms_key_id, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?storage_class: Types::storage_class, ?tag_count: Types::tag_count, ?version_id: Types::object_version_id, ?bucket_key_enabled: Types::bucket_key_enabled) -> Aws::EmptyStructure
     end
     module Types
-      # inputs
-      type bucket_name = ::String
-      type object_key = ::String
-      type multipart_upload_id = ::String
-      type request_payer = ("requester")
-      type account_id = ::String
-      type request_charged = ("requester")
-      type completed_multipart_upload = { parts: completed_part_list? }
-      type completed_part_list = ::Array[completed_part]
-      type completed_part = { etag: etag?, part_number: part_number? }
-      type etag = ::String
-      type part_number = ::Integer
-      type expiration = ::String
-      type server_side_encryption = ("AES256" | "aws:kms")
-      type object_version_id = ::String
-      type ssekms_key_id = ::String
-      type bucket_key_enabled = bool
-      type object_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-      type cache_control = ::String
-      type content_disposition = ::String
-      type content_encoding = ::String
-      type content_language = ::String
-      type content_type = ::String
-      type copy_source = ::String
-      type copy_source_if_match = ::String
-      type copy_source_if_modified_since = ::Time
-      type copy_source_if_none_match = ::String
-      type copy_source_if_unmodified_since = ::Time
-      type expires = ::Time
-      type grant_full_control = ::String
-      type grant_read = ::String
-      type grant_read_acp = ::String
-      type grant_write_acp = ::String
-      type metadata = ::Hash[metadata_key, metadata_value]
-      type metadata_key = ::String
-      type metadata_value = ::String
-      type metadata_directive = ("COPY" | "REPLACE")
-      type tagging_directive = ("COPY" | "REPLACE")
-      type storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-      type website_redirect_location = ::String
-      type sse_customer_algorithm = ::String
-      type sse_customer_key = ::String
-      type sse_customer_key_md5 = ::String
-      type ssekms_encryption_context = ::String
-      type copy_source_sse_customer_algorithm = ::String
-      type copy_source_sse_customer_key = ::String
-      type copy_source_sse_customer_key_md5 = ::String
-      type tagging_header = ::String
-      type object_lock_mode = ("GOVERNANCE" | "COMPLIANCE")
-      type object_lock_retain_until_date = ::Time
-      type object_lock_legal_hold_status = ("ON" | "OFF")
-      type last_modified = ::Time
-      type bucket_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read")
-      type create_bucket_configuration = { location_constraint: bucket_location_constraint? }
-      type bucket_location_constraint = ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
-      type grant_write = ::String
-      type object_lock_enabled_for_bucket = bool
-      type object_ownership = ("BucketOwnerPreferred" | "ObjectWriter" | "BucketOwnerEnforced")
-      type analytics_id = ::String
-      type intelligent_tiering_id = ::String
-      type inventory_id = ::String
-      type metrics_id = ::String
-      type mfa = ::String
-      type bypass_governance_retention = bool
-      type delete_marker = bool
-      type delete = { objects: object_identifier_list, quiet: quiet? }
-      type object_identifier_list = ::Array[object_identifier]
-      type object_identifier = { key: object_key, version_id: object_version_id? }
-      type quiet = bool
-      type bucket_accelerate_status = ("Enabled" | "Suspended")
-      type owner = { display_name: display_name?, id: id? }
-      type display_name = ::String
-      type id = ::String
-      type grants = ::Array[grant]
-      type grant = { grantee: grantee?, permission: permission? }
-      type grantee = { display_name: display_name?, email_address: email_address?, id: id?, type: type_, uri: uri? }
-      type email_address = ::String
-      type type_ = ("CanonicalUser" | "AmazonCustomerByEmail" | "Group")
-      type uri = ::String
-      type permission = ("FULL_CONTROL" | "WRITE" | "WRITE_ACP" | "READ" | "READ_ACP")
-      type analytics_configuration = { id: analytics_id, filter: analytics_filter?, storage_class_analysis: storage_class_analysis }
-      type analytics_filter = { prefix: prefix?, tag: tag?, and: analytics_and_operator? }
-      type prefix = ::String
-      type tag = { key: object_key, value: value }
-      type value = ::String
-      type analytics_and_operator = { prefix: prefix?, tags: tag_set? }
-      type tag_set = ::Array[tag]
-      type storage_class_analysis = { data_export: storage_class_analysis_data_export? }
-      type storage_class_analysis_data_export = { output_schema_version: storage_class_analysis_schema_version, destination: analytics_export_destination }
-      type storage_class_analysis_schema_version = ("V_1")
-      type analytics_export_destination = { s3_bucket_destination: analytics_s3_bucket_destination }
-      type analytics_s3_bucket_destination = { format: analytics_s3_export_file_format, bucket_account_id: account_id?, bucket: bucket_name, prefix: prefix? }
-      type analytics_s3_export_file_format = ("CSV")
-      type cors_rules = ::Array[cors_rule]
-      type cors_rule = { id: id?, allowed_headers: allowed_headers?, allowed_methods: allowed_methods, allowed_origins: allowed_origins, expose_headers: expose_headers?, max_age_seconds: max_age_seconds? }
-      type allowed_headers = ::Array[allowed_header]
-      type allowed_header = ::String
-      type allowed_methods = ::Array[allowed_method]
-      type allowed_method = ::String
-      type allowed_origins = ::Array[allowed_origin]
-      type allowed_origin = ::String
-      type expose_headers = ::Array[expose_header]
-      type expose_header = ::String
-      type max_age_seconds = ::Integer
-      type server_side_encryption_configuration = { rules: server_side_encryption_rules }
-      type server_side_encryption_rules = ::Array[server_side_encryption_rule]
-      type server_side_encryption_rule = { apply_server_side_encryption_by_default: server_side_encryption_by_default?, bucket_key_enabled: bucket_key_enabled? }
-      type server_side_encryption_by_default = { sse_algorithm: server_side_encryption, kms_master_key_id: ssekms_key_id? }
-      type intelligent_tiering_configuration = { id: intelligent_tiering_id, filter: intelligent_tiering_filter?, status: intelligent_tiering_status, tierings: tiering_list }
-      type intelligent_tiering_filter = { prefix: prefix?, tag: tag?, and: intelligent_tiering_and_operator? }
-      type intelligent_tiering_and_operator = { prefix: prefix?, tags: tag_set? }
-      type intelligent_tiering_status = ("Enabled" | "Disabled")
-      type tiering_list = ::Array[tiering]
-      type tiering = { days: intelligent_tiering_days, access_tier: intelligent_tiering_access_tier }
-      type intelligent_tiering_days = ::Integer
-      type intelligent_tiering_access_tier = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
-      type inventory_configuration = { destination: inventory_destination, is_enabled: is_enabled, filter: inventory_filter?, id: inventory_id, included_object_versions: inventory_included_object_versions, optional_fields: inventory_optional_fields?, schedule: inventory_schedule }
-      type inventory_destination = { s3_bucket_destination: inventory_s3_bucket_destination }
-      type inventory_s3_bucket_destination = { account_id: account_id?, bucket: bucket_name, format: inventory_format, prefix: prefix?, encryption: inventory_encryption? }
-      type inventory_format = ("CSV" | "ORC" | "Parquet")
-      type inventory_encryption = { sses3: sses3?, ssekms: ssekms? }
-      type sses3 = ::Hash[untyped, untyped]
-      type ssekms = { key_id: ssekms_key_id }
-      type is_enabled = bool
-      type inventory_filter = { prefix: prefix }
-      type inventory_included_object_versions = ("All" | "Current")
-      type inventory_optional_fields = ::Array[inventory_optional_field]
-      type inventory_optional_field = ("Size" | "LastModifiedDate" | "StorageClass" | "ETag" | "IsMultipartUploaded" | "ReplicationStatus" | "EncryptionStatus" | "ObjectLockRetainUntilDate" | "ObjectLockMode" | "ObjectLockLegalHoldStatus" | "IntelligentTieringAccessTier" | "BucketKeyStatus")
-      type inventory_schedule = { frequency: inventory_frequency }
-      type inventory_frequency = ("Daily" | "Weekly")
-      type rules = ::Array[rule]
-      type rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix, status: expiration_status, transition: transition?, noncurrent_version_transition: noncurrent_version_transition?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
-      type lifecycle_expiration = { date: date?, days: days?, expired_object_delete_marker: expired_object_delete_marker? }
-      type date = ::Time
-      type days = ::Integer
-      type expired_object_delete_marker = bool
-      type expiration_status = ("Enabled" | "Disabled")
-      type transition = { date: date?, days: days?, storage_class: transition_storage_class? }
-      type transition_storage_class = ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
-      type noncurrent_version_transition = { noncurrent_days: days?, storage_class: transition_storage_class?, newer_noncurrent_versions: version_count? }
-      type version_count = ::Integer
-      type noncurrent_version_expiration = { noncurrent_days: days?, newer_noncurrent_versions: version_count? }
+      type abort_date = ::Time
+      class AbortIncompleteMultipartUpload
+        attr_accessor days_after_initiation: days_after_initiation
+      end
       type abort_incomplete_multipart_upload = { days_after_initiation: days_after_initiation? }
-      type days_after_initiation = ::Integer
-      type lifecycle_rules = ::Array[lifecycle_rule]
-      type lifecycle_rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix?, filter: lifecycle_rule_filter?, status: expiration_status, transitions: transition_list?, noncurrent_version_transitions: noncurrent_version_transition_list?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
-      type lifecycle_rule_filter = { prefix: prefix?, tag: tag?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes?, and: lifecycle_rule_and_operator? }
-      type object_size_greater_than_bytes = ::Integer
-      type object_size_less_than_bytes = ::Integer
-      type lifecycle_rule_and_operator = { prefix: prefix?, tags: tag_set?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes? }
-      type transition_list = ::Array[transition]
-      type noncurrent_version_transition_list = ::Array[noncurrent_version_transition]
-      type logging_enabled = { target_bucket: target_bucket, target_grants: target_grants?, target_prefix: target_prefix }
-      type target_bucket = ::String
-      type target_grants = ::Array[target_grant]
-      type target_grant = { grantee: grantee?, permission: bucket_logs_permission? }
-      type bucket_logs_permission = ("FULL_CONTROL" | "READ" | "WRITE")
-      type target_prefix = ::String
-      type metrics_configuration = { id: metrics_id, filter: metrics_filter? }
-      type metrics_filter = { prefix: prefix?, tag: tag?, access_point_arn: access_point_arn?, and: metrics_and_operator? }
-      type access_point_arn = ::String
-      type metrics_and_operator = { prefix: prefix?, tags: tag_set?, access_point_arn: access_point_arn? }
-      type notification_configuration_deprecated = { topic_configuration: topic_configuration_deprecated?, queue_configuration: queue_configuration_deprecated?, cloud_function_configuration: cloud_function_configuration? }
-      type topic_configuration_deprecated = { id: notification_id?, events: event_list?, event: event?, topic: topic_arn? }
-      type notification_id = ::String
-      type event_list = ::Array[event]
-      type event = ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
-      type topic_arn = ::String
-      type queue_configuration_deprecated = { id: notification_id?, event: event?, events: event_list?, queue: queue_arn? }
-      type queue_arn = ::String
-      type cloud_function_configuration = { id: notification_id?, event: event?, events: event_list?, cloud_function: cloud_function?, invocation_role: cloud_function_invocation_role? }
-      type cloud_function = ::String
-      type cloud_function_invocation_role = ::String
-      type notification_configuration = { topic_configurations: topic_configuration_list?, queue_configurations: queue_configuration_list?, lambda_function_configurations: lambda_function_configuration_list?, event_bridge_configuration: event_bridge_configuration? }
-      type topic_configuration_list = ::Array[topic_configuration]
-      type topic_configuration = { id: notification_id?, topic_arn: topic_arn, events: event_list, filter: notification_configuration_filter? }
-      type notification_configuration_filter = { key: s3_key_filter? }
-      type s3_key_filter = { filter_rules: filter_rule_list? }
-      type filter_rule_list = ::Array[filter_rule]
-      type filter_rule = { name: filter_rule_name?, value: filter_rule_value? }
-      type filter_rule_name = ("prefix" | "suffix")
-      type filter_rule_value = ::String
-      type queue_configuration_list = ::Array[queue_configuration]
-      type queue_configuration = { id: notification_id?, queue_arn: queue_arn, events: event_list, filter: notification_configuration_filter? }
-      type lambda_function_configuration_list = ::Array[lambda_function_configuration]
-      type lambda_function_configuration = { id: notification_id?, lambda_function_arn: lambda_function_arn, events: event_list, filter: notification_configuration_filter? }
-      type lambda_function_arn = ::String
-      type event_bridge_configuration = ::Hash[untyped, untyped]
-      type ownership_controls = { rules: ownership_controls_rules }
-      type ownership_controls_rules = ::Array[ownership_controls_rule]
-      type ownership_controls_rule = { object_ownership: object_ownership }
-      type policy = ::String
-      type replication_configuration = { role: role, rules: replication_rules }
-      type role = ::String
-      type replication_rules = ::Array[replication_rule]
-      type replication_rule = { id: id?, priority: priority?, prefix: prefix?, filter: replication_rule_filter?, status: replication_rule_status, source_selection_criteria: source_selection_criteria?, existing_object_replication: existing_object_replication?, destination: destination, delete_marker_replication: delete_marker_replication? }
-      type priority = ::Integer
-      type replication_rule_filter = { prefix: prefix?, tag: tag?, and: replication_rule_and_operator? }
-      type replication_rule_and_operator = { prefix: prefix?, tags: tag_set? }
-      type replication_rule_status = ("Enabled" | "Disabled")
-      type source_selection_criteria = { sse_kms_encrypted_objects: sse_kms_encrypted_objects?, replica_modifications: replica_modifications? }
-      type sse_kms_encrypted_objects = { status: sse_kms_encrypted_objects_status }
-      type sse_kms_encrypted_objects_status = ("Enabled" | "Disabled")
-      type replica_modifications = { status: replica_modifications_status }
-      type replica_modifications_status = ("Enabled" | "Disabled")
-      type existing_object_replication = { status: existing_object_replication_status }
-      type existing_object_replication_status = ("Enabled" | "Disabled")
-      type destination = { bucket: bucket_name, account: account_id?, storage_class: storage_class?, access_control_translation: access_control_translation?, encryption_configuration: encryption_configuration?, replication_time: replication_time?, metrics: metrics? }
-      type access_control_translation = { owner: owner_override }
-      type owner_override = ("Destination")
-      type encryption_configuration = { replica_kms_key_id: replica_kms_key_id? }
-      type replica_kms_key_id = ::String
-      type replication_time = { status: replication_time_status, time: replication_time_value }
-      type replication_time_status = ("Enabled" | "Disabled")
-      type replication_time_value = { minutes: minutes? }
-      type minutes = ::Integer
-      type metrics = { status: metrics_status, event_threshold: replication_time_value? }
-      type metrics_status = ("Enabled" | "Disabled")
-      type delete_marker_replication = { status: delete_marker_replication_status? }
-      type delete_marker_replication_status = ("Enabled" | "Disabled")
-      type payer = ("Requester" | "BucketOwner")
-      type bucket_versioning_status = ("Enabled" | "Suspended")
-      type redirect_all_requests_to = { host_name: host_name, protocol: protocol? }
-      type host_name = ::String
-      type protocol = ("http" | "https")
-      type index_document = { suffix: suffix }
-      type suffix = ::String
-      type error_document = { key: object_key }
-      type routing_rules = ::Array[routing_rule]
-      type routing_rule = { condition: condition?, redirect: redirect }
-      type condition = { http_error_code_returned_equals: http_error_code_returned_equals?, key_prefix_equals: key_prefix_equals? }
-      type http_error_code_returned_equals = ::String
-      type key_prefix_equals = ::String
-      type redirect = { host_name: host_name?, http_redirect_code: http_redirect_code?, protocol: protocol?, replace_key_prefix_with: replace_key_prefix_with?, replace_key_with: replace_key_with? }
-      type http_redirect_code = ::String
-      type replace_key_prefix_with = ::String
-      type replace_key_with = ::String
-      type if_match = ::String
-      type if_modified_since = ::Time
-      type if_none_match = ::String
-      type if_unmodified_since = ::Time
-      type range = ::String
-      type response_cache_control = ::String
-      type response_content_disposition = ::String
-      type response_content_encoding = ::String
-      type response_content_language = ::String
-      type response_content_type = ::String
-      type response_expires = ::Time
-      type body = ::IO
-      type accept_ranges = ::String
-      type restore = ::String
-      type content_length = ::Integer
-      type missing_meta = ::Integer
-      type content_range = ::String
-      type replication_status = ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
-      type parts_count = ::Integer
-      type tag_count = ::Integer
-      type object_lock_legal_hold = { status: object_lock_legal_hold_status? }
-      type object_lock_configuration = { object_lock_enabled: object_lock_enabled?, rule: object_lock_rule? }
-      type object_lock_enabled = ("Enabled")
-      type object_lock_rule = { default_retention: default_retention? }
-      type default_retention = { mode: object_lock_retention_mode?, days: days?, years: years? }
-      type object_lock_retention_mode = ("GOVERNANCE" | "COMPLIANCE")
-      type years = ::Integer
-      type object_lock_retention = { mode: object_lock_retention_mode?, retain_until_date: date? }
-      type public_access_block_configuration = { block_public_acls: setting?, ignore_public_acls: setting?, block_public_policy: setting?, restrict_public_buckets: setting? }
-      type setting = bool
-      type token = ::String
-      type delimiter = ::String
-      type encoding_type = ("url")
-      type key_marker = ::String
-      type max_uploads = ::Integer
-      type upload_id_marker = ::String
-      type max_keys = ::Integer
-      type version_id_marker = ::String
-      type marker = ::String
-      type fetch_owner = bool
-      type start_after = ::String
-      type max_parts = ::Integer
-      type part_number_marker = ::Integer
-      type accelerate_configuration = { status: bucket_accelerate_status? }
-      type access_control_policy = { grants: grants?, owner: owner? }
-      type content_md5 = ::String
-      type cors_configuration = { cors_rules: cors_rules }
-      type lifecycle_configuration = { rules: rules }
-      type bucket_lifecycle_configuration = { rules: lifecycle_rules }
-      type bucket_logging_status = { logging_enabled: logging_enabled? }
-      type skip_validation = bool
-      type confirm_remove_self_bucket_access = bool
-      type object_lock_token = ::String
-      type request_payment_configuration = { payer: payer }
-      type tagging = { tag_set: tag_set }
-      type versioning_configuration = { mfa_delete: mfa_delete?, status: bucket_versioning_status? }
-      type mfa_delete = ("Enabled" | "Disabled")
-      type website_configuration = { error_document: error_document?, index_document: index_document?, redirect_all_requests_to: redirect_all_requests_to?, routing_rules: routing_rules? }
-      type restore_request = { days: days?, glacier_job_parameters: glacier_job_parameters?, type: restore_request_type?, tier: tier?, description: description?, select_parameters: select_parameters?, output_location: output_location? }
-      type glacier_job_parameters = { tier: tier }
-      type tier = ("Standard" | "Bulk" | "Expedited")
-      type restore_request_type = ("SELECT")
-      type description = ::String
-      type select_parameters = { input_serialization: input_serialization, expression_type: expression_type, expression: expression, output_serialization: output_serialization }
-      type input_serialization = { csv: csv_input?, compression_type: compression_type?, json: json_input?, parquet: parquet_input? }
-      type csv_input = { file_header_info: file_header_info?, comments: comments?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character?, allow_quoted_record_delimiter: allow_quoted_record_delimiter? }
-      type file_header_info = ("USE" | "IGNORE" | "NONE")
-      type comments = ::String
-      type quote_escape_character = ::String
-      type record_delimiter = ::String
-      type field_delimiter = ::String
-      type quote_character = ::String
-      type allow_quoted_record_delimiter = bool
-      type compression_type = ("NONE" | "GZIP" | "BZIP2")
-      type json_input = { type: json_type? }
-      type json_type = ("DOCUMENT" | "LINES")
-      type parquet_input = ::Hash[untyped, untyped]
-      type expression_type = ("SQL")
-      type expression = ::String
-      type output_serialization = { csv: csv_output?, json: json_output? }
-      type csv_output = { quote_fields: quote_fields?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character? }
-      type quote_fields = ("ALWAYS" | "ASNEEDED")
-      type json_output = { record_delimiter: record_delimiter? }
-      type output_location = { s3: s3_location? }
-      type s3_location = { bucket_name: bucket_name, prefix: location_prefix, encryption: encryption?, canned_acl: object_canned_acl?, access_control_list: grants?, tagging: tagging?, user_metadata: user_metadata?, storage_class: storage_class? }
-      type location_prefix = ::String
-      type encryption = { encryption_type: server_side_encryption, kms_key_id: ssekms_key_id?, kms_context: kms_context? }
-      type kms_context = ::String
-      type user_metadata = ::Array[metadata_entry]
-      type metadata_entry = { name: metadata_key?, value: metadata_value? }
-      type request_progress = { enabled: enable_request_progress? }
-      type enable_request_progress = bool
-      type scan_range = { start: start?, end: end_? }
-      type start = ::Integer
-      type end_ = ::Integer
-      type copy_source_range = ::String
-      type request_route = ::String
-      type request_token = ::String
-      type get_object_response_status_code = ::Integer
-      type error_code = ::String
-      type error_message = ::String
-      # outputs
       class AbortMultipartUploadOutput
         attr_accessor request_charged: request_charged
       end
+      type abort_rule_id = ::String
+      type accelerate_configuration = { status: bucket_accelerate_status? }
+      type accept_ranges = ::String
+      type access_control_policy = { grants: grants?, owner: owner? }
+      class AccessControlTranslation
+        attr_accessor owner: owner_override
+      end
+      type access_control_translation = { owner: owner_override }
+      type access_point_arn = ::String
+      type account_id = ::String
+      type allow_quoted_record_delimiter = bool
+      type allowed_header = ::String
+      type allowed_headers = ::Array[allowed_header]
+      type allowed_method = ::String
+      type allowed_methods = ::Array[allowed_method]
+      type allowed_origin = ::String
+      type allowed_origins = ::Array[allowed_origin]
+      class AnalyticsAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+      end
+      type analytics_and_operator = { prefix: prefix?, tags: tag_set? }
+      class AnalyticsConfiguration
+        attr_accessor id: analytics_id
+        attr_accessor filter: AnalyticsFilter
+        attr_accessor storage_class_analysis: StorageClassAnalysis
+      end
+      type analytics_configuration = { id: analytics_id, filter: analytics_filter?, storage_class_analysis: storage_class_analysis }
+      type analytics_configuration_list = ::Array[AnalyticsConfiguration]
+      class AnalyticsExportDestination
+        attr_accessor s3_bucket_destination: AnalyticsS3BucketDestination
+      end
+      type analytics_export_destination = { s3_bucket_destination: analytics_s3_bucket_destination }
+      class AnalyticsFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor and: AnalyticsAndOperator
+      end
+      type analytics_filter = { prefix: prefix?, tag: tag?, and: analytics_and_operator? }
+      type analytics_id = ::String
+      class AnalyticsS3BucketDestination
+        attr_accessor format: analytics_s3_export_file_format
+        attr_accessor bucket_account_id: account_id
+        attr_accessor bucket: bucket_name
+        attr_accessor prefix: prefix
+      end
+      type analytics_s3_bucket_destination = { format: analytics_s3_export_file_format, bucket_account_id: account_id?, bucket: bucket_name, prefix: prefix? }
+      type analytics_s3_export_file_format = ("CSV")
+      type archive_status = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
+      type body = ::IO
+      class Bucket
+        attr_accessor name: bucket_name
+        attr_accessor creation_date: creation_date
+      end
+      type bucket_accelerate_status = ("Enabled" | "Suspended")
+      type bucket_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read")
+      type bucket_key_enabled = bool
+      type bucket_lifecycle_configuration = { rules: lifecycle_rules }
+      type bucket_location_constraint = ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
+      type bucket_logging_status = { logging_enabled: logging_enabled? }
+      type bucket_logs_permission = ("FULL_CONTROL" | "READ" | "WRITE")
+      type bucket_name = ::String
+      type bucket_versioning_status = ("Enabled" | "Suspended")
+      type buckets = ::Array[Bucket]
+      type bypass_governance_retention = bool
+      type bytes_processed = ::Integer
+      type bytes_returned = ::Integer
+      type bytes_scanned = ::Integer
+      type cors_configuration = { cors_rules: cors_rules }
+      class CORSRule
+        attr_accessor id: id
+        attr_accessor allowed_headers: allowed_headers
+        attr_accessor allowed_methods: allowed_methods
+        attr_accessor allowed_origins: allowed_origins
+        attr_accessor expose_headers: expose_headers
+        attr_accessor max_age_seconds: max_age_seconds
+      end
+      type cors_rule = { id: id?, allowed_headers: allowed_headers?, allowed_methods: allowed_methods, allowed_origins: allowed_origins, expose_headers: expose_headers?, max_age_seconds: max_age_seconds? }
+      type cors_rules = ::Array[CORSRule]
+      type csv_input = { file_header_info: file_header_info?, comments: comments?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character?, allow_quoted_record_delimiter: allow_quoted_record_delimiter? }
+      type csv_output = { quote_fields: quote_fields?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character? }
+      type cache_control = ::String
+      type cloud_function = ::String
+      class CloudFunctionConfiguration
+        attr_accessor id: notification_id
+        attr_accessor event: event
+        attr_accessor events: event_list
+        attr_accessor cloud_function: cloud_function
+        attr_accessor invocation_role: cloud_function_invocation_role
+      end
+      type cloud_function_configuration = { id: notification_id?, event: event?, events: event_list?, cloud_function: cloud_function?, invocation_role: cloud_function_invocation_role? }
+      type cloud_function_invocation_role = ::String
+      type code = ::String
+      type comments = ::String
+      class CommonPrefix
+        attr_accessor prefix: prefix
+      end
+      type common_prefix_list = ::Array[CommonPrefix]
       class CompleteMultipartUploadOutput
         attr_accessor location: location
         attr_accessor bucket: bucket_name
@@ -461,7 +225,25 @@ module Aws
         attr_accessor bucket_key_enabled: bucket_key_enabled
         attr_accessor request_charged: request_charged
       end
-      type location = ::String
+      type completed_multipart_upload = { parts: completed_part_list? }
+      type completed_part = { etag: etag?, part_number: part_number? }
+      type completed_part_list = ::Array[completed_part]
+      type compression_type = ("NONE" | "GZIP" | "BZIP2")
+      class Condition
+        attr_accessor http_error_code_returned_equals: http_error_code_returned_equals
+        attr_accessor key_prefix_equals: key_prefix_equals
+      end
+      type condition = { http_error_code_returned_equals: http_error_code_returned_equals?, key_prefix_equals: key_prefix_equals? }
+      type confirm_remove_self_bucket_access = bool
+      type content_disposition = ::String
+      type content_encoding = ::String
+      type content_language = ::String
+      type content_length = ::Integer
+      type content_md5 = ::String
+      type content_range = ::String
+      type content_type = ::String
+      class ContinuationEvent
+      end
       class CopyObjectOutput
         attr_accessor copy_object_result: CopyObjectResult
         attr_accessor expiration: expiration
@@ -479,7 +261,21 @@ module Aws
         attr_accessor etag: etag
         attr_accessor last_modified: last_modified
       end
+      class CopyPartResult
+        attr_accessor etag: etag
+        attr_accessor last_modified: last_modified
+      end
+      type copy_source = ::String
+      type copy_source_if_match = ::String
+      type copy_source_if_modified_since = ::Time
+      type copy_source_if_none_match = ::String
+      type copy_source_if_unmodified_since = ::Time
+      type copy_source_range = ::String
+      type copy_source_sse_customer_algorithm = ::String
+      type copy_source_sse_customer_key = ::String
+      type copy_source_sse_customer_key_md5 = ::String
       type copy_source_version_id = ::String
+      type create_bucket_configuration = { location_constraint: bucket_location_constraint? }
       class CreateBucketOutput
         attr_accessor location: location
       end
@@ -497,8 +293,32 @@ module Aws
         attr_accessor bucket_key_enabled: bucket_key_enabled
         attr_accessor request_charged: request_charged
       end
-      type abort_date = ::Time
-      type abort_rule_id = ::String
+      type creation_date = ::Time
+      type date = ::Time
+      type days = ::Integer
+      type days_after_initiation = ::Integer
+      class DefaultRetention
+        attr_accessor mode: object_lock_retention_mode
+        attr_accessor days: days
+        attr_accessor years: years
+      end
+      type default_retention = { mode: object_lock_retention_mode?, days: days?, years: years? }
+      type delete = { objects: object_identifier_list, quiet: quiet? }
+      type delete_marker = bool
+      class DeleteMarkerEntry
+        attr_accessor owner: Owner
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor is_latest: is_latest
+        attr_accessor last_modified: last_modified
+      end
+      class DeleteMarkerReplication
+        attr_accessor status: delete_marker_replication_status
+      end
+      type delete_marker_replication = { status: delete_marker_replication_status? }
+      type delete_marker_replication_status = ("Enabled" | "Disabled")
+      type delete_marker_version_id = ::String
+      type delete_markers = ::Array[DeleteMarkerEntry]
       class DeleteObjectOutput
         attr_accessor delete_marker: delete_marker
         attr_accessor version_id: object_version_id
@@ -512,380 +332,15 @@ module Aws
         attr_accessor request_charged: request_charged
         attr_accessor errors: errors
       end
-      type deleted_objects = ::Array[DeletedObject]
       class DeletedObject
         attr_accessor key: object_key
         attr_accessor version_id: object_version_id
         attr_accessor delete_marker: delete_marker
         attr_accessor delete_marker_version_id: delete_marker_version_id
       end
-      type delete_marker_version_id = ::String
-      type errors = ::Array[Error]
-      class Error
-        attr_accessor key: object_key
-        attr_accessor version_id: object_version_id
-        attr_accessor code: code
-        attr_accessor message: message
-      end
-      type code = ::String
-      type message = ::String
-      class GetBucketAccelerateConfigurationOutput
-        attr_accessor status: bucket_accelerate_status
-      end
-      class GetBucketAclOutput
-        attr_accessor owner: Owner
-        attr_accessor grants: grants
-      end
-      class Owner
-        attr_accessor display_name: display_name
-        attr_accessor id: id
-      end
-      class Grant
-        attr_accessor grantee: Grantee
-        attr_accessor permission: permission
-      end
-      class Grantee
-        attr_accessor display_name: display_name
-        attr_accessor email_address: email_address
-        attr_accessor id: id
-        attr_accessor type_: type_
-        attr_accessor uri: uri
-      end
-      class GetBucketAnalyticsConfigurationOutput
-        attr_accessor analytics_configuration: AnalyticsConfiguration
-      end
-      class AnalyticsConfiguration
-        attr_accessor id: analytics_id
-        attr_accessor filter: AnalyticsFilter
-        attr_accessor storage_class_analysis: StorageClassAnalysis
-      end
-      class AnalyticsFilter
-        attr_accessor prefix: prefix
-        attr_accessor tag: Tag
-        attr_accessor and: AnalyticsAndOperator
-      end
-      class Tag
-        attr_accessor key: object_key
-        attr_accessor value: value
-      end
-      class AnalyticsAndOperator
-        attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
-      end
-      class StorageClassAnalysis
-        attr_accessor data_export: StorageClassAnalysisDataExport
-      end
-      class StorageClassAnalysisDataExport
-        attr_accessor output_schema_version: storage_class_analysis_schema_version
-        attr_accessor destination: AnalyticsExportDestination
-      end
-      class AnalyticsExportDestination
-        attr_accessor s3_bucket_destination: AnalyticsS3BucketDestination
-      end
-      class AnalyticsS3BucketDestination
-        attr_accessor format: analytics_s3_export_file_format
-        attr_accessor bucket_account_id: account_id
-        attr_accessor bucket: bucket_name
-        attr_accessor prefix: prefix
-      end
-      class GetBucketCorsOutput
-        attr_accessor cors_rules: cors_rules
-      end
-      class CORSRule
-        attr_accessor id: id
-        attr_accessor allowed_headers: allowed_headers
-        attr_accessor allowed_methods: allowed_methods
-        attr_accessor allowed_origins: allowed_origins
-        attr_accessor expose_headers: expose_headers
-        attr_accessor max_age_seconds: max_age_seconds
-      end
-      class GetBucketEncryptionOutput
-        attr_accessor server_side_encryption_configuration: ServerSideEncryptionConfiguration
-      end
-      class ServerSideEncryptionConfiguration
-        attr_accessor rules: server_side_encryption_rules
-      end
-      class ServerSideEncryptionRule
-        attr_accessor apply_server_side_encryption_by_default: ServerSideEncryptionByDefault
-        attr_accessor bucket_key_enabled: bucket_key_enabled
-      end
-      class ServerSideEncryptionByDefault
-        attr_accessor sse_algorithm: server_side_encryption
-        attr_accessor kms_master_key_id: ssekms_key_id
-      end
-      class GetBucketIntelligentTieringConfigurationOutput
-        attr_accessor intelligent_tiering_configuration: IntelligentTieringConfiguration
-      end
-      class IntelligentTieringConfiguration
-        attr_accessor id: intelligent_tiering_id
-        attr_accessor filter: IntelligentTieringFilter
-        attr_accessor status: intelligent_tiering_status
-        attr_accessor tierings: tiering_list
-      end
-      class IntelligentTieringFilter
-        attr_accessor prefix: prefix
-        attr_accessor tag: Tag
-        attr_accessor and: IntelligentTieringAndOperator
-      end
-      class IntelligentTieringAndOperator
-        attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
-      end
-      class Tiering
-        attr_accessor days: intelligent_tiering_days
-        attr_accessor access_tier: intelligent_tiering_access_tier
-      end
-      class GetBucketInventoryConfigurationOutput
-        attr_accessor inventory_configuration: InventoryConfiguration
-      end
-      class InventoryConfiguration
-        attr_accessor destination: InventoryDestination
-        attr_accessor is_enabled: is_enabled
-        attr_accessor filter: InventoryFilter
-        attr_accessor id: inventory_id
-        attr_accessor included_object_versions: inventory_included_object_versions
-        attr_accessor optional_fields: inventory_optional_fields
-        attr_accessor schedule: InventorySchedule
-      end
-      class InventoryDestination
-        attr_accessor s3_bucket_destination: InventoryS3BucketDestination
-      end
-      class InventoryS3BucketDestination
-        attr_accessor account_id: account_id
-        attr_accessor bucket: bucket_name
-        attr_accessor format: inventory_format
-        attr_accessor prefix: prefix
-        attr_accessor encryption: InventoryEncryption
-      end
-      class InventoryEncryption
-        attr_accessor sses3: SSES3
-        attr_accessor ssekms: SSEKMS
-      end
-      class SSES3
-      end
-      class SSEKMS
-        attr_accessor key_id: ssekms_key_id
-      end
-      class InventoryFilter
-        attr_accessor prefix: prefix
-      end
-      class InventorySchedule
-        attr_accessor frequency: inventory_frequency
-      end
-      class GetBucketLifecycleOutput
-        attr_accessor rules: rules
-      end
-      class Rule
-        attr_accessor expiration: LifecycleExpiration
-        attr_accessor id: id
-        attr_accessor prefix: prefix
-        attr_accessor status: expiration_status
-        attr_accessor transition: Transition
-        attr_accessor noncurrent_version_transition: NoncurrentVersionTransition
-        attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
-        attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
-      end
-      class LifecycleExpiration
-        attr_accessor date: date
-        attr_accessor days: days
-        attr_accessor expired_object_delete_marker: expired_object_delete_marker
-      end
-      class Transition
-        attr_accessor date: date
-        attr_accessor days: days
-        attr_accessor storage_class: transition_storage_class
-      end
-      class NoncurrentVersionTransition
-        attr_accessor noncurrent_days: days
-        attr_accessor storage_class: transition_storage_class
-        attr_accessor newer_noncurrent_versions: version_count
-      end
-      class NoncurrentVersionExpiration
-        attr_accessor noncurrent_days: days
-        attr_accessor newer_noncurrent_versions: version_count
-      end
-      class AbortIncompleteMultipartUpload
-        attr_accessor days_after_initiation: days_after_initiation
-      end
-      class GetBucketLifecycleConfigurationOutput
-        attr_accessor rules: lifecycle_rules
-      end
-      class LifecycleRule
-        attr_accessor expiration: LifecycleExpiration
-        attr_accessor id: id
-        attr_accessor prefix: prefix
-        attr_accessor filter: LifecycleRuleFilter
-        attr_accessor status: expiration_status
-        attr_accessor transitions: transition_list
-        attr_accessor noncurrent_version_transitions: noncurrent_version_transition_list
-        attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
-        attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
-      end
-      class LifecycleRuleFilter
-        attr_accessor prefix: prefix
-        attr_accessor tag: Tag
-        attr_accessor object_size_greater_than: object_size_greater_than_bytes
-        attr_accessor object_size_less_than: object_size_less_than_bytes
-        attr_accessor and: LifecycleRuleAndOperator
-      end
-      class LifecycleRuleAndOperator
-        attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
-        attr_accessor object_size_greater_than: object_size_greater_than_bytes
-        attr_accessor object_size_less_than: object_size_less_than_bytes
-      end
-      class GetBucketLocationOutput
-        attr_accessor location_constraint: bucket_location_constraint
-      end
-      class GetBucketLoggingOutput
-        attr_accessor logging_enabled: LoggingEnabled
-      end
-      class LoggingEnabled
-        attr_accessor target_bucket: target_bucket
-        attr_accessor target_grants: target_grants
-        attr_accessor target_prefix: target_prefix
-      end
-      class TargetGrant
-        attr_accessor grantee: Grantee
-        attr_accessor permission: bucket_logs_permission
-      end
-      class GetBucketMetricsConfigurationOutput
-        attr_accessor metrics_configuration: MetricsConfiguration
-      end
-      class MetricsConfiguration
-        attr_accessor id: metrics_id
-        attr_accessor filter: MetricsFilter
-      end
-      class MetricsFilter
-        attr_accessor prefix: prefix
-        attr_accessor tag: Tag
-        attr_accessor access_point_arn: access_point_arn
-        attr_accessor and: MetricsAndOperator
-      end
-      class MetricsAndOperator
-        attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
-        attr_accessor access_point_arn: access_point_arn
-      end
-      class NotificationConfigurationDeprecated
-        attr_accessor topic_configuration: TopicConfigurationDeprecated
-        attr_accessor queue_configuration: QueueConfigurationDeprecated
-        attr_accessor cloud_function_configuration: CloudFunctionConfiguration
-      end
-      class TopicConfigurationDeprecated
-        attr_accessor id: notification_id
-        attr_accessor events: event_list
-        attr_accessor event: event
-        attr_accessor topic: topic_arn
-      end
-      class QueueConfigurationDeprecated
-        attr_accessor id: notification_id
-        attr_accessor event: event
-        attr_accessor events: event_list
-        attr_accessor queue: queue_arn
-      end
-      class CloudFunctionConfiguration
-        attr_accessor id: notification_id
-        attr_accessor event: event
-        attr_accessor events: event_list
-        attr_accessor cloud_function: cloud_function
-        attr_accessor invocation_role: cloud_function_invocation_role
-      end
-      class NotificationConfiguration
-        attr_accessor topic_configurations: topic_configuration_list
-        attr_accessor queue_configurations: queue_configuration_list
-        attr_accessor lambda_function_configurations: lambda_function_configuration_list
-        attr_accessor event_bridge_configuration: EventBridgeConfiguration
-      end
-      class TopicConfiguration
-        attr_accessor id: notification_id
-        attr_accessor topic_arn: topic_arn
-        attr_accessor events: event_list
-        attr_accessor filter: NotificationConfigurationFilter
-      end
-      class NotificationConfigurationFilter
-        attr_accessor key: S3KeyFilter
-      end
-      class S3KeyFilter
-        attr_accessor filter_rules: filter_rule_list
-      end
-      class FilterRule
-        attr_accessor name: filter_rule_name
-        attr_accessor value: filter_rule_value
-      end
-      class QueueConfiguration
-        attr_accessor id: notification_id
-        attr_accessor queue_arn: queue_arn
-        attr_accessor events: event_list
-        attr_accessor filter: NotificationConfigurationFilter
-      end
-      class LambdaFunctionConfiguration
-        attr_accessor id: notification_id
-        attr_accessor lambda_function_arn: lambda_function_arn
-        attr_accessor events: event_list
-        attr_accessor filter: NotificationConfigurationFilter
-      end
-      class EventBridgeConfiguration
-      end
-      class GetBucketOwnershipControlsOutput
-        attr_accessor ownership_controls: OwnershipControls
-      end
-      class OwnershipControls
-        attr_accessor rules: ownership_controls_rules
-      end
-      class OwnershipControlsRule
-        attr_accessor object_ownership: object_ownership
-      end
-      class GetBucketPolicyOutput
-        attr_accessor policy: policy
-      end
-      class GetBucketPolicyStatusOutput
-        attr_accessor policy_status: PolicyStatus
-      end
-      class PolicyStatus
-        attr_accessor is_public: is_public
-      end
-      type is_public = bool
-      class GetBucketReplicationOutput
-        attr_accessor replication_configuration: ReplicationConfiguration
-      end
-      class ReplicationConfiguration
-        attr_accessor role: role
-        attr_accessor rules: replication_rules
-      end
-      class ReplicationRule
-        attr_accessor id: id
-        attr_accessor priority: priority
-        attr_accessor prefix: prefix
-        attr_accessor filter: ReplicationRuleFilter
-        attr_accessor status: replication_rule_status
-        attr_accessor source_selection_criteria: SourceSelectionCriteria
-        attr_accessor existing_object_replication: ExistingObjectReplication
-        attr_accessor destination: Destination
-        attr_accessor delete_marker_replication: DeleteMarkerReplication
-      end
-      class ReplicationRuleFilter
-        attr_accessor prefix: prefix
-        attr_accessor tag: Tag
-        attr_accessor and: ReplicationRuleAndOperator
-      end
-      class ReplicationRuleAndOperator
-        attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
-      end
-      class SourceSelectionCriteria
-        attr_accessor sse_kms_encrypted_objects: SseKmsEncryptedObjects
-        attr_accessor replica_modifications: ReplicaModifications
-      end
-      class SseKmsEncryptedObjects
-        attr_accessor status: sse_kms_encrypted_objects_status
-      end
-      class ReplicaModifications
-        attr_accessor status: replica_modifications_status
-      end
-      class ExistingObjectReplication
-        attr_accessor status: existing_object_replication_status
-      end
+      type deleted_objects = ::Array[DeletedObject]
+      type delimiter = ::String
+      type description = ::String
       class Destination
         attr_accessor bucket: bucket_name
         attr_accessor account: account_id
@@ -895,25 +350,110 @@ module Aws
         attr_accessor replication_time: ReplicationTime
         attr_accessor metrics: Metrics
       end
-      class AccessControlTranslation
-        attr_accessor owner: owner_override
-      end
+      type destination = { bucket: bucket_name, account: account_id?, storage_class: storage_class?, access_control_translation: access_control_translation?, encryption_configuration: encryption_configuration?, replication_time: replication_time?, metrics: metrics? }
+      type display_name = ::String
+      type etag = ::String
+      type email_address = ::String
+      type enable_request_progress = bool
+      type encoding_type = ("url")
+      type encryption = { encryption_type: server_side_encryption, kms_key_id: ssekms_key_id?, kms_context: kms_context? }
       class EncryptionConfiguration
         attr_accessor replica_kms_key_id: replica_kms_key_id
       end
-      class ReplicationTime
-        attr_accessor status: replication_time_status
-        attr_accessor time: ReplicationTimeValue
+      type encryption_configuration = { replica_kms_key_id: replica_kms_key_id? }
+      type end_ = ::Integer
+      class EndEvent
       end
-      class ReplicationTimeValue
-        attr_accessor minutes: minutes
+      class Error
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor code: code
+        attr_accessor message: message
       end
-      class Metrics
-        attr_accessor status: metrics_status
-        attr_accessor event_threshold: ReplicationTimeValue
+      type error_code = ::String
+      class ErrorDocument
+        attr_accessor key: object_key
       end
-      class DeleteMarkerReplication
-        attr_accessor status: delete_marker_replication_status
+      type error_document = { key: object_key }
+      type error_message = ::String
+      type errors = ::Array[Error]
+      type event = ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
+      class EventBridgeConfiguration
+      end
+      type event_bridge_configuration = ::Hash[untyped, untyped]
+      type event_list = ::Array[event]
+      class ExistingObjectReplication
+        attr_accessor status: existing_object_replication_status
+      end
+      type existing_object_replication = { status: existing_object_replication_status }
+      type existing_object_replication_status = ("Enabled" | "Disabled")
+      type expiration = ::String
+      type expiration_status = ("Enabled" | "Disabled")
+      type expired_object_delete_marker = bool
+      type expires = ::Time
+      type expose_header = ::String
+      type expose_headers = ::Array[expose_header]
+      type expression = ::String
+      type expression_type = ("SQL")
+      type fetch_owner = bool
+      type field_delimiter = ::String
+      type file_header_info = ("USE" | "IGNORE" | "NONE")
+      class FilterRule
+        attr_accessor name: filter_rule_name
+        attr_accessor value: filter_rule_value
+      end
+      type filter_rule = { name: filter_rule_name?, value: filter_rule_value? }
+      type filter_rule_list = ::Array[FilterRule]
+      type filter_rule_name = ("prefix" | "suffix")
+      type filter_rule_value = ::String
+      class GetBucketAccelerateConfigurationOutput
+        attr_accessor status: bucket_accelerate_status
+      end
+      class GetBucketAclOutput
+        attr_accessor owner: Owner
+        attr_accessor grants: grants
+      end
+      class GetBucketAnalyticsConfigurationOutput
+        attr_accessor analytics_configuration: AnalyticsConfiguration
+      end
+      class GetBucketCorsOutput
+        attr_accessor cors_rules: cors_rules
+      end
+      class GetBucketEncryptionOutput
+        attr_accessor server_side_encryption_configuration: ServerSideEncryptionConfiguration
+      end
+      class GetBucketIntelligentTieringConfigurationOutput
+        attr_accessor intelligent_tiering_configuration: IntelligentTieringConfiguration
+      end
+      class GetBucketInventoryConfigurationOutput
+        attr_accessor inventory_configuration: InventoryConfiguration
+      end
+      class GetBucketLifecycleConfigurationOutput
+        attr_accessor rules: lifecycle_rules
+      end
+      class GetBucketLifecycleOutput
+        attr_accessor rules: rules
+      end
+      class GetBucketLocationOutput
+        attr_accessor location_constraint: bucket_location_constraint
+      end
+      class GetBucketLoggingOutput
+        attr_accessor logging_enabled: LoggingEnabled
+      end
+      class GetBucketMetricsConfigurationOutput
+        attr_accessor metrics_configuration: MetricsConfiguration
+      end
+      class GetBucketOwnershipControlsOutput
+        attr_accessor ownership_controls: OwnershipControls
+      end
+      class GetBucketPolicyOutput
+        attr_accessor policy: policy
+      end
+      class GetBucketPolicyStatusOutput
+        attr_accessor policy_status: PolicyStatus
+      end
+      class GetBucketReplicationOutput
+        attr_accessor replication_configuration: ReplicationConfiguration
       end
       class GetBucketRequestPaymentOutput
         attr_accessor payer: payer
@@ -925,37 +465,22 @@ module Aws
         attr_accessor status: bucket_versioning_status
         attr_accessor mfa_delete: mfa_delete_status
       end
-      type mfa_delete_status = ("Enabled" | "Disabled")
       class GetBucketWebsiteOutput
         attr_accessor redirect_all_requests_to: RedirectAllRequestsTo
         attr_accessor index_document: IndexDocument
         attr_accessor error_document: ErrorDocument
         attr_accessor routing_rules: routing_rules
       end
-      class RedirectAllRequestsTo
-        attr_accessor host_name: host_name
-        attr_accessor protocol: protocol
+      class GetObjectAclOutput
+        attr_accessor owner: Owner
+        attr_accessor grants: grants
+        attr_accessor request_charged: request_charged
       end
-      class IndexDocument
-        attr_accessor suffix: suffix
+      class GetObjectLegalHoldOutput
+        attr_accessor legal_hold: ObjectLockLegalHold
       end
-      class ErrorDocument
-        attr_accessor key: object_key
-      end
-      class RoutingRule
-        attr_accessor condition: Condition
-        attr_accessor redirect: Redirect
-      end
-      class Condition
-        attr_accessor http_error_code_returned_equals: http_error_code_returned_equals
-        attr_accessor key_prefix_equals: key_prefix_equals
-      end
-      class Redirect
-        attr_accessor host_name: host_name
-        attr_accessor http_redirect_code: http_redirect_code
-        attr_accessor protocol: protocol
-        attr_accessor replace_key_prefix_with: replace_key_prefix_with
-        attr_accessor replace_key_with: replace_key_with
+      class GetObjectLockConfigurationOutput
+        attr_accessor object_lock_configuration: ObjectLockConfiguration
       end
       class GetObjectOutput
         attr_accessor body: body
@@ -991,38 +516,9 @@ module Aws
         attr_accessor object_lock_retain_until_date: object_lock_retain_until_date
         attr_accessor object_lock_legal_hold_status: object_lock_legal_hold_status
       end
-      class GetObjectAclOutput
-        attr_accessor owner: Owner
-        attr_accessor grants: grants
-        attr_accessor request_charged: request_charged
-      end
-      class GetObjectLegalHoldOutput
-        attr_accessor legal_hold: ObjectLockLegalHold
-      end
-      class ObjectLockLegalHold
-        attr_accessor status: object_lock_legal_hold_status
-      end
-      class GetObjectLockConfigurationOutput
-        attr_accessor object_lock_configuration: ObjectLockConfiguration
-      end
-      class ObjectLockConfiguration
-        attr_accessor object_lock_enabled: object_lock_enabled
-        attr_accessor rule: ObjectLockRule
-      end
-      class ObjectLockRule
-        attr_accessor default_retention: DefaultRetention
-      end
-      class DefaultRetention
-        attr_accessor mode: object_lock_retention_mode
-        attr_accessor days: days
-        attr_accessor years: years
-      end
+      type get_object_response_status_code = ::Integer
       class GetObjectRetentionOutput
         attr_accessor retention: ObjectLockRetention
-      end
-      class ObjectLockRetention
-        attr_accessor mode: object_lock_retention_mode
-        attr_accessor retain_until_date: date
       end
       class GetObjectTaggingOutput
         attr_accessor version_id: object_version_id
@@ -1035,12 +531,26 @@ module Aws
       class GetPublicAccessBlockOutput
         attr_accessor public_access_block_configuration: PublicAccessBlockConfiguration
       end
-      class PublicAccessBlockConfiguration
-        attr_accessor block_public_acls: setting
-        attr_accessor ignore_public_acls: setting
-        attr_accessor block_public_policy: setting
-        attr_accessor restrict_public_buckets: setting
+      type glacier_job_parameters = { tier: tier }
+      class Grant
+        attr_accessor grantee: Grantee
+        attr_accessor permission: permission
       end
+      type grant = { grantee: grantee?, permission: permission? }
+      type grant_full_control = ::String
+      type grant_read = ::String
+      type grant_read_acp = ::String
+      type grant_write = ::String
+      type grant_write_acp = ::String
+      class Grantee
+        attr_accessor display_name: display_name
+        attr_accessor email_address: email_address
+        attr_accessor id: id
+        attr_accessor type_: type_
+        attr_accessor uri: uri
+      end
+      type grantee = { display_name: display_name?, email_address: email_address?, id: id?, type: type_, uri: uri? }
+      type grants = ::Array[Grant]
       class HeadObjectOutput
         attr_accessor delete_marker: delete_marker
         attr_accessor accept_ranges: accept_ranges
@@ -1073,47 +583,173 @@ module Aws
         attr_accessor object_lock_retain_until_date: object_lock_retain_until_date
         attr_accessor object_lock_legal_hold_status: object_lock_legal_hold_status
       end
-      type archive_status = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
+      type host_name = ::String
+      type http_error_code_returned_equals = ::String
+      type http_redirect_code = ::String
+      type id = ::String
+      type if_match = ::String
+      type if_modified_since = ::Time
+      type if_none_match = ::String
+      type if_unmodified_since = ::Time
+      class IndexDocument
+        attr_accessor suffix: suffix
+      end
+      type index_document = { suffix: suffix }
+      type initiated = ::Time
+      class Initiator
+        attr_accessor id: id
+        attr_accessor display_name: display_name
+      end
+      type input_serialization = { csv: csv_input?, compression_type: compression_type?, json: json_input?, parquet: parquet_input? }
+      type intelligent_tiering_access_tier = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
+      class IntelligentTieringAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+      end
+      type intelligent_tiering_and_operator = { prefix: prefix?, tags: tag_set? }
+      class IntelligentTieringConfiguration
+        attr_accessor id: intelligent_tiering_id
+        attr_accessor filter: IntelligentTieringFilter
+        attr_accessor status: intelligent_tiering_status
+        attr_accessor tierings: tiering_list
+      end
+      type intelligent_tiering_configuration = { id: intelligent_tiering_id, filter: intelligent_tiering_filter?, status: intelligent_tiering_status, tierings: tiering_list }
+      type intelligent_tiering_configuration_list = ::Array[IntelligentTieringConfiguration]
+      type intelligent_tiering_days = ::Integer
+      class IntelligentTieringFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor and: IntelligentTieringAndOperator
+      end
+      type intelligent_tiering_filter = { prefix: prefix?, tag: tag?, and: intelligent_tiering_and_operator? }
+      type intelligent_tiering_id = ::String
+      type intelligent_tiering_status = ("Enabled" | "Disabled")
+      class InventoryConfiguration
+        attr_accessor destination: InventoryDestination
+        attr_accessor is_enabled: is_enabled
+        attr_accessor filter: InventoryFilter
+        attr_accessor id: inventory_id
+        attr_accessor included_object_versions: inventory_included_object_versions
+        attr_accessor optional_fields: inventory_optional_fields
+        attr_accessor schedule: InventorySchedule
+      end
+      type inventory_configuration = { destination: inventory_destination, is_enabled: is_enabled, filter: inventory_filter?, id: inventory_id, included_object_versions: inventory_included_object_versions, optional_fields: inventory_optional_fields?, schedule: inventory_schedule }
+      type inventory_configuration_list = ::Array[InventoryConfiguration]
+      class InventoryDestination
+        attr_accessor s3_bucket_destination: InventoryS3BucketDestination
+      end
+      type inventory_destination = { s3_bucket_destination: inventory_s3_bucket_destination }
+      class InventoryEncryption
+        attr_accessor sses3: SSES3
+        attr_accessor ssekms: SSEKMS
+      end
+      type inventory_encryption = { sses3: sses3?, ssekms: ssekms? }
+      class InventoryFilter
+        attr_accessor prefix: prefix
+      end
+      type inventory_filter = { prefix: prefix }
+      type inventory_format = ("CSV" | "ORC" | "Parquet")
+      type inventory_frequency = ("Daily" | "Weekly")
+      type inventory_id = ::String
+      type inventory_included_object_versions = ("All" | "Current")
+      type inventory_optional_field = ("Size" | "LastModifiedDate" | "StorageClass" | "ETag" | "IsMultipartUploaded" | "ReplicationStatus" | "EncryptionStatus" | "ObjectLockRetainUntilDate" | "ObjectLockMode" | "ObjectLockLegalHoldStatus" | "IntelligentTieringAccessTier" | "BucketKeyStatus")
+      type inventory_optional_fields = ::Array[inventory_optional_field]
+      class InventoryS3BucketDestination
+        attr_accessor account_id: account_id
+        attr_accessor bucket: bucket_name
+        attr_accessor format: inventory_format
+        attr_accessor prefix: prefix
+        attr_accessor encryption: InventoryEncryption
+      end
+      type inventory_s3_bucket_destination = { account_id: account_id?, bucket: bucket_name, format: inventory_format, prefix: prefix?, encryption: inventory_encryption? }
+      class InventorySchedule
+        attr_accessor frequency: inventory_frequency
+      end
+      type inventory_schedule = { frequency: inventory_frequency }
+      type is_enabled = bool
+      type is_latest = bool
+      type is_public = bool
+      type is_truncated = bool
+      type json_input = { type: json_type? }
+      type json_output = { record_delimiter: record_delimiter? }
+      type json_type = ("DOCUMENT" | "LINES")
+      type kms_context = ::String
+      type key_count = ::Integer
+      type key_marker = ::String
+      type key_prefix_equals = ::String
+      type lambda_function_arn = ::String
+      class LambdaFunctionConfiguration
+        attr_accessor id: notification_id
+        attr_accessor lambda_function_arn: lambda_function_arn
+        attr_accessor events: event_list
+        attr_accessor filter: NotificationConfigurationFilter
+      end
+      type lambda_function_configuration = { id: notification_id?, lambda_function_arn: lambda_function_arn, events: event_list, filter: notification_configuration_filter? }
+      type lambda_function_configuration_list = ::Array[LambdaFunctionConfiguration]
+      type last_modified = ::Time
+      type lifecycle_configuration = { rules: rules }
+      class LifecycleExpiration
+        attr_accessor date: date
+        attr_accessor days: days
+        attr_accessor expired_object_delete_marker: expired_object_delete_marker
+      end
+      type lifecycle_expiration = { date: date?, days: days?, expired_object_delete_marker: expired_object_delete_marker? }
+      class LifecycleRule
+        attr_accessor expiration: LifecycleExpiration
+        attr_accessor id: id
+        attr_accessor prefix: prefix
+        attr_accessor filter: LifecycleRuleFilter
+        attr_accessor status: expiration_status
+        attr_accessor transitions: transition_list
+        attr_accessor noncurrent_version_transitions: noncurrent_version_transition_list
+        attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
+        attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
+      end
+      type lifecycle_rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix?, filter: lifecycle_rule_filter?, status: expiration_status, transitions: transition_list?, noncurrent_version_transitions: noncurrent_version_transition_list?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
+      class LifecycleRuleAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+        attr_accessor object_size_greater_than: object_size_greater_than_bytes
+        attr_accessor object_size_less_than: object_size_less_than_bytes
+      end
+      type lifecycle_rule_and_operator = { prefix: prefix?, tags: tag_set?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes? }
+      class LifecycleRuleFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor object_size_greater_than: object_size_greater_than_bytes
+        attr_accessor object_size_less_than: object_size_less_than_bytes
+        attr_accessor and: LifecycleRuleAndOperator
+      end
+      type lifecycle_rule_filter = { prefix: prefix?, tag: tag?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes?, and: lifecycle_rule_and_operator? }
+      type lifecycle_rules = ::Array[LifecycleRule]
       class ListBucketAnalyticsConfigurationsOutput
         attr_accessor is_truncated: is_truncated
         attr_accessor continuation_token: token
         attr_accessor next_continuation_token: next_token
         attr_accessor analytics_configuration_list: analytics_configuration_list
       end
-      type is_truncated = bool
-      type next_token = ::String
-      type analytics_configuration_list = ::Array[AnalyticsConfiguration]
       class ListBucketIntelligentTieringConfigurationsOutput
         attr_accessor is_truncated: is_truncated
         attr_accessor continuation_token: token
         attr_accessor next_continuation_token: next_token
         attr_accessor intelligent_tiering_configuration_list: intelligent_tiering_configuration_list
       end
-      type intelligent_tiering_configuration_list = ::Array[IntelligentTieringConfiguration]
       class ListBucketInventoryConfigurationsOutput
         attr_accessor continuation_token: token
         attr_accessor inventory_configuration_list: inventory_configuration_list
         attr_accessor is_truncated: is_truncated
         attr_accessor next_continuation_token: next_token
       end
-      type inventory_configuration_list = ::Array[InventoryConfiguration]
       class ListBucketMetricsConfigurationsOutput
         attr_accessor is_truncated: is_truncated
         attr_accessor continuation_token: token
         attr_accessor next_continuation_token: next_token
         attr_accessor metrics_configuration_list: metrics_configuration_list
       end
-      type metrics_configuration_list = ::Array[MetricsConfiguration]
       class ListBucketsOutput
         attr_accessor buckets: buckets
         attr_accessor owner: Owner
       end
-      type buckets = ::Array[Bucket]
-      class Bucket
-        attr_accessor name: bucket_name
-        attr_accessor creation_date: creation_date
-      end
-      type creation_date = ::Time
       class ListMultipartUploadsOutput
         attr_accessor bucket: bucket_name
         attr_accessor key_marker: key_marker
@@ -1127,26 +763,6 @@ module Aws
         attr_accessor uploads: multipart_upload_list
         attr_accessor common_prefixes: common_prefix_list
         attr_accessor encoding_type: encoding_type
-      end
-      type next_key_marker = ::String
-      type next_upload_id_marker = ::String
-      type multipart_upload_list = ::Array[MultipartUpload]
-      class MultipartUpload
-        attr_accessor upload_id: multipart_upload_id
-        attr_accessor key: object_key
-        attr_accessor initiated: initiated
-        attr_accessor storage_class: storage_class
-        attr_accessor owner: Owner
-        attr_accessor initiator: Initiator
-      end
-      type initiated = ::Time
-      class Initiator
-        attr_accessor id: id
-        attr_accessor display_name: display_name
-      end
-      type common_prefix_list = ::Array[CommonPrefix]
-      class CommonPrefix
-        attr_accessor prefix: prefix
       end
       class ListObjectVersionsOutput
         attr_accessor is_truncated: is_truncated
@@ -1163,29 +779,6 @@ module Aws
         attr_accessor common_prefixes: common_prefix_list
         attr_accessor encoding_type: encoding_type
       end
-      type next_version_id_marker = ::String
-      type object_version_list = ::Array[ObjectVersion]
-      class ObjectVersion
-        attr_accessor etag: etag
-        attr_accessor size: size
-        attr_accessor storage_class: object_version_storage_class
-        attr_accessor key: object_key
-        attr_accessor version_id: object_version_id
-        attr_accessor is_latest: is_latest
-        attr_accessor last_modified: last_modified
-        attr_accessor owner: Owner
-      end
-      type size = ::Integer
-      type object_version_storage_class = ("STANDARD")
-      type is_latest = bool
-      type delete_markers = ::Array[DeleteMarkerEntry]
-      class DeleteMarkerEntry
-        attr_accessor owner: Owner
-        attr_accessor key: object_key
-        attr_accessor version_id: object_version_id
-        attr_accessor is_latest: is_latest
-        attr_accessor last_modified: last_modified
-      end
       class ListObjectsOutput
         attr_accessor is_truncated: is_truncated
         attr_accessor marker: marker
@@ -1198,17 +791,6 @@ module Aws
         attr_accessor common_prefixes: common_prefix_list
         attr_accessor encoding_type: encoding_type
       end
-      type next_marker = ::String
-      type object_list = ::Array[Object]
-      class Object
-        attr_accessor key: object_key
-        attr_accessor last_modified: last_modified
-        attr_accessor etag: etag
-        attr_accessor size: size
-        attr_accessor storage_class: object_storage_class
-        attr_accessor owner: Owner
-      end
-      type object_storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
       class ListObjectsV2Output
         attr_accessor is_truncated: is_truncated
         attr_accessor contents: object_list
@@ -1223,7 +805,6 @@ module Aws
         attr_accessor next_continuation_token: next_token
         attr_accessor start_after: start_after
       end
-      type key_count = ::Integer
       class ListPartsOutput
         attr_accessor abort_date: abort_date
         attr_accessor abort_rule_id: abort_rule_id
@@ -1240,13 +821,217 @@ module Aws
         attr_accessor storage_class: storage_class
         attr_accessor request_charged: request_charged
       end
+      type location = ::String
+      type location_prefix = ::String
+      class LoggingEnabled
+        attr_accessor target_bucket: target_bucket
+        attr_accessor target_grants: target_grants
+        attr_accessor target_prefix: target_prefix
+      end
+      type logging_enabled = { target_bucket: target_bucket, target_grants: target_grants?, target_prefix: target_prefix }
+      type mfa = ::String
+      type mfa_delete = ("Enabled" | "Disabled")
+      type mfa_delete_status = ("Enabled" | "Disabled")
+      type marker = ::String
+      type max_age_seconds = ::Integer
+      type max_keys = ::Integer
+      type max_parts = ::Integer
+      type max_uploads = ::Integer
+      type message = ::String
+      type metadata = ::Hash[metadata_key, metadata_value]
+      type metadata_directive = ("COPY" | "REPLACE")
+      type metadata_entry = { name: metadata_key?, value: metadata_value? }
+      type metadata_key = ::String
+      type metadata_value = ::String
+      class Metrics
+        attr_accessor status: metrics_status
+        attr_accessor event_threshold: ReplicationTimeValue
+      end
+      type metrics = { status: metrics_status, event_threshold: replication_time_value? }
+      class MetricsAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+        attr_accessor access_point_arn: access_point_arn
+      end
+      type metrics_and_operator = { prefix: prefix?, tags: tag_set?, access_point_arn: access_point_arn? }
+      class MetricsConfiguration
+        attr_accessor id: metrics_id
+        attr_accessor filter: MetricsFilter
+      end
+      type metrics_configuration = { id: metrics_id, filter: metrics_filter? }
+      type metrics_configuration_list = ::Array[MetricsConfiguration]
+      class MetricsFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor access_point_arn: access_point_arn
+        attr_accessor and: MetricsAndOperator
+      end
+      type metrics_filter = { prefix: prefix?, tag: tag?, access_point_arn: access_point_arn?, and: metrics_and_operator? }
+      type metrics_id = ::String
+      type metrics_status = ("Enabled" | "Disabled")
+      type minutes = ::Integer
+      type missing_meta = ::Integer
+      class MultipartUpload
+        attr_accessor upload_id: multipart_upload_id
+        attr_accessor key: object_key
+        attr_accessor initiated: initiated
+        attr_accessor storage_class: storage_class
+        attr_accessor owner: Owner
+        attr_accessor initiator: Initiator
+      end
+      type multipart_upload_id = ::String
+      type multipart_upload_list = ::Array[MultipartUpload]
+      type next_key_marker = ::String
+      type next_marker = ::String
       type next_part_number_marker = ::Integer
-      type parts = ::Array[Part]
+      type next_token = ::String
+      type next_upload_id_marker = ::String
+      type next_version_id_marker = ::String
+      class NoncurrentVersionExpiration
+        attr_accessor noncurrent_days: days
+        attr_accessor newer_noncurrent_versions: version_count
+      end
+      type noncurrent_version_expiration = { noncurrent_days: days?, newer_noncurrent_versions: version_count? }
+      class NoncurrentVersionTransition
+        attr_accessor noncurrent_days: days
+        attr_accessor storage_class: transition_storage_class
+        attr_accessor newer_noncurrent_versions: version_count
+      end
+      type noncurrent_version_transition = { noncurrent_days: days?, storage_class: transition_storage_class?, newer_noncurrent_versions: version_count? }
+      type noncurrent_version_transition_list = ::Array[NoncurrentVersionTransition]
+      class NotificationConfiguration
+        attr_accessor topic_configurations: topic_configuration_list
+        attr_accessor queue_configurations: queue_configuration_list
+        attr_accessor lambda_function_configurations: lambda_function_configuration_list
+        attr_accessor event_bridge_configuration: EventBridgeConfiguration
+      end
+      type notification_configuration = { topic_configurations: topic_configuration_list?, queue_configurations: queue_configuration_list?, lambda_function_configurations: lambda_function_configuration_list?, event_bridge_configuration: event_bridge_configuration? }
+      class NotificationConfigurationDeprecated
+        attr_accessor topic_configuration: TopicConfigurationDeprecated
+        attr_accessor queue_configuration: QueueConfigurationDeprecated
+        attr_accessor cloud_function_configuration: CloudFunctionConfiguration
+      end
+      type notification_configuration_deprecated = { topic_configuration: topic_configuration_deprecated?, queue_configuration: queue_configuration_deprecated?, cloud_function_configuration: cloud_function_configuration? }
+      class NotificationConfigurationFilter
+        attr_accessor key: S3KeyFilter
+      end
+      type notification_configuration_filter = { key: s3_key_filter? }
+      type notification_id = ::String
+      class Object
+        attr_accessor key: object_key
+        attr_accessor last_modified: last_modified
+        attr_accessor etag: etag
+        attr_accessor size: size
+        attr_accessor storage_class: object_storage_class
+        attr_accessor owner: Owner
+      end
+      type object_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
+      type object_identifier = { key: object_key, version_id: object_version_id? }
+      type object_identifier_list = ::Array[object_identifier]
+      type object_key = ::String
+      type object_list = ::Array[Object]
+      class ObjectLockConfiguration
+        attr_accessor object_lock_enabled: object_lock_enabled
+        attr_accessor rule: ObjectLockRule
+      end
+      type object_lock_configuration = { object_lock_enabled: object_lock_enabled?, rule: object_lock_rule? }
+      type object_lock_enabled = ("Enabled")
+      type object_lock_enabled_for_bucket = bool
+      class ObjectLockLegalHold
+        attr_accessor status: object_lock_legal_hold_status
+      end
+      type object_lock_legal_hold = { status: object_lock_legal_hold_status? }
+      type object_lock_legal_hold_status = ("ON" | "OFF")
+      type object_lock_mode = ("GOVERNANCE" | "COMPLIANCE")
+      type object_lock_retain_until_date = ::Time
+      class ObjectLockRetention
+        attr_accessor mode: object_lock_retention_mode
+        attr_accessor retain_until_date: date
+      end
+      type object_lock_retention = { mode: object_lock_retention_mode?, retain_until_date: date? }
+      type object_lock_retention_mode = ("GOVERNANCE" | "COMPLIANCE")
+      class ObjectLockRule
+        attr_accessor default_retention: DefaultRetention
+      end
+      type object_lock_rule = { default_retention: default_retention? }
+      type object_lock_token = ::String
+      type object_ownership = ("BucketOwnerPreferred" | "ObjectWriter" | "BucketOwnerEnforced")
+      type object_size_greater_than_bytes = ::Integer
+      type object_size_less_than_bytes = ::Integer
+      type object_storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
+      class ObjectVersion
+        attr_accessor etag: etag
+        attr_accessor size: size
+        attr_accessor storage_class: object_version_storage_class
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor is_latest: is_latest
+        attr_accessor last_modified: last_modified
+        attr_accessor owner: Owner
+      end
+      type object_version_id = ::String
+      type object_version_list = ::Array[ObjectVersion]
+      type object_version_storage_class = ("STANDARD")
+      type output_location = { s3: s3_location? }
+      type output_serialization = { csv: csv_output?, json: json_output? }
+      class Owner
+        attr_accessor display_name: display_name
+        attr_accessor id: id
+      end
+      type owner = { display_name: display_name?, id: id? }
+      type owner_override = ("Destination")
+      class OwnershipControls
+        attr_accessor rules: ownership_controls_rules
+      end
+      type ownership_controls = { rules: ownership_controls_rules }
+      class OwnershipControlsRule
+        attr_accessor object_ownership: object_ownership
+      end
+      type ownership_controls_rule = { object_ownership: object_ownership }
+      type ownership_controls_rules = ::Array[OwnershipControlsRule]
+      type parquet_input = ::Hash[untyped, untyped]
       class Part
         attr_accessor part_number: part_number
         attr_accessor last_modified: last_modified
         attr_accessor etag: etag
         attr_accessor size: size
+      end
+      type part_number = ::Integer
+      type part_number_marker = ::Integer
+      type parts = ::Array[Part]
+      type parts_count = ::Integer
+      type payer = ("Requester" | "BucketOwner")
+      type permission = ("FULL_CONTROL" | "WRITE" | "WRITE_ACP" | "READ" | "READ_ACP")
+      type policy = ::String
+      class PolicyStatus
+        attr_accessor is_public: is_public
+      end
+      type prefix = ::String
+      type priority = ::Integer
+      class Progress
+        attr_accessor bytes_scanned: bytes_scanned
+        attr_accessor bytes_processed: bytes_processed
+        attr_accessor bytes_returned: bytes_returned
+      end
+      class ProgressEvent
+        attr_accessor details: Progress
+      end
+      type protocol = ("http" | "https")
+      class PublicAccessBlockConfiguration
+        attr_accessor block_public_acls: setting
+        attr_accessor ignore_public_acls: setting
+        attr_accessor block_public_policy: setting
+        attr_accessor restrict_public_buckets: setting
+      end
+      type public_access_block_configuration = { block_public_acls: setting?, ignore_public_acls: setting?, block_public_policy: setting?, restrict_public_buckets: setting? }
+      class PutObjectAclOutput
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectLegalHoldOutput
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectLockConfigurationOutput
+        attr_accessor request_charged: request_charged
       end
       class PutObjectOutput
         attr_accessor expiration: expiration
@@ -1260,29 +1045,156 @@ module Aws
         attr_accessor bucket_key_enabled: bucket_key_enabled
         attr_accessor request_charged: request_charged
       end
-      class PutObjectAclOutput
-        attr_accessor request_charged: request_charged
-      end
-      class PutObjectLegalHoldOutput
-        attr_accessor request_charged: request_charged
-      end
-      class PutObjectLockConfigurationOutput
-        attr_accessor request_charged: request_charged
-      end
       class PutObjectRetentionOutput
         attr_accessor request_charged: request_charged
       end
       class PutObjectTaggingOutput
         attr_accessor version_id: object_version_id
       end
+      type queue_arn = ::String
+      class QueueConfiguration
+        attr_accessor id: notification_id
+        attr_accessor queue_arn: queue_arn
+        attr_accessor events: event_list
+        attr_accessor filter: NotificationConfigurationFilter
+      end
+      type queue_configuration = { id: notification_id?, queue_arn: queue_arn, events: event_list, filter: notification_configuration_filter? }
+      class QueueConfigurationDeprecated
+        attr_accessor id: notification_id
+        attr_accessor event: event
+        attr_accessor events: event_list
+        attr_accessor queue: queue_arn
+      end
+      type queue_configuration_deprecated = { id: notification_id?, event: event?, events: event_list?, queue: queue_arn? }
+      type queue_configuration_list = ::Array[QueueConfiguration]
+      type quiet = bool
+      type quote_character = ::String
+      type quote_escape_character = ::String
+      type quote_fields = ("ALWAYS" | "ASNEEDED")
+      type range = ::String
+      type record_delimiter = ::String
+      class RecordsEvent
+        attr_accessor payload: body
+      end
+      class Redirect
+        attr_accessor host_name: host_name
+        attr_accessor http_redirect_code: http_redirect_code
+        attr_accessor protocol: protocol
+        attr_accessor replace_key_prefix_with: replace_key_prefix_with
+        attr_accessor replace_key_with: replace_key_with
+      end
+      type redirect = { host_name: host_name?, http_redirect_code: http_redirect_code?, protocol: protocol?, replace_key_prefix_with: replace_key_prefix_with?, replace_key_with: replace_key_with? }
+      class RedirectAllRequestsTo
+        attr_accessor host_name: host_name
+        attr_accessor protocol: protocol
+      end
+      type redirect_all_requests_to = { host_name: host_name, protocol: protocol? }
+      type replace_key_prefix_with = ::String
+      type replace_key_with = ::String
+      type replica_kms_key_id = ::String
+      class ReplicaModifications
+        attr_accessor status: replica_modifications_status
+      end
+      type replica_modifications = { status: replica_modifications_status }
+      type replica_modifications_status = ("Enabled" | "Disabled")
+      class ReplicationConfiguration
+        attr_accessor role: role
+        attr_accessor rules: replication_rules
+      end
+      type replication_configuration = { role: role, rules: replication_rules }
+      class ReplicationRule
+        attr_accessor id: id
+        attr_accessor priority: priority
+        attr_accessor prefix: prefix
+        attr_accessor filter: ReplicationRuleFilter
+        attr_accessor status: replication_rule_status
+        attr_accessor source_selection_criteria: SourceSelectionCriteria
+        attr_accessor existing_object_replication: ExistingObjectReplication
+        attr_accessor destination: Destination
+        attr_accessor delete_marker_replication: DeleteMarkerReplication
+      end
+      type replication_rule = { id: id?, priority: priority?, prefix: prefix?, filter: replication_rule_filter?, status: replication_rule_status, source_selection_criteria: source_selection_criteria?, existing_object_replication: existing_object_replication?, destination: destination, delete_marker_replication: delete_marker_replication? }
+      class ReplicationRuleAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+      end
+      type replication_rule_and_operator = { prefix: prefix?, tags: tag_set? }
+      class ReplicationRuleFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor and: ReplicationRuleAndOperator
+      end
+      type replication_rule_filter = { prefix: prefix?, tag: tag?, and: replication_rule_and_operator? }
+      type replication_rule_status = ("Enabled" | "Disabled")
+      type replication_rules = ::Array[ReplicationRule]
+      type replication_status = ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
+      class ReplicationTime
+        attr_accessor status: replication_time_status
+        attr_accessor time: ReplicationTimeValue
+      end
+      type replication_time = { status: replication_time_status, time: replication_time_value }
+      type replication_time_status = ("Enabled" | "Disabled")
+      class ReplicationTimeValue
+        attr_accessor minutes: minutes
+      end
+      type replication_time_value = { minutes: minutes? }
+      type request_charged = ("requester")
+      type request_payer = ("requester")
+      type request_payment_configuration = { payer: payer }
+      type request_progress = { enabled: enable_request_progress? }
+      type request_route = ::String
+      type request_token = ::String
+      type response_cache_control = ::String
+      type response_content_disposition = ::String
+      type response_content_encoding = ::String
+      type response_content_language = ::String
+      type response_content_type = ::String
+      type response_expires = ::Time
+      type restore = ::String
       class RestoreObjectOutput
         attr_accessor request_charged: request_charged
         attr_accessor restore_output_path: restore_output_path
       end
       type restore_output_path = ::String
-      class SelectObjectContentOutput
-        attr_accessor payload: SelectObjectContentEventStream
+      type restore_request = { days: days?, glacier_job_parameters: glacier_job_parameters?, type: restore_request_type?, tier: tier?, description: description?, select_parameters: select_parameters?, output_location: output_location? }
+      type restore_request_type = ("SELECT")
+      type role = ::String
+      class RoutingRule
+        attr_accessor condition: Condition
+        attr_accessor redirect: Redirect
       end
+      type routing_rule = { condition: condition?, redirect: redirect }
+      type routing_rules = ::Array[RoutingRule]
+      class Rule
+        attr_accessor expiration: LifecycleExpiration
+        attr_accessor id: id
+        attr_accessor prefix: prefix
+        attr_accessor status: expiration_status
+        attr_accessor transition: Transition
+        attr_accessor noncurrent_version_transition: NoncurrentVersionTransition
+        attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
+        attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
+      end
+      type rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix, status: expiration_status, transition: transition?, noncurrent_version_transition: noncurrent_version_transition?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
+      type rules = ::Array[Rule]
+      class S3KeyFilter
+        attr_accessor filter_rules: filter_rule_list
+      end
+      type s3_key_filter = { filter_rules: filter_rule_list? }
+      type s3_location = { bucket_name: bucket_name, prefix: location_prefix, encryption: encryption?, canned_acl: object_canned_acl?, access_control_list: grants?, tagging: tagging?, user_metadata: user_metadata?, storage_class: storage_class? }
+      type sse_customer_algorithm = ::String
+      type sse_customer_key = ::String
+      type sse_customer_key_md5 = ::String
+      class SSEKMS
+        attr_accessor key_id: ssekms_key_id
+      end
+      type ssekms = { key_id: ssekms_key_id }
+      type ssekms_encryption_context = ::String
+      type ssekms_key_id = ::String
+      class SSES3
+      end
+      type sses3 = ::Hash[untyped, untyped]
+      type scan_range = { start: start?, end: end_? }
       class SelectObjectContentEventStream
         attr_accessor records: RecordsEvent
         attr_accessor stats: StatsEvent
@@ -1290,41 +1202,114 @@ module Aws
         attr_accessor cont: ContinuationEvent
         attr_accessor end_: EndEvent
       end
-      class RecordsEvent
-        attr_accessor payload: body
+      class SelectObjectContentOutput
+        attr_accessor payload: SelectObjectContentEventStream
       end
-      class StatsEvent
-        attr_accessor details: Stats
+      type select_parameters = { input_serialization: input_serialization, expression_type: expression_type, expression: expression, output_serialization: output_serialization }
+      type server_side_encryption = ("AES256" | "aws:kms")
+      class ServerSideEncryptionByDefault
+        attr_accessor sse_algorithm: server_side_encryption
+        attr_accessor kms_master_key_id: ssekms_key_id
       end
+      type server_side_encryption_by_default = { sse_algorithm: server_side_encryption, kms_master_key_id: ssekms_key_id? }
+      class ServerSideEncryptionConfiguration
+        attr_accessor rules: server_side_encryption_rules
+      end
+      type server_side_encryption_configuration = { rules: server_side_encryption_rules }
+      class ServerSideEncryptionRule
+        attr_accessor apply_server_side_encryption_by_default: ServerSideEncryptionByDefault
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+      end
+      type server_side_encryption_rule = { apply_server_side_encryption_by_default: server_side_encryption_by_default?, bucket_key_enabled: bucket_key_enabled? }
+      type server_side_encryption_rules = ::Array[ServerSideEncryptionRule]
+      type setting = bool
+      type size = ::Integer
+      type skip_validation = bool
+      class SourceSelectionCriteria
+        attr_accessor sse_kms_encrypted_objects: SseKmsEncryptedObjects
+        attr_accessor replica_modifications: ReplicaModifications
+      end
+      type source_selection_criteria = { sse_kms_encrypted_objects: sse_kms_encrypted_objects?, replica_modifications: replica_modifications? }
+      class SseKmsEncryptedObjects
+        attr_accessor status: sse_kms_encrypted_objects_status
+      end
+      type sse_kms_encrypted_objects = { status: sse_kms_encrypted_objects_status }
+      type sse_kms_encrypted_objects_status = ("Enabled" | "Disabled")
+      type start = ::Integer
+      type start_after = ::String
       class Stats
         attr_accessor bytes_scanned: bytes_scanned
         attr_accessor bytes_processed: bytes_processed
         attr_accessor bytes_returned: bytes_returned
       end
-      type bytes_scanned = ::Integer
-      type bytes_processed = ::Integer
-      type bytes_returned = ::Integer
-      class ProgressEvent
-        attr_accessor details: Progress
+      class StatsEvent
+        attr_accessor details: Stats
       end
-      class Progress
-        attr_accessor bytes_scanned: bytes_scanned
-        attr_accessor bytes_processed: bytes_processed
-        attr_accessor bytes_returned: bytes_returned
+      type storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
+      class StorageClassAnalysis
+        attr_accessor data_export: StorageClassAnalysisDataExport
       end
-      class ContinuationEvent
+      type storage_class_analysis = { data_export: storage_class_analysis_data_export? }
+      class StorageClassAnalysisDataExport
+        attr_accessor output_schema_version: storage_class_analysis_schema_version
+        attr_accessor destination: AnalyticsExportDestination
       end
-      class EndEvent
+      type storage_class_analysis_data_export = { output_schema_version: storage_class_analysis_schema_version, destination: analytics_export_destination }
+      type storage_class_analysis_schema_version = ("V_1")
+      type suffix = ::String
+      class Tag
+        attr_accessor key: object_key
+        attr_accessor value: value
       end
-      class UploadPartOutput
-        attr_accessor server_side_encryption: server_side_encryption
-        attr_accessor etag: etag
-        attr_accessor sse_customer_algorithm: sse_customer_algorithm
-        attr_accessor sse_customer_key_md5: sse_customer_key_md5
-        attr_accessor ssekms_key_id: ssekms_key_id
-        attr_accessor bucket_key_enabled: bucket_key_enabled
-        attr_accessor request_charged: request_charged
+      type tag = { key: object_key, value: value }
+      type tag_count = ::Integer
+      type tag_set = ::Array[Tag]
+      type tagging = { tag_set: tag_set }
+      type tagging_directive = ("COPY" | "REPLACE")
+      type tagging_header = ::String
+      type target_bucket = ::String
+      class TargetGrant
+        attr_accessor grantee: Grantee
+        attr_accessor permission: bucket_logs_permission
       end
+      type target_grant = { grantee: grantee?, permission: bucket_logs_permission? }
+      type target_grants = ::Array[TargetGrant]
+      type target_prefix = ::String
+      type tier = ("Standard" | "Bulk" | "Expedited")
+      class Tiering
+        attr_accessor days: intelligent_tiering_days
+        attr_accessor access_tier: intelligent_tiering_access_tier
+      end
+      type tiering = { days: intelligent_tiering_days, access_tier: intelligent_tiering_access_tier }
+      type tiering_list = ::Array[Tiering]
+      type token = ::String
+      type topic_arn = ::String
+      class TopicConfiguration
+        attr_accessor id: notification_id
+        attr_accessor topic_arn: topic_arn
+        attr_accessor events: event_list
+        attr_accessor filter: NotificationConfigurationFilter
+      end
+      type topic_configuration = { id: notification_id?, topic_arn: topic_arn, events: event_list, filter: notification_configuration_filter? }
+      class TopicConfigurationDeprecated
+        attr_accessor id: notification_id
+        attr_accessor events: event_list
+        attr_accessor event: event
+        attr_accessor topic: topic_arn
+      end
+      type topic_configuration_deprecated = { id: notification_id?, events: event_list?, event: event?, topic: topic_arn? }
+      type topic_configuration_list = ::Array[TopicConfiguration]
+      class Transition
+        attr_accessor date: date
+        attr_accessor days: days
+        attr_accessor storage_class: transition_storage_class
+      end
+      type transition = { date: date?, days: days?, storage_class: transition_storage_class? }
+      type transition_list = ::Array[Transition]
+      type transition_storage_class = ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
+      type type_ = ("CanonicalUser" | "AmazonCustomerByEmail" | "Group")
+      type uri = ::String
+      type upload_id_marker = ::String
       class UploadPartCopyOutput
         attr_accessor copy_source_version_id: copy_source_version_id
         attr_accessor copy_part_result: CopyPartResult
@@ -1335,19 +1320,30 @@ module Aws
         attr_accessor bucket_key_enabled: bucket_key_enabled
         attr_accessor request_charged: request_charged
       end
-      class CopyPartResult
+      class UploadPartOutput
+        attr_accessor server_side_encryption: server_side_encryption
         attr_accessor etag: etag
-        attr_accessor last_modified: last_modified
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
       end
+      type user_metadata = ::Array[metadata_entry]
+      type value = ::String
+      type version_count = ::Integer
+      type version_id_marker = ::String
+      type versioning_configuration = { mfa_delete: mfa_delete?, status: bucket_versioning_status? }
+      type website_configuration = { error_document: error_document?, index_document: index_document?, redirect_all_requests_to: redirect_all_requests_to?, routing_rules: routing_rules? }
+      type website_redirect_location = ::String
+      type years = ::Integer
     end
     module Errors
-      class StorageClass < ::RuntimeError
-      end
-      class IntelligentTieringAccessTier < ::RuntimeError
-      end
       class BucketAlreadyExists < ::RuntimeError
       end
       class BucketAlreadyOwnedByYou < ::RuntimeError
+      end
+      class IntelligentTieringAccessTier < ::RuntimeError
       end
       class InvalidObjectState < ::RuntimeError
         attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
@@ -1362,6 +1358,8 @@ module Aws
       class ObjectAlreadyInActiveTierError < ::RuntimeError
       end
       class ObjectNotInActiveTierError < ::RuntimeError
+      end
+      class StorageClass < ::RuntimeError
       end
     end
   end

--- a/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs
+++ b/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs
@@ -10,9 +10,9 @@ module Aws
     class Client
       def self.new: (?credentials: untyped, ?region: String, ?access_key_id: String?, ?active_endpoint_cache: bool?, ?adaptive_retry_wait_to_fill: bool?, ?client_side_monitoring: bool?, ?client_side_monitoring_client_id: String?, ?client_side_monitoring_host: String?, ?client_side_monitoring_port: Integer?, ?client_side_monitoring_publisher: untyped?, ?compute_checksums: bool?, ?convert_params: bool?, ?correct_clock_skew: bool?, ?defaults_mode: String?, ?disable_host_prefix_injection: bool?, ?endpoint: untyped?, ?endpoint_cache_max_entries: Integer?, ?endpoint_cache_max_threads: Integer?, ?endpoint_cache_poll_interval: Integer?, ?endpoint_discovery: bool?, ?event_stream_handler: Proc?, ?follow_redirects: bool?, ?force_path_style: bool?, ?http_continue_timeout: Integer?, ?http_idle_timeout: Integer?, ?http_open_timeout: Integer?, ?http_proxy: String?, ?http_read_timeout: Integer?, ?http_wire_trace: bool?, ?input_event_stream_handler: Proc?, ?log_formatter: untyped?, ?log_level: Symbol?, ?logger: untyped?, ?max_attempts: Integer?, ?on_chunk_sent: Proc?, ?output_event_stream_handler: Proc?, ?profile: String?, ?raise_response_errors: bool?, ?require_https_for_sse_cpk: bool?, ?retry_backoff: Proc?, ?retry_base_delay: Float?, ?retry_jitter: (:none | :equal | :full | ^(Integer) -> Integer)?, ?retry_limit: Integer?, ?retry_max_delay: Integer?, ?retry_mode: ("legacy" | "standard" | "adaptive")?, ?s3_disable_multiregion_access_points: bool?, ?s3_us_east_1_regional_endpoint: String?, ?s3_use_arn_region: bool?, ?secret_access_key: String?, ?session_token: String?, ?ssl_ca_bundle: String?, ?ssl_ca_directory: String?, ?ssl_ca_store: String?, ?ssl_timeout: Float?, ?ssl_verify_peer: bool?, ?stub_responses: bool?, ?use_accelerate_endpoint: bool?, ?use_dualstack_endpoint: bool?, ?use_fips_endpoint: bool?, ?validate_params: bool?) -> instance
       def abort_multipart_upload: (bucket: Types::bucket_name, key: Types::object_key, upload_id: Types::multipart_upload_id, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::AbortMultipartUploadOutput
-      def complete_multipart_upload: (bucket: Types::bucket_name, key: Types::object_key, ?multipart_upload: Types::CompletedMultipartUpload, upload_id: Types::multipart_upload_id, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::CompleteMultipartUploadOutput
+      def complete_multipart_upload: (bucket: Types::bucket_name, key: Types::object_key, ?multipart_upload: Types::completed_multipart_upload, upload_id: Types::multipart_upload_id, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::CompleteMultipartUploadOutput
       def copy_object: (?acl: Types::object_canned_acl, bucket: Types::bucket_name, ?cache_control: Types::cache_control, ?content_disposition: Types::content_disposition, ?content_encoding: Types::content_encoding, ?content_language: Types::content_language, ?content_type: Types::content_type, copy_source: Types::copy_source, ?copy_source_if_match: Types::copy_source_if_match, ?copy_source_if_modified_since: Types::copy_source_if_modified_since, ?copy_source_if_none_match: Types::copy_source_if_none_match, ?copy_source_if_unmodified_since: Types::copy_source_if_unmodified_since, ?expires: Types::expires, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write_acp: Types::grant_write_acp, key: Types::object_key, ?metadata: Types::metadata, ?metadata_directive: Types::metadata_directive, ?tagging_directive: Types::tagging_directive, ?server_side_encryption: Types::server_side_encryption, ?storage_class: Types::storage_class, ?website_redirect_location: Types::website_redirect_location, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?ssekms_key_id: Types::ssekms_key_id, ?ssekms_encryption_context: Types::ssekms_encryption_context, ?bucket_key_enabled: Types::bucket_key_enabled, ?copy_source_sse_customer_algorithm: Types::copy_source_sse_customer_algorithm, ?copy_source_sse_customer_key: Types::copy_source_sse_customer_key, ?copy_source_sse_customer_key_md5: Types::copy_source_sse_customer_key_md5, ?request_payer: Types::request_payer, ?tagging: Types::tagging_header, ?object_lock_mode: Types::object_lock_mode, ?object_lock_retain_until_date: Types::object_lock_retain_until_date, ?object_lock_legal_hold_status: Types::object_lock_legal_hold_status, ?expected_bucket_owner: Types::account_id, ?expected_source_bucket_owner: Types::account_id) -> Types::CopyObjectOutput
-      def create_bucket: (?acl: Types::bucket_canned_acl, bucket: Types::bucket_name, ?create_bucket_configuration: Types::CreateBucketConfiguration, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write: Types::grant_write, ?grant_write_acp: Types::grant_write_acp, ?object_lock_enabled_for_bucket: Types::object_lock_enabled_for_bucket, ?object_ownership: Types::object_ownership) -> Types::CreateBucketOutput
+      def create_bucket: (?acl: Types::bucket_canned_acl, bucket: Types::bucket_name, ?create_bucket_configuration: Types::create_bucket_configuration, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write: Types::grant_write, ?grant_write_acp: Types::grant_write_acp, ?object_lock_enabled_for_bucket: Types::object_lock_enabled_for_bucket, ?object_ownership: Types::object_ownership) -> Types::CreateBucketOutput
       def create_multipart_upload: (?acl: Types::object_canned_acl, bucket: Types::bucket_name, ?cache_control: Types::cache_control, ?content_disposition: Types::content_disposition, ?content_encoding: Types::content_encoding, ?content_language: Types::content_language, ?content_type: Types::content_type, ?expires: Types::expires, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write_acp: Types::grant_write_acp, key: Types::object_key, ?metadata: Types::metadata, ?server_side_encryption: Types::server_side_encryption, ?storage_class: Types::storage_class, ?website_redirect_location: Types::website_redirect_location, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?ssekms_key_id: Types::ssekms_key_id, ?ssekms_encryption_context: Types::ssekms_encryption_context, ?bucket_key_enabled: Types::bucket_key_enabled, ?request_payer: Types::request_payer, ?tagging: Types::tagging_header, ?object_lock_mode: Types::object_lock_mode, ?object_lock_retain_until_date: Types::object_lock_retain_until_date, ?object_lock_legal_hold_status: Types::object_lock_legal_hold_status, ?expected_bucket_owner: Types::account_id) -> Types::CreateMultipartUploadOutput
       def delete_bucket: (bucket: Types::bucket_name, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
       def delete_bucket_analytics_configuration: (bucket: Types::bucket_name, id: Types::analytics_id, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
@@ -29,7 +29,7 @@ module Aws
       def delete_bucket_website: (bucket: Types::bucket_name, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
       def delete_object: (bucket: Types::bucket_name, key: Types::object_key, ?mfa: Types::mfa, ?version_id: Types::object_version_id, ?request_payer: Types::request_payer, ?bypass_governance_retention: Types::bypass_governance_retention, ?expected_bucket_owner: Types::account_id) -> Types::DeleteObjectOutput
       def delete_object_tagging: (bucket: Types::bucket_name, key: Types::object_key, ?version_id: Types::object_version_id, ?expected_bucket_owner: Types::account_id) -> Types::DeleteObjectTaggingOutput
-      def delete_objects: (bucket: Types::bucket_name, delete: Types::Delete, ?mfa: Types::mfa, ?request_payer: Types::request_payer, ?bypass_governance_retention: Types::bypass_governance_retention, ?expected_bucket_owner: Types::account_id) -> Types::DeleteObjectsOutput
+      def delete_objects: (bucket: Types::bucket_name, delete: Types::delete, ?mfa: Types::mfa, ?request_payer: Types::request_payer, ?bypass_governance_retention: Types::bypass_governance_retention, ?expected_bucket_owner: Types::account_id) -> Types::DeleteObjectsOutput
       def delete_public_access_block: (bucket: Types::bucket_name, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
       def get_bucket_accelerate_configuration: (bucket: Types::bucket_name, ?expected_bucket_owner: Types::account_id) -> Types::GetBucketAccelerateConfigurationOutput
       def get_bucket_acl: (bucket: Types::bucket_name, ?expected_bucket_owner: Types::account_id) -> Types::GetBucketAclOutput
@@ -73,1794 +73,1215 @@ module Aws
       def list_objects: (bucket: Types::bucket_name, ?delimiter: Types::delimiter, ?encoding_type: Types::encoding_type, ?marker: Types::marker, ?max_keys: Types::max_keys, ?prefix: Types::prefix, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::ListObjectsOutput
       def list_objects_v2: (bucket: Types::bucket_name, ?delimiter: Types::delimiter, ?encoding_type: Types::encoding_type, ?max_keys: Types::max_keys, ?prefix: Types::prefix, ?continuation_token: Types::token, ?fetch_owner: Types::fetch_owner, ?start_after: Types::start_after, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::ListObjectsV2Output
       def list_parts: (bucket: Types::bucket_name, key: Types::object_key, ?max_parts: Types::max_parts, ?part_number_marker: Types::part_number_marker, upload_id: Types::multipart_upload_id, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::ListPartsOutput
-      def put_bucket_accelerate_configuration: (bucket: Types::bucket_name, accelerate_configuration: Types::AccelerateConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_acl: (?acl: Types::bucket_canned_acl, ?access_control_policy: Types::AccessControlPolicy, bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write: Types::grant_write, ?grant_write_acp: Types::grant_write_acp, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_analytics_configuration: (bucket: Types::bucket_name, id: Types::analytics_id, analytics_configuration: Types::AnalyticsConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_cors: (bucket: Types::bucket_name, cors_configuration: Types::CORSConfiguration, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_encryption: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, server_side_encryption_configuration: Types::ServerSideEncryptionConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_intelligent_tiering_configuration: (bucket: Types::bucket_name, id: Types::intelligent_tiering_id, intelligent_tiering_configuration: Types::IntelligentTieringConfiguration) -> Aws::EmptyStructure
-      def put_bucket_inventory_configuration: (bucket: Types::bucket_name, id: Types::inventory_id, inventory_configuration: Types::InventoryConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_lifecycle: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?lifecycle_configuration: Types::LifecycleConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_lifecycle_configuration: (bucket: Types::bucket_name, ?lifecycle_configuration: Types::BucketLifecycleConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_logging: (bucket: Types::bucket_name, bucket_logging_status: Types::BucketLoggingStatus, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_metrics_configuration: (bucket: Types::bucket_name, id: Types::metrics_id, metrics_configuration: Types::MetricsConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_notification: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, notification_configuration: Types::NotificationConfigurationDeprecated, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_notification_configuration: (bucket: Types::bucket_name, notification_configuration: Types::NotificationConfiguration, ?expected_bucket_owner: Types::account_id, ?skip_destination_validation: Types::skip_validation) -> Aws::EmptyStructure
-      def put_bucket_ownership_controls: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id, ownership_controls: Types::OwnershipControls) -> Aws::EmptyStructure
+      def put_bucket_accelerate_configuration: (bucket: Types::bucket_name, accelerate_configuration: Types::accelerate_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_acl: (?acl: Types::bucket_canned_acl, ?access_control_policy: Types::access_control_policy, bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write: Types::grant_write, ?grant_write_acp: Types::grant_write_acp, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_analytics_configuration: (bucket: Types::bucket_name, id: Types::analytics_id, analytics_configuration: Types::analytics_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_cors: (bucket: Types::bucket_name, cors_configuration: Types::cors_configuration, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_encryption: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, server_side_encryption_configuration: Types::server_side_encryption_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_intelligent_tiering_configuration: (bucket: Types::bucket_name, id: Types::intelligent_tiering_id, intelligent_tiering_configuration: Types::intelligent_tiering_configuration) -> Aws::EmptyStructure
+      def put_bucket_inventory_configuration: (bucket: Types::bucket_name, id: Types::inventory_id, inventory_configuration: Types::inventory_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_lifecycle: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?lifecycle_configuration: Types::lifecycle_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_lifecycle_configuration: (bucket: Types::bucket_name, ?lifecycle_configuration: Types::bucket_lifecycle_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_logging: (bucket: Types::bucket_name, bucket_logging_status: Types::bucket_logging_status, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_metrics_configuration: (bucket: Types::bucket_name, id: Types::metrics_id, metrics_configuration: Types::metrics_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_notification: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, notification_configuration: Types::notification_configuration_deprecated, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_notification_configuration: (bucket: Types::bucket_name, notification_configuration: Types::notification_configuration, ?expected_bucket_owner: Types::account_id, ?skip_destination_validation: Types::skip_validation) -> Aws::EmptyStructure
+      def put_bucket_ownership_controls: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id, ownership_controls: Types::ownership_controls) -> Aws::EmptyStructure
       def put_bucket_policy: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?confirm_remove_self_bucket_access: Types::confirm_remove_self_bucket_access, policy: Types::policy, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_replication: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, replication_configuration: Types::ReplicationConfiguration, ?token: Types::object_lock_token, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_request_payment: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, request_payment_configuration: Types::RequestPaymentConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_tagging: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, tagging: Types::Tagging, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_versioning: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?mfa: Types::mfa, versioning_configuration: Types::VersioningConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def put_bucket_website: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, website_configuration: Types::WebsiteConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_replication: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, replication_configuration: Types::replication_configuration, ?token: Types::object_lock_token, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_request_payment: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, request_payment_configuration: Types::request_payment_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_tagging: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, tagging: Types::tagging, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_versioning: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?mfa: Types::mfa, versioning_configuration: Types::versioning_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def put_bucket_website: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, website_configuration: Types::website_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
       def put_object: (?acl: Types::object_canned_acl, ?body: Types::body, bucket: Types::bucket_name, ?cache_control: Types::cache_control, ?content_disposition: Types::content_disposition, ?content_encoding: Types::content_encoding, ?content_language: Types::content_language, ?content_length: Types::content_length, ?content_md5: Types::content_md5, ?content_type: Types::content_type, ?expires: Types::expires, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write_acp: Types::grant_write_acp, key: Types::object_key, ?metadata: Types::metadata, ?server_side_encryption: Types::server_side_encryption, ?storage_class: Types::storage_class, ?website_redirect_location: Types::website_redirect_location, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?ssekms_key_id: Types::ssekms_key_id, ?ssekms_encryption_context: Types::ssekms_encryption_context, ?bucket_key_enabled: Types::bucket_key_enabled, ?request_payer: Types::request_payer, ?tagging: Types::tagging_header, ?object_lock_mode: Types::object_lock_mode, ?object_lock_retain_until_date: Types::object_lock_retain_until_date, ?object_lock_legal_hold_status: Types::object_lock_legal_hold_status, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectOutput
-      def put_object_acl: (?acl: Types::object_canned_acl, ?access_control_policy: Types::AccessControlPolicy, bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write: Types::grant_write, ?grant_write_acp: Types::grant_write_acp, key: Types::object_key, ?request_payer: Types::request_payer, ?version_id: Types::object_version_id, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectAclOutput
-      def put_object_legal_hold: (bucket: Types::bucket_name, key: Types::object_key, ?legal_hold: Types::ObjectLockLegalHold, ?request_payer: Types::request_payer, ?version_id: Types::object_version_id, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectLegalHoldOutput
-      def put_object_lock_configuration: (bucket: Types::bucket_name, ?object_lock_configuration: Types::ObjectLockConfiguration, ?request_payer: Types::request_payer, ?token: Types::object_lock_token, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectLockConfigurationOutput
-      def put_object_retention: (bucket: Types::bucket_name, key: Types::object_key, ?retention: Types::ObjectLockRetention, ?request_payer: Types::request_payer, ?version_id: Types::object_version_id, ?bypass_governance_retention: Types::bypass_governance_retention, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectRetentionOutput
-      def put_object_tagging: (bucket: Types::bucket_name, key: Types::object_key, ?version_id: Types::object_version_id, ?content_md5: Types::content_md5, tagging: Types::Tagging, ?expected_bucket_owner: Types::account_id, ?request_payer: Types::request_payer) -> Types::PutObjectTaggingOutput
-      def put_public_access_block: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, public_access_block_configuration: Types::PublicAccessBlockConfiguration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
-      def restore_object: (bucket: Types::bucket_name, key: Types::object_key, ?version_id: Types::object_version_id, ?restore_request: Types::RestoreRequest, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::RestoreObjectOutput
-      def select_object_content: (bucket: Types::bucket_name, key: Types::object_key, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, expression: Types::expression, expression_type: Types::expression_type, ?request_progress: Types::RequestProgress, input_serialization: Types::InputSerialization, output_serialization: Types::OutputSerialization, ?scan_range: Types::ScanRange, ?expected_bucket_owner: Types::account_id) -> Types::SelectObjectContentOutput
+      def put_object_acl: (?acl: Types::object_canned_acl, ?access_control_policy: Types::access_control_policy, bucket: Types::bucket_name, ?content_md5: Types::content_md5, ?grant_full_control: Types::grant_full_control, ?grant_read: Types::grant_read, ?grant_read_acp: Types::grant_read_acp, ?grant_write: Types::grant_write, ?grant_write_acp: Types::grant_write_acp, key: Types::object_key, ?request_payer: Types::request_payer, ?version_id: Types::object_version_id, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectAclOutput
+      def put_object_legal_hold: (bucket: Types::bucket_name, key: Types::object_key, ?legal_hold: Types::object_lock_legal_hold, ?request_payer: Types::request_payer, ?version_id: Types::object_version_id, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectLegalHoldOutput
+      def put_object_lock_configuration: (bucket: Types::bucket_name, ?object_lock_configuration: Types::object_lock_configuration, ?request_payer: Types::request_payer, ?token: Types::object_lock_token, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectLockConfigurationOutput
+      def put_object_retention: (bucket: Types::bucket_name, key: Types::object_key, ?retention: Types::object_lock_retention, ?request_payer: Types::request_payer, ?version_id: Types::object_version_id, ?bypass_governance_retention: Types::bypass_governance_retention, ?content_md5: Types::content_md5, ?expected_bucket_owner: Types::account_id) -> Types::PutObjectRetentionOutput
+      def put_object_tagging: (bucket: Types::bucket_name, key: Types::object_key, ?version_id: Types::object_version_id, ?content_md5: Types::content_md5, tagging: Types::tagging, ?expected_bucket_owner: Types::account_id, ?request_payer: Types::request_payer) -> Types::PutObjectTaggingOutput
+      def put_public_access_block: (bucket: Types::bucket_name, ?content_md5: Types::content_md5, public_access_block_configuration: Types::public_access_block_configuration, ?expected_bucket_owner: Types::account_id) -> Aws::EmptyStructure
+      def restore_object: (bucket: Types::bucket_name, key: Types::object_key, ?version_id: Types::object_version_id, ?restore_request: Types::restore_request, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::RestoreObjectOutput
+      def select_object_content: (bucket: Types::bucket_name, key: Types::object_key, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, expression: Types::expression, expression_type: Types::expression_type, ?request_progress: Types::request_progress, input_serialization: Types::input_serialization, output_serialization: Types::output_serialization, ?scan_range: Types::scan_range, ?expected_bucket_owner: Types::account_id) -> Types::SelectObjectContentOutput
       def upload_part: (?body: Types::body, bucket: Types::bucket_name, ?content_length: Types::content_length, ?content_md5: Types::content_md5, key: Types::object_key, part_number: Types::part_number, upload_id: Types::multipart_upload_id, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id) -> Types::UploadPartOutput
       def upload_part_copy: (bucket: Types::bucket_name, copy_source: Types::copy_source, ?copy_source_if_match: Types::copy_source_if_match, ?copy_source_if_modified_since: Types::copy_source_if_modified_since, ?copy_source_if_none_match: Types::copy_source_if_none_match, ?copy_source_if_unmodified_since: Types::copy_source_if_unmodified_since, ?copy_source_range: Types::copy_source_range, key: Types::object_key, part_number: Types::part_number, upload_id: Types::multipart_upload_id, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?sse_customer_key: Types::sse_customer_key, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?copy_source_sse_customer_algorithm: Types::copy_source_sse_customer_algorithm, ?copy_source_sse_customer_key: Types::copy_source_sse_customer_key, ?copy_source_sse_customer_key_md5: Types::copy_source_sse_customer_key_md5, ?request_payer: Types::request_payer, ?expected_bucket_owner: Types::account_id, ?expected_source_bucket_owner: Types::account_id) -> Types::UploadPartCopyOutput
       def write_get_object_response: (request_route: Types::request_route, request_token: Types::request_token, ?body: Types::body, ?status_code: Types::get_object_response_status_code, ?error_code: Types::error_code, ?error_message: Types::error_message, ?accept_ranges: Types::accept_ranges, ?cache_control: Types::cache_control, ?content_disposition: Types::content_disposition, ?content_encoding: Types::content_encoding, ?content_language: Types::content_language, ?content_length: Types::content_length, ?content_range: Types::content_range, ?content_type: Types::content_type, ?delete_marker: Types::delete_marker, ?etag: Types::etag, ?expires: Types::expires, ?expiration: Types::expiration, ?last_modified: Types::last_modified, ?missing_meta: Types::missing_meta, ?metadata: Types::metadata, ?object_lock_mode: Types::object_lock_mode, ?object_lock_legal_hold_status: Types::object_lock_legal_hold_status, ?object_lock_retain_until_date: Types::object_lock_retain_until_date, ?parts_count: Types::parts_count, ?replication_status: Types::replication_status, ?request_charged: Types::request_charged, ?restore: Types::restore, ?server_side_encryption: Types::server_side_encryption, ?sse_customer_algorithm: Types::sse_customer_algorithm, ?ssekms_key_id: Types::ssekms_key_id, ?sse_customer_key_md5: Types::sse_customer_key_md5, ?storage_class: Types::storage_class, ?tag_count: Types::tag_count, ?version_id: Types::object_version_id, ?bucket_key_enabled: Types::bucket_key_enabled) -> Aws::EmptyStructure
     end
     module Types
-      type abort_date = ::Time
-      class AbortIncompleteMultipartUpload
-        attr_accessor days_after_initiation: ::Integer
-      end
-      class AbortMultipartUploadOutput
-        attr_accessor request_charged: ("requester")
-      end
-      class AbortMultipartUploadRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor upload_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type abort_rule_id = ::String
-      class AccelerateConfiguration
-        attr_accessor status: ("Enabled" | "Suspended")
-      end
-      type accept_ranges = ::String
-      class AccessControlPolicy
-        attr_accessor grants: ::Array[Grant]
-        attr_accessor owner: Owner
-      end
-      class AccessControlTranslation
-        attr_accessor owner: ("Destination")
-      end
-      type access_point_arn = ::String
-      type account_id = ::String
-      type allow_quoted_record_delimiter = bool
-      type allowed_header = ::String
-      type allowed_headers = ::Array[allowed_header]
-      type allowed_method = ::String
-      type allowed_methods = ::Array[allowed_method]
-      type allowed_origin = ::String
-      type allowed_origins = ::Array[allowed_origin]
-      class AnalyticsAndOperator
-        attr_accessor prefix: ::String
-        attr_accessor tags: ::Array[Tag]
-      end
-      class AnalyticsConfiguration
-        attr_accessor id: ::String
-        attr_accessor filter: AnalyticsFilter
-        attr_accessor storage_class_analysis: StorageClassAnalysis
-      end
-      type analytics_configuration_list = ::Array[AnalyticsConfiguration]
-      class AnalyticsExportDestination
-        attr_accessor s3_bucket_destination: AnalyticsS3BucketDestination
-      end
-      class AnalyticsFilter
-        attr_accessor prefix: ::String
-        attr_accessor tag: Tag
-        attr_accessor and: AnalyticsAndOperator
-      end
-      type analytics_id = ::String
-      class AnalyticsS3BucketDestination
-        attr_accessor format: ("CSV")
-        attr_accessor bucket_account_id: ::String
-        attr_accessor bucket: ::String
-        attr_accessor prefix: ::String
-      end
-      type analytics_s3_export_file_format = ("CSV")
-      type archive_status = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
-      type body = ::IO
-      class Bucket
-        attr_accessor name: ::String
-        attr_accessor creation_date: ::Time
-      end
-      type bucket_accelerate_status = ("Enabled" | "Suspended")
-      type bucket_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read")
-      type bucket_key_enabled = bool
-      class BucketLifecycleConfiguration
-        attr_accessor rules: ::Array[LifecycleRule]
-      end
-      type bucket_location_constraint = ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
-      class BucketLoggingStatus
-        attr_accessor logging_enabled: LoggingEnabled
-      end
-      type bucket_logs_permission = ("FULL_CONTROL" | "READ" | "WRITE")
+      # inputs
       type bucket_name = ::String
-      type bucket_versioning_status = ("Enabled" | "Suspended")
-      type buckets = ::Array[Bucket]
-      type bypass_governance_retention = bool
-      type bytes_processed = ::Integer
-      type bytes_returned = ::Integer
-      type bytes_scanned = ::Integer
-      class CORSConfiguration
-        attr_accessor cors_rules: ::Array[CORSRule]
-      end
-      class CORSRule
-        attr_accessor id: ::String
-        attr_accessor allowed_headers: ::Array[allowed_header]
-        attr_accessor allowed_methods: ::Array[allowed_method]
-        attr_accessor allowed_origins: ::Array[allowed_origin]
-        attr_accessor expose_headers: ::Array[expose_header]
-        attr_accessor max_age_seconds: ::Integer
-      end
-      type cors_rules = ::Array[CORSRule]
-      class CSVInput
-        attr_accessor file_header_info: ("USE" | "IGNORE" | "NONE")
-        attr_accessor comments: ::String
-        attr_accessor quote_escape_character: ::String
-        attr_accessor record_delimiter: ::String
-        attr_accessor field_delimiter: ::String
-        attr_accessor quote_character: ::String
-        attr_accessor allow_quoted_record_delimiter: bool
-      end
-      class CSVOutput
-        attr_accessor quote_fields: ("ALWAYS" | "ASNEEDED")
-        attr_accessor quote_escape_character: ::String
-        attr_accessor record_delimiter: ::String
-        attr_accessor field_delimiter: ::String
-        attr_accessor quote_character: ::String
-      end
+      type object_key = ::String
+      type multipart_upload_id = ::String
+      type request_payer = ("requester")
+      type account_id = ::String
+      type request_charged = ("requester")
+      type completed_multipart_upload = { parts: completed_part_list? }
+      type completed_part_list = ::Array[completed_part]
+      type completed_part = { etag: etag?, part_number: part_number? }
+      type etag = ::String
+      type part_number = ::Integer
+      type expiration = ::String
+      type server_side_encryption = ("AES256" | "aws:kms")
+      type object_version_id = ::String
+      type ssekms_key_id = ::String
+      type bucket_key_enabled = bool
+      type object_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
       type cache_control = ::String
-      type cloud_function = ::String
-      class CloudFunctionConfiguration
-        attr_accessor id: ::String
-        attr_accessor event: ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
-        attr_accessor events: ::Array[event]
-        attr_accessor cloud_function: ::String
-        attr_accessor invocation_role: ::String
-      end
-      type cloud_function_invocation_role = ::String
-      type code = ::String
-      type comments = ::String
-      class CommonPrefix
-        attr_accessor prefix: ::String
-      end
-      type common_prefix_list = ::Array[CommonPrefix]
-      class CompleteMultipartUploadOutput
-        attr_accessor location: ::String
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor expiration: ::String
-        attr_accessor etag: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor version_id: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_charged: ("requester")
-      end
-      class CompleteMultipartUploadRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor multipart_upload: CompletedMultipartUpload
-        attr_accessor upload_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class CompletedMultipartUpload
-        attr_accessor parts: ::Array[CompletedPart]
-      end
-      class CompletedPart
-        attr_accessor etag: ::String
-        attr_accessor part_number: ::Integer
-      end
-      type completed_part_list = ::Array[CompletedPart]
-      type compression_type = ("NONE" | "GZIP" | "BZIP2")
-      class Condition
-        attr_accessor http_error_code_returned_equals: ::String
-        attr_accessor key_prefix_equals: ::String
-      end
-      type confirm_remove_self_bucket_access = bool
       type content_disposition = ::String
       type content_encoding = ::String
       type content_language = ::String
-      type content_length = ::Integer
-      type content_md5 = ::String
-      type content_range = ::String
       type content_type = ::String
-      class ContinuationEvent
-      end
-      class CopyObjectOutput
-        attr_accessor copy_object_result: CopyObjectResult
-        attr_accessor expiration: ::String
-        attr_accessor copy_source_version_id: ::String
-        attr_accessor version_id: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor ssekms_encryption_context: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_charged: ("requester")
-      end
-      class CopyObjectRequest
-        attr_accessor acl: ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-        attr_accessor bucket: ::String
-        attr_accessor cache_control: ::String
-        attr_accessor content_disposition: ::String
-        attr_accessor content_encoding: ::String
-        attr_accessor content_language: ::String
-        attr_accessor content_type: ::String
-        attr_accessor copy_source: ::String
-        attr_accessor copy_source_if_match: ::String
-        attr_accessor copy_source_if_modified_since: ::Time
-        attr_accessor copy_source_if_none_match: ::String
-        attr_accessor copy_source_if_unmodified_since: ::Time
-        attr_accessor expires: ::Time
-        attr_accessor grant_full_control: ::String
-        attr_accessor grant_read: ::String
-        attr_accessor grant_read_acp: ::String
-        attr_accessor grant_write_acp: ::String
-        attr_accessor key: ::String
-        attr_accessor metadata: ::Hash[metadata_key, metadata_value]
-        attr_accessor metadata_directive: ("COPY" | "REPLACE")
-        attr_accessor tagging_directive: ("COPY" | "REPLACE")
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor website_redirect_location: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor ssekms_encryption_context: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor copy_source_sse_customer_algorithm: ::String
-        attr_accessor copy_source_sse_customer_key: ::String
-        attr_accessor copy_source_sse_customer_key_md5: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor tagging: ::String
-        attr_accessor object_lock_mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor object_lock_retain_until_date: ::Time
-        attr_accessor object_lock_legal_hold_status: ("ON" | "OFF")
-        attr_accessor expected_bucket_owner: ::String
-        attr_accessor expected_source_bucket_owner: ::String
-      end
-      class CopyObjectResult
-        attr_accessor etag: ::String
-        attr_accessor last_modified: ::Time
-      end
-      class CopyPartResult
-        attr_accessor etag: ::String
-        attr_accessor last_modified: ::Time
-      end
       type copy_source = ::String
       type copy_source_if_match = ::String
       type copy_source_if_modified_since = ::Time
       type copy_source_if_none_match = ::String
       type copy_source_if_unmodified_since = ::Time
-      type copy_source_range = ::String
-      type copy_source_sse_customer_algorithm = ::String
-      type copy_source_sse_customer_key = ::String
-      type copy_source_sse_customer_key_md5 = ::String
-      type copy_source_version_id = ::String
-      class CreateBucketConfiguration
-        attr_accessor location_constraint: ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
-      end
-      class CreateBucketOutput
-        attr_accessor location: ::String
-      end
-      class CreateBucketRequest
-        attr_accessor acl: ("private" | "public-read" | "public-read-write" | "authenticated-read")
-        attr_accessor bucket: ::String
-        attr_accessor create_bucket_configuration: CreateBucketConfiguration
-        attr_accessor grant_full_control: ::String
-        attr_accessor grant_read: ::String
-        attr_accessor grant_read_acp: ::String
-        attr_accessor grant_write: ::String
-        attr_accessor grant_write_acp: ::String
-        attr_accessor object_lock_enabled_for_bucket: bool
-        attr_accessor object_ownership: ("BucketOwnerPreferred" | "ObjectWriter" | "BucketOwnerEnforced")
-      end
-      class CreateMultipartUploadOutput
-        attr_accessor abort_date: ::Time
-        attr_accessor abort_rule_id: ::String
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor upload_id: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor ssekms_encryption_context: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_charged: ("requester")
-      end
-      class CreateMultipartUploadRequest
-        attr_accessor acl: ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-        attr_accessor bucket: ::String
-        attr_accessor cache_control: ::String
-        attr_accessor content_disposition: ::String
-        attr_accessor content_encoding: ::String
-        attr_accessor content_language: ::String
-        attr_accessor content_type: ::String
-        attr_accessor expires: ::Time
-        attr_accessor grant_full_control: ::String
-        attr_accessor grant_read: ::String
-        attr_accessor grant_read_acp: ::String
-        attr_accessor grant_write_acp: ::String
-        attr_accessor key: ::String
-        attr_accessor metadata: ::Hash[metadata_key, metadata_value]
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor website_redirect_location: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor ssekms_encryption_context: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_payer: ("requester")
-        attr_accessor tagging: ::String
-        attr_accessor object_lock_mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor object_lock_retain_until_date: ::Time
-        attr_accessor object_lock_legal_hold_status: ("ON" | "OFF")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type creation_date = ::Time
-      type date = ::Time
-      type days = ::Integer
-      type days_after_initiation = ::Integer
-      class DefaultRetention
-        attr_accessor mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor days: ::Integer
-        attr_accessor years: ::Integer
-      end
-      class Delete
-        attr_accessor objects: ::Array[ObjectIdentifier]
-        attr_accessor quiet: bool
-      end
-      class DeleteBucketAnalyticsConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketCorsRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketEncryptionRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketIntelligentTieringConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-      end
-      class DeleteBucketInventoryConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketLifecycleRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketMetricsConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketOwnershipControlsRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketPolicyRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketReplicationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketTaggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteBucketWebsiteRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type delete_marker = bool
-      class DeleteMarkerEntry
-        attr_accessor owner: Owner
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor is_latest: bool
-        attr_accessor last_modified: ::Time
-      end
-      class DeleteMarkerReplication
-        attr_accessor status: ("Enabled" | "Disabled")
-      end
-      type delete_marker_replication_status = ("Enabled" | "Disabled")
-      type delete_marker_version_id = ::String
-      type delete_markers = ::Array[DeleteMarkerEntry]
-      class DeleteObjectOutput
-        attr_accessor delete_marker: bool
-        attr_accessor version_id: ::String
-        attr_accessor request_charged: ("requester")
-      end
-      class DeleteObjectRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor mfa: ::String
-        attr_accessor version_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor bypass_governance_retention: bool
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteObjectTaggingOutput
-        attr_accessor version_id: ::String
-      end
-      class DeleteObjectTaggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeleteObjectsOutput
-        attr_accessor deleted: ::Array[DeletedObject]
-        attr_accessor request_charged: ("requester")
-        attr_accessor errors: ::Array[Error]
-      end
-      class DeleteObjectsRequest
-        attr_accessor bucket: ::String
-        attr_accessor delete: Delete
-        attr_accessor mfa: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor bypass_governance_retention: bool
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeletePublicAccessBlockRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class DeletedObject
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor delete_marker: bool
-        attr_accessor delete_marker_version_id: ::String
-      end
-      type deleted_objects = ::Array[DeletedObject]
-      type delimiter = ::String
-      type description = ::String
-      class Destination
-        attr_accessor bucket: ::String
-        attr_accessor account: ::String
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor access_control_translation: AccessControlTranslation
-        attr_accessor encryption_configuration: EncryptionConfiguration
-        attr_accessor replication_time: ReplicationTime
-        attr_accessor metrics: Metrics
-      end
-      type display_name = ::String
-      type etag = ::String
-      type email_address = ::String
-      type enable_request_progress = bool
-      type encoding_type = ("url")
-      class Encryption
-        attr_accessor encryption_type: ("AES256" | "aws:kms")
-        attr_accessor kms_key_id: ::String
-        attr_accessor kms_context: ::String
-      end
-      class EncryptionConfiguration
-        attr_accessor replica_kms_key_id: ::String
-      end
-      type end_ = ::Integer
-      class EndEvent
-      end
-      class Error
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor code: ::String
-        attr_accessor message: ::String
-      end
-      type error_code = ::String
-      class ErrorDocument
-        attr_accessor key: ::String
-      end
-      type error_message = ::String
-      type errors = ::Array[Error]
-      type event = ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
-      class EventBridgeConfiguration
-      end
-      type event_list = ::Array[event]
-      class ExistingObjectReplication
-        attr_accessor status: ("Enabled" | "Disabled")
-      end
-      type existing_object_replication_status = ("Enabled" | "Disabled")
-      type expiration = ::String
-      type expiration_status = ("Enabled" | "Disabled")
-      type expired_object_delete_marker = bool
       type expires = ::Time
-      type expose_header = ::String
-      type expose_headers = ::Array[expose_header]
-      type expression = ::String
-      type expression_type = ("SQL")
-      type fetch_owner = bool
-      type field_delimiter = ::String
-      type file_header_info = ("USE" | "IGNORE" | "NONE")
-      class FilterRule
-        attr_accessor name: ("prefix" | "suffix")
-        attr_accessor value: ::String
-      end
-      type filter_rule_list = ::Array[FilterRule]
-      type filter_rule_name = ("prefix" | "suffix")
-      type filter_rule_value = ::String
-      class GetBucketAccelerateConfigurationOutput
-        attr_accessor status: ("Enabled" | "Suspended")
-      end
-      class GetBucketAccelerateConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketAclOutput
-        attr_accessor owner: Owner
-        attr_accessor grants: ::Array[Grant]
-      end
-      class GetBucketAclRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketAnalyticsConfigurationOutput
-        attr_accessor analytics_configuration: AnalyticsConfiguration
-      end
-      class GetBucketAnalyticsConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketCorsOutput
-        attr_accessor cors_rules: ::Array[CORSRule]
-      end
-      class GetBucketCorsRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketEncryptionOutput
-        attr_accessor server_side_encryption_configuration: ServerSideEncryptionConfiguration
-      end
-      class GetBucketEncryptionRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketIntelligentTieringConfigurationOutput
-        attr_accessor intelligent_tiering_configuration: IntelligentTieringConfiguration
-      end
-      class GetBucketIntelligentTieringConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-      end
-      class GetBucketInventoryConfigurationOutput
-        attr_accessor inventory_configuration: InventoryConfiguration
-      end
-      class GetBucketInventoryConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketLifecycleConfigurationOutput
-        attr_accessor rules: ::Array[LifecycleRule]
-      end
-      class GetBucketLifecycleConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketLifecycleOutput
-        attr_accessor rules: ::Array[Rule]
-      end
-      class GetBucketLifecycleRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketLocationOutput
-        attr_accessor location_constraint: ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
-      end
-      class GetBucketLocationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketLoggingOutput
-        attr_accessor logging_enabled: LoggingEnabled
-      end
-      class GetBucketLoggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketMetricsConfigurationOutput
-        attr_accessor metrics_configuration: MetricsConfiguration
-      end
-      class GetBucketMetricsConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketNotificationConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketOwnershipControlsOutput
-        attr_accessor ownership_controls: OwnershipControls
-      end
-      class GetBucketOwnershipControlsRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketPolicyOutput
-        attr_accessor policy: ::String
-      end
-      class GetBucketPolicyRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketPolicyStatusOutput
-        attr_accessor policy_status: PolicyStatus
-      end
-      class GetBucketPolicyStatusRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketReplicationOutput
-        attr_accessor replication_configuration: ReplicationConfiguration
-      end
-      class GetBucketReplicationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketRequestPaymentOutput
-        attr_accessor payer: ("Requester" | "BucketOwner")
-      end
-      class GetBucketRequestPaymentRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketTaggingOutput
-        attr_accessor tag_set: ::Array[Tag]
-      end
-      class GetBucketTaggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketVersioningOutput
-        attr_accessor status: ("Enabled" | "Suspended")
-        attr_accessor mfa_delete: ("Enabled" | "Disabled")
-      end
-      class GetBucketVersioningRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetBucketWebsiteOutput
-        attr_accessor redirect_all_requests_to: RedirectAllRequestsTo
-        attr_accessor index_document: IndexDocument
-        attr_accessor error_document: ErrorDocument
-        attr_accessor routing_rules: ::Array[RoutingRule]
-      end
-      class GetBucketWebsiteRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetObjectAclOutput
-        attr_accessor owner: Owner
-        attr_accessor grants: ::Array[Grant]
-        attr_accessor request_charged: ("requester")
-      end
-      class GetObjectAclRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetObjectLegalHoldOutput
-        attr_accessor legal_hold: ObjectLockLegalHold
-      end
-      class GetObjectLegalHoldRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetObjectLockConfigurationOutput
-        attr_accessor object_lock_configuration: ObjectLockConfiguration
-      end
-      class GetObjectLockConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetObjectOutput
-        attr_accessor body: ::IO
-        attr_accessor delete_marker: bool
-        attr_accessor accept_ranges: ::String
-        attr_accessor expiration: ::String
-        attr_accessor restore: ::String
-        attr_accessor last_modified: ::Time
-        attr_accessor content_length: ::Integer
-        attr_accessor etag: ::String
-        attr_accessor missing_meta: ::Integer
-        attr_accessor version_id: ::String
-        attr_accessor cache_control: ::String
-        attr_accessor content_disposition: ::String
-        attr_accessor content_encoding: ::String
-        attr_accessor content_language: ::String
-        attr_accessor content_range: ::String
-        attr_accessor content_type: ::String
-        attr_accessor expires: ::Time
-        attr_accessor website_redirect_location: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor metadata: ::Hash[metadata_key, metadata_value]
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor request_charged: ("requester")
-        attr_accessor replication_status: ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
-        attr_accessor parts_count: ::Integer
-        attr_accessor tag_count: ::Integer
-        attr_accessor object_lock_mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor object_lock_retain_until_date: ::Time
-        attr_accessor object_lock_legal_hold_status: ("ON" | "OFF")
-      end
-      class GetObjectRequest
-        attr_accessor bucket: ::String
-        attr_accessor if_match: ::String
-        attr_accessor if_modified_since: ::Time
-        attr_accessor if_none_match: ::String
-        attr_accessor if_unmodified_since: ::Time
-        attr_accessor key: ::String
-        attr_accessor range: ::String
-        attr_accessor response_cache_control: ::String
-        attr_accessor response_content_disposition: ::String
-        attr_accessor response_content_encoding: ::String
-        attr_accessor response_content_language: ::String
-        attr_accessor response_content_type: ::String
-        attr_accessor response_expires: ::Time
-        attr_accessor version_id: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor part_number: ::Integer
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type get_object_response_status_code = ::Integer
-      class GetObjectRetentionOutput
-        attr_accessor retention: ObjectLockRetention
-      end
-      class GetObjectRetentionRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetObjectTaggingOutput
-        attr_accessor version_id: ::String
-        attr_accessor tag_set: ::Array[Tag]
-      end
-      class GetObjectTaggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor expected_bucket_owner: ::String
-        attr_accessor request_payer: ("requester")
-      end
-      class GetObjectTorrentOutput
-        attr_accessor body: ::IO
-        attr_accessor request_charged: ("requester")
-      end
-      class GetObjectTorrentRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GetPublicAccessBlockOutput
-        attr_accessor public_access_block_configuration: PublicAccessBlockConfiguration
-      end
-      class GetPublicAccessBlockRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class GlacierJobParameters
-        attr_accessor tier: ("Standard" | "Bulk" | "Expedited")
-      end
-      class Grant
-        attr_accessor grantee: Grantee
-        attr_accessor permission: ("FULL_CONTROL" | "WRITE" | "WRITE_ACP" | "READ" | "READ_ACP")
-      end
       type grant_full_control = ::String
       type grant_read = ::String
       type grant_read_acp = ::String
-      type grant_write = ::String
       type grant_write_acp = ::String
-      class Grantee
-        attr_accessor display_name: ::String
-        attr_accessor email_address: ::String
-        attr_accessor id: ::String
-        attr_accessor type_: ("CanonicalUser" | "AmazonCustomerByEmail" | "Group")
-        attr_accessor uri: ::String
-      end
-      type grants = ::Array[Grant]
-      class HeadBucketRequest
-        attr_accessor bucket: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class HeadObjectOutput
-        attr_accessor delete_marker: bool
-        attr_accessor accept_ranges: ::String
-        attr_accessor expiration: ::String
-        attr_accessor restore: ::String
-        attr_accessor archive_status: ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
-        attr_accessor last_modified: ::Time
-        attr_accessor content_length: ::Integer
-        attr_accessor etag: ::String
-        attr_accessor missing_meta: ::Integer
-        attr_accessor version_id: ::String
-        attr_accessor cache_control: ::String
-        attr_accessor content_disposition: ::String
-        attr_accessor content_encoding: ::String
-        attr_accessor content_language: ::String
-        attr_accessor content_type: ::String
-        attr_accessor expires: ::Time
-        attr_accessor website_redirect_location: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor metadata: ::Hash[metadata_key, metadata_value]
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor request_charged: ("requester")
-        attr_accessor replication_status: ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
-        attr_accessor parts_count: ::Integer
-        attr_accessor object_lock_mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor object_lock_retain_until_date: ::Time
-        attr_accessor object_lock_legal_hold_status: ("ON" | "OFF")
-      end
-      class HeadObjectRequest
-        attr_accessor bucket: ::String
-        attr_accessor if_match: ::String
-        attr_accessor if_modified_since: ::Time
-        attr_accessor if_none_match: ::String
-        attr_accessor if_unmodified_since: ::Time
-        attr_accessor key: ::String
-        attr_accessor range: ::String
-        attr_accessor version_id: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor part_number: ::Integer
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type host_name = ::String
-      type http_error_code_returned_equals = ::String
-      type http_redirect_code = ::String
+      type metadata = ::Hash[metadata_key, metadata_value]
+      type metadata_key = ::String
+      type metadata_value = ::String
+      type metadata_directive = ("COPY" | "REPLACE")
+      type tagging_directive = ("COPY" | "REPLACE")
+      type storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
+      type website_redirect_location = ::String
+      type sse_customer_algorithm = ::String
+      type sse_customer_key = ::String
+      type sse_customer_key_md5 = ::String
+      type ssekms_encryption_context = ::String
+      type copy_source_sse_customer_algorithm = ::String
+      type copy_source_sse_customer_key = ::String
+      type copy_source_sse_customer_key_md5 = ::String
+      type tagging_header = ::String
+      type object_lock_mode = ("GOVERNANCE" | "COMPLIANCE")
+      type object_lock_retain_until_date = ::Time
+      type object_lock_legal_hold_status = ("ON" | "OFF")
+      type last_modified = ::Time
+      type bucket_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read")
+      type create_bucket_configuration = { location_constraint: bucket_location_constraint? }
+      type bucket_location_constraint = ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
+      type grant_write = ::String
+      type object_lock_enabled_for_bucket = bool
+      type object_ownership = ("BucketOwnerPreferred" | "ObjectWriter" | "BucketOwnerEnforced")
+      type analytics_id = ::String
+      type intelligent_tiering_id = ::String
+      type inventory_id = ::String
+      type metrics_id = ::String
+      type mfa = ::String
+      type bypass_governance_retention = bool
+      type delete_marker = bool
+      type delete = { objects: object_identifier_list, quiet: quiet? }
+      type object_identifier_list = ::Array[object_identifier]
+      type object_identifier = { key: object_key, version_id: object_version_id? }
+      type quiet = bool
+      type bucket_accelerate_status = ("Enabled" | "Suspended")
+      type owner = { display_name: display_name?, id: id? }
+      type display_name = ::String
       type id = ::String
+      type grants = ::Array[grant]
+      type grant = { grantee: grantee?, permission: permission? }
+      type grantee = { display_name: display_name?, email_address: email_address?, id: id?, type: type_, uri: uri? }
+      type email_address = ::String
+      type type_ = ("CanonicalUser" | "AmazonCustomerByEmail" | "Group")
+      type uri = ::String
+      type permission = ("FULL_CONTROL" | "WRITE" | "WRITE_ACP" | "READ" | "READ_ACP")
+      type analytics_configuration = { id: analytics_id, filter: analytics_filter?, storage_class_analysis: storage_class_analysis }
+      type analytics_filter = { prefix: prefix?, tag: tag?, and: analytics_and_operator? }
+      type prefix = ::String
+      type tag = { key: object_key, value: value }
+      type value = ::String
+      type analytics_and_operator = { prefix: prefix?, tags: tag_set? }
+      type tag_set = ::Array[tag]
+      type storage_class_analysis = { data_export: storage_class_analysis_data_export? }
+      type storage_class_analysis_data_export = { output_schema_version: storage_class_analysis_schema_version, destination: analytics_export_destination }
+      type storage_class_analysis_schema_version = ("V_1")
+      type analytics_export_destination = { s3_bucket_destination: analytics_s3_bucket_destination }
+      type analytics_s3_bucket_destination = { format: analytics_s3_export_file_format, bucket_account_id: account_id?, bucket: bucket_name, prefix: prefix? }
+      type analytics_s3_export_file_format = ("CSV")
+      type cors_rules = ::Array[cors_rule]
+      type cors_rule = { id: id?, allowed_headers: allowed_headers?, allowed_methods: allowed_methods, allowed_origins: allowed_origins, expose_headers: expose_headers?, max_age_seconds: max_age_seconds? }
+      type allowed_headers = ::Array[allowed_header]
+      type allowed_header = ::String
+      type allowed_methods = ::Array[allowed_method]
+      type allowed_method = ::String
+      type allowed_origins = ::Array[allowed_origin]
+      type allowed_origin = ::String
+      type expose_headers = ::Array[expose_header]
+      type expose_header = ::String
+      type max_age_seconds = ::Integer
+      type server_side_encryption_configuration = { rules: server_side_encryption_rules }
+      type server_side_encryption_rules = ::Array[server_side_encryption_rule]
+      type server_side_encryption_rule = { apply_server_side_encryption_by_default: server_side_encryption_by_default?, bucket_key_enabled: bucket_key_enabled? }
+      type server_side_encryption_by_default = { sse_algorithm: server_side_encryption, kms_master_key_id: ssekms_key_id? }
+      type intelligent_tiering_configuration = { id: intelligent_tiering_id, filter: intelligent_tiering_filter?, status: intelligent_tiering_status, tierings: tiering_list }
+      type intelligent_tiering_filter = { prefix: prefix?, tag: tag?, and: intelligent_tiering_and_operator? }
+      type intelligent_tiering_and_operator = { prefix: prefix?, tags: tag_set? }
+      type intelligent_tiering_status = ("Enabled" | "Disabled")
+      type tiering_list = ::Array[tiering]
+      type tiering = { days: intelligent_tiering_days, access_tier: intelligent_tiering_access_tier }
+      type intelligent_tiering_days = ::Integer
+      type intelligent_tiering_access_tier = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
+      type inventory_configuration = { destination: inventory_destination, is_enabled: is_enabled, filter: inventory_filter?, id: inventory_id, included_object_versions: inventory_included_object_versions, optional_fields: inventory_optional_fields?, schedule: inventory_schedule }
+      type inventory_destination = { s3_bucket_destination: inventory_s3_bucket_destination }
+      type inventory_s3_bucket_destination = { account_id: account_id?, bucket: bucket_name, format: inventory_format, prefix: prefix?, encryption: inventory_encryption? }
+      type inventory_format = ("CSV" | "ORC" | "Parquet")
+      type inventory_encryption = { sses3: sses3?, ssekms: ssekms? }
+      type sses3 = ::Hash[untyped, untyped]
+      type ssekms = { key_id: ssekms_key_id }
+      type is_enabled = bool
+      type inventory_filter = { prefix: prefix }
+      type inventory_included_object_versions = ("All" | "Current")
+      type inventory_optional_fields = ::Array[inventory_optional_field]
+      type inventory_optional_field = ("Size" | "LastModifiedDate" | "StorageClass" | "ETag" | "IsMultipartUploaded" | "ReplicationStatus" | "EncryptionStatus" | "ObjectLockRetainUntilDate" | "ObjectLockMode" | "ObjectLockLegalHoldStatus" | "IntelligentTieringAccessTier" | "BucketKeyStatus")
+      type inventory_schedule = { frequency: inventory_frequency }
+      type inventory_frequency = ("Daily" | "Weekly")
+      type rules = ::Array[rule]
+      type rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix, status: expiration_status, transition: transition?, noncurrent_version_transition: noncurrent_version_transition?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
+      type lifecycle_expiration = { date: date?, days: days?, expired_object_delete_marker: expired_object_delete_marker? }
+      type date = ::Time
+      type days = ::Integer
+      type expired_object_delete_marker = bool
+      type expiration_status = ("Enabled" | "Disabled")
+      type transition = { date: date?, days: days?, storage_class: transition_storage_class? }
+      type transition_storage_class = ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
+      type noncurrent_version_transition = { noncurrent_days: days?, storage_class: transition_storage_class?, newer_noncurrent_versions: version_count? }
+      type version_count = ::Integer
+      type noncurrent_version_expiration = { noncurrent_days: days?, newer_noncurrent_versions: version_count? }
+      type abort_incomplete_multipart_upload = { days_after_initiation: days_after_initiation? }
+      type days_after_initiation = ::Integer
+      type lifecycle_rules = ::Array[lifecycle_rule]
+      type lifecycle_rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix?, filter: lifecycle_rule_filter?, status: expiration_status, transitions: transition_list?, noncurrent_version_transitions: noncurrent_version_transition_list?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
+      type lifecycle_rule_filter = { prefix: prefix?, tag: tag?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes?, and: lifecycle_rule_and_operator? }
+      type object_size_greater_than_bytes = ::Integer
+      type object_size_less_than_bytes = ::Integer
+      type lifecycle_rule_and_operator = { prefix: prefix?, tags: tag_set?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes? }
+      type transition_list = ::Array[transition]
+      type noncurrent_version_transition_list = ::Array[noncurrent_version_transition]
+      type logging_enabled = { target_bucket: target_bucket, target_grants: target_grants?, target_prefix: target_prefix }
+      type target_bucket = ::String
+      type target_grants = ::Array[target_grant]
+      type target_grant = { grantee: grantee?, permission: bucket_logs_permission? }
+      type bucket_logs_permission = ("FULL_CONTROL" | "READ" | "WRITE")
+      type target_prefix = ::String
+      type metrics_configuration = { id: metrics_id, filter: metrics_filter? }
+      type metrics_filter = { prefix: prefix?, tag: tag?, access_point_arn: access_point_arn?, and: metrics_and_operator? }
+      type access_point_arn = ::String
+      type metrics_and_operator = { prefix: prefix?, tags: tag_set?, access_point_arn: access_point_arn? }
+      type notification_configuration_deprecated = { topic_configuration: topic_configuration_deprecated?, queue_configuration: queue_configuration_deprecated?, cloud_function_configuration: cloud_function_configuration? }
+      type topic_configuration_deprecated = { id: notification_id?, events: event_list?, event: event?, topic: topic_arn? }
+      type notification_id = ::String
+      type event_list = ::Array[event]
+      type event = ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
+      type topic_arn = ::String
+      type queue_configuration_deprecated = { id: notification_id?, event: event?, events: event_list?, queue: queue_arn? }
+      type queue_arn = ::String
+      type cloud_function_configuration = { id: notification_id?, event: event?, events: event_list?, cloud_function: cloud_function?, invocation_role: cloud_function_invocation_role? }
+      type cloud_function = ::String
+      type cloud_function_invocation_role = ::String
+      type notification_configuration = { topic_configurations: topic_configuration_list?, queue_configurations: queue_configuration_list?, lambda_function_configurations: lambda_function_configuration_list?, event_bridge_configuration: event_bridge_configuration? }
+      type topic_configuration_list = ::Array[topic_configuration]
+      type topic_configuration = { id: notification_id?, topic_arn: topic_arn, events: event_list, filter: notification_configuration_filter? }
+      type notification_configuration_filter = { key: s3_key_filter? }
+      type s3_key_filter = { filter_rules: filter_rule_list? }
+      type filter_rule_list = ::Array[filter_rule]
+      type filter_rule = { name: filter_rule_name?, value: filter_rule_value? }
+      type filter_rule_name = ("prefix" | "suffix")
+      type filter_rule_value = ::String
+      type queue_configuration_list = ::Array[queue_configuration]
+      type queue_configuration = { id: notification_id?, queue_arn: queue_arn, events: event_list, filter: notification_configuration_filter? }
+      type lambda_function_configuration_list = ::Array[lambda_function_configuration]
+      type lambda_function_configuration = { id: notification_id?, lambda_function_arn: lambda_function_arn, events: event_list, filter: notification_configuration_filter? }
+      type lambda_function_arn = ::String
+      type event_bridge_configuration = ::Hash[untyped, untyped]
+      type ownership_controls = { rules: ownership_controls_rules }
+      type ownership_controls_rules = ::Array[ownership_controls_rule]
+      type ownership_controls_rule = { object_ownership: object_ownership }
+      type policy = ::String
+      type replication_configuration = { role: role, rules: replication_rules }
+      type role = ::String
+      type replication_rules = ::Array[replication_rule]
+      type replication_rule = { id: id?, priority: priority?, prefix: prefix?, filter: replication_rule_filter?, status: replication_rule_status, source_selection_criteria: source_selection_criteria?, existing_object_replication: existing_object_replication?, destination: destination, delete_marker_replication: delete_marker_replication? }
+      type priority = ::Integer
+      type replication_rule_filter = { prefix: prefix?, tag: tag?, and: replication_rule_and_operator? }
+      type replication_rule_and_operator = { prefix: prefix?, tags: tag_set? }
+      type replication_rule_status = ("Enabled" | "Disabled")
+      type source_selection_criteria = { sse_kms_encrypted_objects: sse_kms_encrypted_objects?, replica_modifications: replica_modifications? }
+      type sse_kms_encrypted_objects = { status: sse_kms_encrypted_objects_status }
+      type sse_kms_encrypted_objects_status = ("Enabled" | "Disabled")
+      type replica_modifications = { status: replica_modifications_status }
+      type replica_modifications_status = ("Enabled" | "Disabled")
+      type existing_object_replication = { status: existing_object_replication_status }
+      type existing_object_replication_status = ("Enabled" | "Disabled")
+      type destination = { bucket: bucket_name, account: account_id?, storage_class: storage_class?, access_control_translation: access_control_translation?, encryption_configuration: encryption_configuration?, replication_time: replication_time?, metrics: metrics? }
+      type access_control_translation = { owner: owner_override }
+      type owner_override = ("Destination")
+      type encryption_configuration = { replica_kms_key_id: replica_kms_key_id? }
+      type replica_kms_key_id = ::String
+      type replication_time = { status: replication_time_status, time: replication_time_value }
+      type replication_time_status = ("Enabled" | "Disabled")
+      type replication_time_value = { minutes: minutes? }
+      type minutes = ::Integer
+      type metrics = { status: metrics_status, event_threshold: replication_time_value? }
+      type metrics_status = ("Enabled" | "Disabled")
+      type delete_marker_replication = { status: delete_marker_replication_status? }
+      type delete_marker_replication_status = ("Enabled" | "Disabled")
+      type payer = ("Requester" | "BucketOwner")
+      type bucket_versioning_status = ("Enabled" | "Suspended")
+      type redirect_all_requests_to = { host_name: host_name, protocol: protocol? }
+      type host_name = ::String
+      type protocol = ("http" | "https")
+      type index_document = { suffix: suffix }
+      type suffix = ::String
+      type error_document = { key: object_key }
+      type routing_rules = ::Array[routing_rule]
+      type routing_rule = { condition: condition?, redirect: redirect }
+      type condition = { http_error_code_returned_equals: http_error_code_returned_equals?, key_prefix_equals: key_prefix_equals? }
+      type http_error_code_returned_equals = ::String
+      type key_prefix_equals = ::String
+      type redirect = { host_name: host_name?, http_redirect_code: http_redirect_code?, protocol: protocol?, replace_key_prefix_with: replace_key_prefix_with?, replace_key_with: replace_key_with? }
+      type http_redirect_code = ::String
+      type replace_key_prefix_with = ::String
+      type replace_key_with = ::String
       type if_match = ::String
       type if_modified_since = ::Time
       type if_none_match = ::String
       type if_unmodified_since = ::Time
-      class IndexDocument
-        attr_accessor suffix: ::String
-      end
-      type initiated = ::Time
-      class Initiator
-        attr_accessor id: ::String
-        attr_accessor display_name: ::String
-      end
-      class InputSerialization
-        attr_accessor csv: CSVInput
-        attr_accessor compression_type: ("NONE" | "GZIP" | "BZIP2")
-        attr_accessor json: JSONInput
-        attr_accessor parquet: ParquetInput
-      end
-      type intelligent_tiering_access_tier = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
-      class IntelligentTieringAndOperator
-        attr_accessor prefix: ::String
-        attr_accessor tags: ::Array[Tag]
-      end
-      class IntelligentTieringConfiguration
-        attr_accessor id: ::String
-        attr_accessor filter: IntelligentTieringFilter
-        attr_accessor status: ("Enabled" | "Disabled")
-        attr_accessor tierings: ::Array[Tiering]
-      end
-      type intelligent_tiering_configuration_list = ::Array[IntelligentTieringConfiguration]
-      type intelligent_tiering_days = ::Integer
-      class IntelligentTieringFilter
-        attr_accessor prefix: ::String
-        attr_accessor tag: Tag
-        attr_accessor and: IntelligentTieringAndOperator
-      end
-      type intelligent_tiering_id = ::String
-      type intelligent_tiering_status = ("Enabled" | "Disabled")
-      class InventoryConfiguration
-        attr_accessor destination: InventoryDestination
-        attr_accessor is_enabled: bool
-        attr_accessor filter: InventoryFilter
-        attr_accessor id: ::String
-        attr_accessor included_object_versions: ("All" | "Current")
-        attr_accessor optional_fields: ::Array[inventory_optional_field]
-        attr_accessor schedule: InventorySchedule
-      end
-      type inventory_configuration_list = ::Array[InventoryConfiguration]
-      class InventoryDestination
-        attr_accessor s3_bucket_destination: InventoryS3BucketDestination
-      end
-      class InventoryEncryption
-        attr_accessor sses3: SSES3
-        attr_accessor ssekms: SSEKMS
-      end
-      class InventoryFilter
-        attr_accessor prefix: ::String
-      end
-      type inventory_format = ("CSV" | "ORC" | "Parquet")
-      type inventory_frequency = ("Daily" | "Weekly")
-      type inventory_id = ::String
-      type inventory_included_object_versions = ("All" | "Current")
-      type inventory_optional_field = ("Size" | "LastModifiedDate" | "StorageClass" | "ETag" | "IsMultipartUploaded" | "ReplicationStatus" | "EncryptionStatus" | "ObjectLockRetainUntilDate" | "ObjectLockMode" | "ObjectLockLegalHoldStatus" | "IntelligentTieringAccessTier" | "BucketKeyStatus")
-      type inventory_optional_fields = ::Array[inventory_optional_field]
-      class InventoryS3BucketDestination
-        attr_accessor account_id: ::String
-        attr_accessor bucket: ::String
-        attr_accessor format: ("CSV" | "ORC" | "Parquet")
-        attr_accessor prefix: ::String
-        attr_accessor encryption: InventoryEncryption
-      end
-      class InventorySchedule
-        attr_accessor frequency: ("Daily" | "Weekly")
-      end
-      type is_enabled = bool
-      type is_latest = bool
-      type is_public = bool
-      type is_truncated = bool
-      class JSONInput
-        attr_accessor type_: ("DOCUMENT" | "LINES")
-      end
-      class JSONOutput
-        attr_accessor record_delimiter: ::String
-      end
-      type json_type = ("DOCUMENT" | "LINES")
-      type kms_context = ::String
-      type key_count = ::Integer
-      type key_marker = ::String
-      type key_prefix_equals = ::String
-      type lambda_function_arn = ::String
-      class LambdaFunctionConfiguration
-        attr_accessor id: ::String
-        attr_accessor lambda_function_arn: ::String
-        attr_accessor events: ::Array[event]
-        attr_accessor filter: NotificationConfigurationFilter
-      end
-      type lambda_function_configuration_list = ::Array[LambdaFunctionConfiguration]
-      type last_modified = ::Time
-      class LifecycleConfiguration
-        attr_accessor rules: ::Array[Rule]
-      end
-      class LifecycleExpiration
-        attr_accessor date: ::Time
-        attr_accessor days: ::Integer
-        attr_accessor expired_object_delete_marker: bool
-      end
-      class LifecycleRule
-        attr_accessor expiration: LifecycleExpiration
-        attr_accessor id: ::String
-        attr_accessor prefix: ::String
-        attr_accessor filter: LifecycleRuleFilter
-        attr_accessor status: ("Enabled" | "Disabled")
-        attr_accessor transitions: ::Array[Transition]
-        attr_accessor noncurrent_version_transitions: ::Array[NoncurrentVersionTransition]
-        attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
-        attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
-      end
-      class LifecycleRuleAndOperator
-        attr_accessor prefix: ::String
-        attr_accessor tags: ::Array[Tag]
-        attr_accessor object_size_greater_than: ::Integer
-        attr_accessor object_size_less_than: ::Integer
-      end
-      class LifecycleRuleFilter
-        attr_accessor prefix: ::String
-        attr_accessor tag: Tag
-        attr_accessor object_size_greater_than: ::Integer
-        attr_accessor object_size_less_than: ::Integer
-        attr_accessor and: LifecycleRuleAndOperator
-      end
-      type lifecycle_rules = ::Array[LifecycleRule]
-      class ListBucketAnalyticsConfigurationsOutput
-        attr_accessor is_truncated: bool
-        attr_accessor continuation_token: ::String
-        attr_accessor next_continuation_token: ::String
-        attr_accessor analytics_configuration_list: ::Array[AnalyticsConfiguration]
-      end
-      class ListBucketAnalyticsConfigurationsRequest
-        attr_accessor bucket: ::String
-        attr_accessor continuation_token: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListBucketIntelligentTieringConfigurationsOutput
-        attr_accessor is_truncated: bool
-        attr_accessor continuation_token: ::String
-        attr_accessor next_continuation_token: ::String
-        attr_accessor intelligent_tiering_configuration_list: ::Array[IntelligentTieringConfiguration]
-      end
-      class ListBucketIntelligentTieringConfigurationsRequest
-        attr_accessor bucket: ::String
-        attr_accessor continuation_token: ::String
-      end
-      class ListBucketInventoryConfigurationsOutput
-        attr_accessor continuation_token: ::String
-        attr_accessor inventory_configuration_list: ::Array[InventoryConfiguration]
-        attr_accessor is_truncated: bool
-        attr_accessor next_continuation_token: ::String
-      end
-      class ListBucketInventoryConfigurationsRequest
-        attr_accessor bucket: ::String
-        attr_accessor continuation_token: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListBucketMetricsConfigurationsOutput
-        attr_accessor is_truncated: bool
-        attr_accessor continuation_token: ::String
-        attr_accessor next_continuation_token: ::String
-        attr_accessor metrics_configuration_list: ::Array[MetricsConfiguration]
-      end
-      class ListBucketMetricsConfigurationsRequest
-        attr_accessor bucket: ::String
-        attr_accessor continuation_token: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListBucketsOutput
-        attr_accessor buckets: ::Array[Bucket]
-        attr_accessor owner: Owner
-      end
-      class ListMultipartUploadsOutput
-        attr_accessor bucket: ::String
-        attr_accessor key_marker: ::String
-        attr_accessor upload_id_marker: ::String
-        attr_accessor next_key_marker: ::String
-        attr_accessor prefix: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor next_upload_id_marker: ::String
-        attr_accessor max_uploads: ::Integer
-        attr_accessor is_truncated: bool
-        attr_accessor uploads: ::Array[MultipartUpload]
-        attr_accessor common_prefixes: ::Array[CommonPrefix]
-        attr_accessor encoding_type: ("url")
-      end
-      class ListMultipartUploadsRequest
-        attr_accessor bucket: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor encoding_type: ("url")
-        attr_accessor key_marker: ::String
-        attr_accessor max_uploads: ::Integer
-        attr_accessor prefix: ::String
-        attr_accessor upload_id_marker: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListObjectVersionsOutput
-        attr_accessor is_truncated: bool
-        attr_accessor key_marker: ::String
-        attr_accessor version_id_marker: ::String
-        attr_accessor next_key_marker: ::String
-        attr_accessor next_version_id_marker: ::String
-        attr_accessor versions: ::Array[ObjectVersion]
-        attr_accessor delete_markers: ::Array[DeleteMarkerEntry]
-        attr_accessor name: ::String
-        attr_accessor prefix: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor max_keys: ::Integer
-        attr_accessor common_prefixes: ::Array[CommonPrefix]
-        attr_accessor encoding_type: ("url")
-      end
-      class ListObjectVersionsRequest
-        attr_accessor bucket: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor encoding_type: ("url")
-        attr_accessor key_marker: ::String
-        attr_accessor max_keys: ::Integer
-        attr_accessor prefix: ::String
-        attr_accessor version_id_marker: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListObjectsOutput
-        attr_accessor is_truncated: bool
-        attr_accessor marker: ::String
-        attr_accessor next_marker: ::String
-        attr_accessor contents: ::Array[Object]
-        attr_accessor name: ::String
-        attr_accessor prefix: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor max_keys: ::Integer
-        attr_accessor common_prefixes: ::Array[CommonPrefix]
-        attr_accessor encoding_type: ("url")
-      end
-      class ListObjectsRequest
-        attr_accessor bucket: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor encoding_type: ("url")
-        attr_accessor marker: ::String
-        attr_accessor max_keys: ::Integer
-        attr_accessor prefix: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListObjectsV2Output
-        attr_accessor is_truncated: bool
-        attr_accessor contents: ::Array[Object]
-        attr_accessor name: ::String
-        attr_accessor prefix: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor max_keys: ::Integer
-        attr_accessor common_prefixes: ::Array[CommonPrefix]
-        attr_accessor encoding_type: ("url")
-        attr_accessor key_count: ::Integer
-        attr_accessor continuation_token: ::String
-        attr_accessor next_continuation_token: ::String
-        attr_accessor start_after: ::String
-      end
-      class ListObjectsV2Request
-        attr_accessor bucket: ::String
-        attr_accessor delimiter: ::String
-        attr_accessor encoding_type: ("url")
-        attr_accessor max_keys: ::Integer
-        attr_accessor prefix: ::String
-        attr_accessor continuation_token: ::String
-        attr_accessor fetch_owner: bool
-        attr_accessor start_after: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class ListPartsOutput
-        attr_accessor abort_date: ::Time
-        attr_accessor abort_rule_id: ::String
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor upload_id: ::String
-        attr_accessor part_number_marker: ::Integer
-        attr_accessor next_part_number_marker: ::Integer
-        attr_accessor max_parts: ::Integer
-        attr_accessor is_truncated: bool
-        attr_accessor parts: ::Array[Part]
-        attr_accessor initiator: Initiator
-        attr_accessor owner: Owner
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor request_charged: ("requester")
-      end
-      class ListPartsRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor max_parts: ::Integer
-        attr_accessor part_number_marker: ::Integer
-        attr_accessor upload_id: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type location = ::String
-      type location_prefix = ::String
-      class LoggingEnabled
-        attr_accessor target_bucket: ::String
-        attr_accessor target_grants: ::Array[TargetGrant]
-        attr_accessor target_prefix: ::String
-      end
-      type mfa = ::String
-      type mfa_delete = ("Enabled" | "Disabled")
-      type mfa_delete_status = ("Enabled" | "Disabled")
-      type marker = ::String
-      type max_age_seconds = ::Integer
-      type max_keys = ::Integer
-      type max_parts = ::Integer
-      type max_uploads = ::Integer
-      type message = ::String
-      type metadata = ::Hash[metadata_key, metadata_value]
-      type metadata_directive = ("COPY" | "REPLACE")
-      class MetadataEntry
-        attr_accessor name: ::String
-        attr_accessor value: ::String
-      end
-      type metadata_key = ::String
-      type metadata_value = ::String
-      class Metrics
-        attr_accessor status: ("Enabled" | "Disabled")
-        attr_accessor event_threshold: ReplicationTimeValue
-      end
-      class MetricsAndOperator
-        attr_accessor prefix: ::String
-        attr_accessor tags: ::Array[Tag]
-        attr_accessor access_point_arn: ::String
-      end
-      class MetricsConfiguration
-        attr_accessor id: ::String
-        attr_accessor filter: MetricsFilter
-      end
-      type metrics_configuration_list = ::Array[MetricsConfiguration]
-      class MetricsFilter
-        attr_accessor prefix: ::String
-        attr_accessor tag: Tag
-        attr_accessor access_point_arn: ::String
-        attr_accessor and: MetricsAndOperator
-      end
-      type metrics_id = ::String
-      type metrics_status = ("Enabled" | "Disabled")
-      type minutes = ::Integer
-      type missing_meta = ::Integer
-      class MultipartUpload
-        attr_accessor upload_id: ::String
-        attr_accessor key: ::String
-        attr_accessor initiated: ::Time
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor owner: Owner
-        attr_accessor initiator: Initiator
-      end
-      type multipart_upload_id = ::String
-      type multipart_upload_list = ::Array[MultipartUpload]
-      type next_key_marker = ::String
-      type next_marker = ::String
-      type next_part_number_marker = ::Integer
-      type next_token = ::String
-      type next_upload_id_marker = ::String
-      type next_version_id_marker = ::String
-      class NoncurrentVersionExpiration
-        attr_accessor noncurrent_days: ::Integer
-        attr_accessor newer_noncurrent_versions: ::Integer
-      end
-      class NoncurrentVersionTransition
-        attr_accessor noncurrent_days: ::Integer
-        attr_accessor storage_class: ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
-        attr_accessor newer_noncurrent_versions: ::Integer
-      end
-      type noncurrent_version_transition_list = ::Array[NoncurrentVersionTransition]
-      class NotificationConfiguration
-        attr_accessor topic_configurations: ::Array[TopicConfiguration]
-        attr_accessor queue_configurations: ::Array[QueueConfiguration]
-        attr_accessor lambda_function_configurations: ::Array[LambdaFunctionConfiguration]
-        attr_accessor event_bridge_configuration: EventBridgeConfiguration
-      end
-      class NotificationConfigurationDeprecated
-        attr_accessor topic_configuration: TopicConfigurationDeprecated
-        attr_accessor queue_configuration: QueueConfigurationDeprecated
-        attr_accessor cloud_function_configuration: CloudFunctionConfiguration
-      end
-      class NotificationConfigurationFilter
-        attr_accessor key: S3KeyFilter
-      end
-      type notification_id = ::String
-      class Object
-        attr_accessor key: ::String
-        attr_accessor last_modified: ::Time
-        attr_accessor etag: ::String
-        attr_accessor size: ::Integer
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor owner: Owner
-      end
-      type object_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-      class ObjectIdentifier
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-      end
-      type object_identifier_list = ::Array[ObjectIdentifier]
-      type object_key = ::String
-      type object_list = ::Array[Object]
-      class ObjectLockConfiguration
-        attr_accessor object_lock_enabled: ("Enabled")
-        attr_accessor rule: ObjectLockRule
-      end
-      type object_lock_enabled = ("Enabled")
-      type object_lock_enabled_for_bucket = bool
-      class ObjectLockLegalHold
-        attr_accessor status: ("ON" | "OFF")
-      end
-      type object_lock_legal_hold_status = ("ON" | "OFF")
-      type object_lock_mode = ("GOVERNANCE" | "COMPLIANCE")
-      type object_lock_retain_until_date = ::Time
-      class ObjectLockRetention
-        attr_accessor mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor retain_until_date: ::Time
-      end
-      type object_lock_retention_mode = ("GOVERNANCE" | "COMPLIANCE")
-      class ObjectLockRule
-        attr_accessor default_retention: DefaultRetention
-      end
-      type object_lock_token = ::String
-      type object_ownership = ("BucketOwnerPreferred" | "ObjectWriter" | "BucketOwnerEnforced")
-      type object_size_greater_than_bytes = ::Integer
-      type object_size_less_than_bytes = ::Integer
-      type object_storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-      class ObjectVersion
-        attr_accessor etag: ::String
-        attr_accessor size: ::Integer
-        attr_accessor storage_class: ("STANDARD")
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor is_latest: bool
-        attr_accessor last_modified: ::Time
-        attr_accessor owner: Owner
-      end
-      type object_version_id = ::String
-      type object_version_list = ::Array[ObjectVersion]
-      type object_version_storage_class = ("STANDARD")
-      class OutputLocation
-        attr_accessor s3: S3Location
-      end
-      class OutputSerialization
-        attr_accessor csv: CSVOutput
-        attr_accessor json: JSONOutput
-      end
-      class Owner
-        attr_accessor display_name: ::String
-        attr_accessor id: ::String
-      end
-      type owner_override = ("Destination")
-      class OwnershipControls
-        attr_accessor rules: ::Array[OwnershipControlsRule]
-      end
-      class OwnershipControlsRule
-        attr_accessor object_ownership: ("BucketOwnerPreferred" | "ObjectWriter" | "BucketOwnerEnforced")
-      end
-      type ownership_controls_rules = ::Array[OwnershipControlsRule]
-      class ParquetInput
-      end
-      class Part
-        attr_accessor part_number: ::Integer
-        attr_accessor last_modified: ::Time
-        attr_accessor etag: ::String
-        attr_accessor size: ::Integer
-      end
-      type part_number = ::Integer
-      type part_number_marker = ::Integer
-      type parts = ::Array[Part]
-      type parts_count = ::Integer
-      type payer = ("Requester" | "BucketOwner")
-      type permission = ("FULL_CONTROL" | "WRITE" | "WRITE_ACP" | "READ" | "READ_ACP")
-      type policy = ::String
-      class PolicyStatus
-        attr_accessor is_public: bool
-      end
-      type prefix = ::String
-      type priority = ::Integer
-      class Progress
-        attr_accessor bytes_scanned: ::Integer
-        attr_accessor bytes_processed: ::Integer
-        attr_accessor bytes_returned: ::Integer
-      end
-      class ProgressEvent
-        attr_accessor details: Progress
-      end
-      type protocol = ("http" | "https")
-      class PublicAccessBlockConfiguration
-        attr_accessor block_public_acls: bool
-        attr_accessor ignore_public_acls: bool
-        attr_accessor block_public_policy: bool
-        attr_accessor restrict_public_buckets: bool
-      end
-      class PutBucketAccelerateConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor accelerate_configuration: AccelerateConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketAclRequest
-        attr_accessor acl: ("private" | "public-read" | "public-read-write" | "authenticated-read")
-        attr_accessor access_control_policy: AccessControlPolicy
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor grant_full_control: ::String
-        attr_accessor grant_read: ::String
-        attr_accessor grant_read_acp: ::String
-        attr_accessor grant_write: ::String
-        attr_accessor grant_write_acp: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketAnalyticsConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor analytics_configuration: AnalyticsConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketCorsRequest
-        attr_accessor bucket: ::String
-        attr_accessor cors_configuration: CORSConfiguration
-        attr_accessor content_md5: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketEncryptionRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor server_side_encryption_configuration: ServerSideEncryptionConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketIntelligentTieringConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor intelligent_tiering_configuration: IntelligentTieringConfiguration
-      end
-      class PutBucketInventoryConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor inventory_configuration: InventoryConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketLifecycleConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor lifecycle_configuration: BucketLifecycleConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketLifecycleRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor lifecycle_configuration: LifecycleConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketLoggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor bucket_logging_status: BucketLoggingStatus
-        attr_accessor content_md5: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketMetricsConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor id: ::String
-        attr_accessor metrics_configuration: MetricsConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketNotificationConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor notification_configuration: NotificationConfiguration
-        attr_accessor expected_bucket_owner: ::String
-        attr_accessor skip_destination_validation: bool
-      end
-      class PutBucketNotificationRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor notification_configuration: NotificationConfigurationDeprecated
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketOwnershipControlsRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor expected_bucket_owner: ::String
-        attr_accessor ownership_controls: OwnershipControls
-      end
-      class PutBucketPolicyRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor confirm_remove_self_bucket_access: bool
-        attr_accessor policy: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketReplicationRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor replication_configuration: ReplicationConfiguration
-        attr_accessor token: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketRequestPaymentRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor request_payment_configuration: RequestPaymentConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketTaggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor tagging: Tagging
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketVersioningRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor mfa: ::String
-        attr_accessor versioning_configuration: VersioningConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutBucketWebsiteRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor website_configuration: WebsiteConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutObjectAclOutput
-        attr_accessor request_charged: ("requester")
-      end
-      class PutObjectAclRequest
-        attr_accessor acl: ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-        attr_accessor access_control_policy: AccessControlPolicy
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor grant_full_control: ::String
-        attr_accessor grant_read: ::String
-        attr_accessor grant_read_acp: ::String
-        attr_accessor grant_write: ::String
-        attr_accessor grant_write_acp: ::String
-        attr_accessor key: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor version_id: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutObjectLegalHoldOutput
-        attr_accessor request_charged: ("requester")
-      end
-      class PutObjectLegalHoldRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor legal_hold: ObjectLockLegalHold
-        attr_accessor request_payer: ("requester")
-        attr_accessor version_id: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutObjectLockConfigurationOutput
-        attr_accessor request_charged: ("requester")
-      end
-      class PutObjectLockConfigurationRequest
-        attr_accessor bucket: ::String
-        attr_accessor object_lock_configuration: ObjectLockConfiguration
-        attr_accessor request_payer: ("requester")
-        attr_accessor token: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutObjectOutput
-        attr_accessor expiration: ::String
-        attr_accessor etag: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor version_id: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor ssekms_encryption_context: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_charged: ("requester")
-      end
-      class PutObjectRequest
-        attr_accessor acl: ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-        attr_accessor body: ::IO
-        attr_accessor bucket: ::String
-        attr_accessor cache_control: ::String
-        attr_accessor content_disposition: ::String
-        attr_accessor content_encoding: ::String
-        attr_accessor content_language: ::String
-        attr_accessor content_length: ::Integer
-        attr_accessor content_md5: ::String
-        attr_accessor content_type: ::String
-        attr_accessor expires: ::Time
-        attr_accessor grant_full_control: ::String
-        attr_accessor grant_read: ::String
-        attr_accessor grant_read_acp: ::String
-        attr_accessor grant_write_acp: ::String
-        attr_accessor key: ::String
-        attr_accessor metadata: ::Hash[metadata_key, metadata_value]
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor website_redirect_location: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor ssekms_encryption_context: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_payer: ("requester")
-        attr_accessor tagging: ::String
-        attr_accessor object_lock_mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor object_lock_retain_until_date: ::Time
-        attr_accessor object_lock_legal_hold_status: ("ON" | "OFF")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutObjectRetentionOutput
-        attr_accessor request_charged: ("requester")
-      end
-      class PutObjectRetentionRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor retention: ObjectLockRetention
-        attr_accessor request_payer: ("requester")
-        attr_accessor version_id: ::String
-        attr_accessor bypass_governance_retention: bool
-        attr_accessor content_md5: ::String
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class PutObjectTaggingOutput
-        attr_accessor version_id: ::String
-      end
-      class PutObjectTaggingRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor tagging: Tagging
-        attr_accessor expected_bucket_owner: ::String
-        attr_accessor request_payer: ("requester")
-      end
-      class PutPublicAccessBlockRequest
-        attr_accessor bucket: ::String
-        attr_accessor content_md5: ::String
-        attr_accessor public_access_block_configuration: PublicAccessBlockConfiguration
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type queue_arn = ::String
-      class QueueConfiguration
-        attr_accessor id: ::String
-        attr_accessor queue_arn: ::String
-        attr_accessor events: ::Array[event]
-        attr_accessor filter: NotificationConfigurationFilter
-      end
-      class QueueConfigurationDeprecated
-        attr_accessor id: ::String
-        attr_accessor event: ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
-        attr_accessor events: ::Array[event]
-        attr_accessor queue: ::String
-      end
-      type queue_configuration_list = ::Array[QueueConfiguration]
-      type quiet = bool
-      type quote_character = ::String
-      type quote_escape_character = ::String
-      type quote_fields = ("ALWAYS" | "ASNEEDED")
       type range = ::String
-      type record_delimiter = ::String
-      class RecordsEvent
-        attr_accessor payload: ::IO
-      end
-      class Redirect
-        attr_accessor host_name: ::String
-        attr_accessor http_redirect_code: ::String
-        attr_accessor protocol: ("http" | "https")
-        attr_accessor replace_key_prefix_with: ::String
-        attr_accessor replace_key_with: ::String
-      end
-      class RedirectAllRequestsTo
-        attr_accessor host_name: ::String
-        attr_accessor protocol: ("http" | "https")
-      end
-      type replace_key_prefix_with = ::String
-      type replace_key_with = ::String
-      type replica_kms_key_id = ::String
-      class ReplicaModifications
-        attr_accessor status: ("Enabled" | "Disabled")
-      end
-      type replica_modifications_status = ("Enabled" | "Disabled")
-      class ReplicationConfiguration
-        attr_accessor role: ::String
-        attr_accessor rules: ::Array[ReplicationRule]
-      end
-      class ReplicationRule
-        attr_accessor id: ::String
-        attr_accessor priority: ::Integer
-        attr_accessor prefix: ::String
-        attr_accessor filter: ReplicationRuleFilter
-        attr_accessor status: ("Enabled" | "Disabled")
-        attr_accessor source_selection_criteria: SourceSelectionCriteria
-        attr_accessor existing_object_replication: ExistingObjectReplication
-        attr_accessor destination: Destination
-        attr_accessor delete_marker_replication: DeleteMarkerReplication
-      end
-      class ReplicationRuleAndOperator
-        attr_accessor prefix: ::String
-        attr_accessor tags: ::Array[Tag]
-      end
-      class ReplicationRuleFilter
-        attr_accessor prefix: ::String
-        attr_accessor tag: Tag
-        attr_accessor and: ReplicationRuleAndOperator
-      end
-      type replication_rule_status = ("Enabled" | "Disabled")
-      type replication_rules = ::Array[ReplicationRule]
-      type replication_status = ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
-      class ReplicationTime
-        attr_accessor status: ("Enabled" | "Disabled")
-        attr_accessor time: ReplicationTimeValue
-      end
-      type replication_time_status = ("Enabled" | "Disabled")
-      class ReplicationTimeValue
-        attr_accessor minutes: ::Integer
-      end
-      type request_charged = ("requester")
-      type request_payer = ("requester")
-      class RequestPaymentConfiguration
-        attr_accessor payer: ("Requester" | "BucketOwner")
-      end
-      class RequestProgress
-        attr_accessor enabled: bool
-      end
-      type request_route = ::String
-      type request_token = ::String
       type response_cache_control = ::String
       type response_content_disposition = ::String
       type response_content_encoding = ::String
       type response_content_language = ::String
       type response_content_type = ::String
       type response_expires = ::Time
+      type body = ::IO
+      type accept_ranges = ::String
       type restore = ::String
-      class RestoreObjectOutput
-        attr_accessor request_charged: ("requester")
-        attr_accessor restore_output_path: ::String
-      end
-      class RestoreObjectRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor version_id: ::String
-        attr_accessor restore_request: RestoreRequest
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-      end
-      type restore_output_path = ::String
-      class RestoreRequest
-        attr_accessor days: ::Integer
-        attr_accessor glacier_job_parameters: GlacierJobParameters
-        attr_accessor type_: ("SELECT")
-        attr_accessor tier: ("Standard" | "Bulk" | "Expedited")
-        attr_accessor description: ::String
-        attr_accessor select_parameters: SelectParameters
-        attr_accessor output_location: OutputLocation
-      end
+      type content_length = ::Integer
+      type missing_meta = ::Integer
+      type content_range = ::String
+      type replication_status = ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
+      type parts_count = ::Integer
+      type tag_count = ::Integer
+      type object_lock_legal_hold = { status: object_lock_legal_hold_status? }
+      type object_lock_configuration = { object_lock_enabled: object_lock_enabled?, rule: object_lock_rule? }
+      type object_lock_enabled = ("Enabled")
+      type object_lock_rule = { default_retention: default_retention? }
+      type default_retention = { mode: object_lock_retention_mode?, days: days?, years: years? }
+      type object_lock_retention_mode = ("GOVERNANCE" | "COMPLIANCE")
+      type years = ::Integer
+      type object_lock_retention = { mode: object_lock_retention_mode?, retain_until_date: date? }
+      type public_access_block_configuration = { block_public_acls: setting?, ignore_public_acls: setting?, block_public_policy: setting?, restrict_public_buckets: setting? }
+      type setting = bool
+      type token = ::String
+      type delimiter = ::String
+      type encoding_type = ("url")
+      type key_marker = ::String
+      type max_uploads = ::Integer
+      type upload_id_marker = ::String
+      type max_keys = ::Integer
+      type version_id_marker = ::String
+      type marker = ::String
+      type fetch_owner = bool
+      type start_after = ::String
+      type max_parts = ::Integer
+      type part_number_marker = ::Integer
+      type accelerate_configuration = { status: bucket_accelerate_status? }
+      type access_control_policy = { grants: grants?, owner: owner? }
+      type content_md5 = ::String
+      type cors_configuration = { cors_rules: cors_rules }
+      type lifecycle_configuration = { rules: rules }
+      type bucket_lifecycle_configuration = { rules: lifecycle_rules }
+      type bucket_logging_status = { logging_enabled: logging_enabled? }
+      type skip_validation = bool
+      type confirm_remove_self_bucket_access = bool
+      type object_lock_token = ::String
+      type request_payment_configuration = { payer: payer }
+      type tagging = { tag_set: tag_set }
+      type versioning_configuration = { mfa_delete: mfa_delete?, status: bucket_versioning_status? }
+      type mfa_delete = ("Enabled" | "Disabled")
+      type website_configuration = { error_document: error_document?, index_document: index_document?, redirect_all_requests_to: redirect_all_requests_to?, routing_rules: routing_rules? }
+      type restore_request = { days: days?, glacier_job_parameters: glacier_job_parameters?, type: restore_request_type?, tier: tier?, description: description?, select_parameters: select_parameters?, output_location: output_location? }
+      type glacier_job_parameters = { tier: tier }
+      type tier = ("Standard" | "Bulk" | "Expedited")
       type restore_request_type = ("SELECT")
-      type role = ::String
-      class RoutingRule
-        attr_accessor condition: Condition
-        attr_accessor redirect: Redirect
+      type description = ::String
+      type select_parameters = { input_serialization: input_serialization, expression_type: expression_type, expression: expression, output_serialization: output_serialization }
+      type input_serialization = { csv: csv_input?, compression_type: compression_type?, json: json_input?, parquet: parquet_input? }
+      type csv_input = { file_header_info: file_header_info?, comments: comments?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character?, allow_quoted_record_delimiter: allow_quoted_record_delimiter? }
+      type file_header_info = ("USE" | "IGNORE" | "NONE")
+      type comments = ::String
+      type quote_escape_character = ::String
+      type record_delimiter = ::String
+      type field_delimiter = ::String
+      type quote_character = ::String
+      type allow_quoted_record_delimiter = bool
+      type compression_type = ("NONE" | "GZIP" | "BZIP2")
+      type json_input = { type: json_type? }
+      type json_type = ("DOCUMENT" | "LINES")
+      type parquet_input = ::Hash[untyped, untyped]
+      type expression_type = ("SQL")
+      type expression = ::String
+      type output_serialization = { csv: csv_output?, json: json_output? }
+      type csv_output = { quote_fields: quote_fields?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character? }
+      type quote_fields = ("ALWAYS" | "ASNEEDED")
+      type json_output = { record_delimiter: record_delimiter? }
+      type output_location = { s3: s3_location? }
+      type s3_location = { bucket_name: bucket_name, prefix: location_prefix, encryption: encryption?, canned_acl: object_canned_acl?, access_control_list: grants?, tagging: tagging?, user_metadata: user_metadata?, storage_class: storage_class? }
+      type location_prefix = ::String
+      type encryption = { encryption_type: server_side_encryption, kms_key_id: ssekms_key_id?, kms_context: kms_context? }
+      type kms_context = ::String
+      type user_metadata = ::Array[metadata_entry]
+      type metadata_entry = { name: metadata_key?, value: metadata_value? }
+      type request_progress = { enabled: enable_request_progress? }
+      type enable_request_progress = bool
+      type scan_range = { start: start?, end: end_? }
+      type start = ::Integer
+      type end_ = ::Integer
+      type copy_source_range = ::String
+      type request_route = ::String
+      type request_token = ::String
+      type get_object_response_status_code = ::Integer
+      type error_code = ::String
+      type error_message = ::String
+      # outputs
+      class AbortMultipartUploadOutput
+        attr_accessor request_charged: request_charged
       end
-      type routing_rules = ::Array[RoutingRule]
+      class CompleteMultipartUploadOutput
+        attr_accessor location: location
+        attr_accessor bucket: bucket_name
+        attr_accessor key: object_key
+        attr_accessor expiration: expiration
+        attr_accessor etag: etag
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor version_id: object_version_id
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
+      end
+      type location = ::String
+      class CopyObjectOutput
+        attr_accessor copy_object_result: CopyObjectResult
+        attr_accessor expiration: expiration
+        attr_accessor copy_source_version_id: copy_source_version_id
+        attr_accessor version_id: object_version_id
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor ssekms_encryption_context: ssekms_encryption_context
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
+      end
+      class CopyObjectResult
+        attr_accessor etag: etag
+        attr_accessor last_modified: last_modified
+      end
+      type copy_source_version_id = ::String
+      class CreateBucketOutput
+        attr_accessor location: location
+      end
+      class CreateMultipartUploadOutput
+        attr_accessor abort_date: abort_date
+        attr_accessor abort_rule_id: abort_rule_id
+        attr_accessor bucket: bucket_name
+        attr_accessor key: object_key
+        attr_accessor upload_id: multipart_upload_id
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor ssekms_encryption_context: ssekms_encryption_context
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
+      end
+      type abort_date = ::Time
+      type abort_rule_id = ::String
+      class DeleteObjectOutput
+        attr_accessor delete_marker: delete_marker
+        attr_accessor version_id: object_version_id
+        attr_accessor request_charged: request_charged
+      end
+      class DeleteObjectTaggingOutput
+        attr_accessor version_id: object_version_id
+      end
+      class DeleteObjectsOutput
+        attr_accessor deleted: deleted_objects
+        attr_accessor request_charged: request_charged
+        attr_accessor errors: errors
+      end
+      type deleted_objects = ::Array[DeletedObject]
+      class DeletedObject
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor delete_marker: delete_marker
+        attr_accessor delete_marker_version_id: delete_marker_version_id
+      end
+      type delete_marker_version_id = ::String
+      type errors = ::Array[Error]
+      class Error
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor code: code
+        attr_accessor message: message
+      end
+      type code = ::String
+      type message = ::String
+      class GetBucketAccelerateConfigurationOutput
+        attr_accessor status: bucket_accelerate_status
+      end
+      class GetBucketAclOutput
+        attr_accessor owner: Owner
+        attr_accessor grants: grants
+      end
+      class Owner
+        attr_accessor display_name: display_name
+        attr_accessor id: id
+      end
+      class Grant
+        attr_accessor grantee: Grantee
+        attr_accessor permission: permission
+      end
+      class Grantee
+        attr_accessor display_name: display_name
+        attr_accessor email_address: email_address
+        attr_accessor id: id
+        attr_accessor type_: type_
+        attr_accessor uri: uri
+      end
+      class GetBucketAnalyticsConfigurationOutput
+        attr_accessor analytics_configuration: AnalyticsConfiguration
+      end
+      class AnalyticsConfiguration
+        attr_accessor id: analytics_id
+        attr_accessor filter: AnalyticsFilter
+        attr_accessor storage_class_analysis: StorageClassAnalysis
+      end
+      class AnalyticsFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor and: AnalyticsAndOperator
+      end
+      class Tag
+        attr_accessor key: object_key
+        attr_accessor value: value
+      end
+      class AnalyticsAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+      end
+      class StorageClassAnalysis
+        attr_accessor data_export: StorageClassAnalysisDataExport
+      end
+      class StorageClassAnalysisDataExport
+        attr_accessor output_schema_version: storage_class_analysis_schema_version
+        attr_accessor destination: AnalyticsExportDestination
+      end
+      class AnalyticsExportDestination
+        attr_accessor s3_bucket_destination: AnalyticsS3BucketDestination
+      end
+      class AnalyticsS3BucketDestination
+        attr_accessor format: analytics_s3_export_file_format
+        attr_accessor bucket_account_id: account_id
+        attr_accessor bucket: bucket_name
+        attr_accessor prefix: prefix
+      end
+      class GetBucketCorsOutput
+        attr_accessor cors_rules: cors_rules
+      end
+      class CORSRule
+        attr_accessor id: id
+        attr_accessor allowed_headers: allowed_headers
+        attr_accessor allowed_methods: allowed_methods
+        attr_accessor allowed_origins: allowed_origins
+        attr_accessor expose_headers: expose_headers
+        attr_accessor max_age_seconds: max_age_seconds
+      end
+      class GetBucketEncryptionOutput
+        attr_accessor server_side_encryption_configuration: ServerSideEncryptionConfiguration
+      end
+      class ServerSideEncryptionConfiguration
+        attr_accessor rules: server_side_encryption_rules
+      end
+      class ServerSideEncryptionRule
+        attr_accessor apply_server_side_encryption_by_default: ServerSideEncryptionByDefault
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+      end
+      class ServerSideEncryptionByDefault
+        attr_accessor sse_algorithm: server_side_encryption
+        attr_accessor kms_master_key_id: ssekms_key_id
+      end
+      class GetBucketIntelligentTieringConfigurationOutput
+        attr_accessor intelligent_tiering_configuration: IntelligentTieringConfiguration
+      end
+      class IntelligentTieringConfiguration
+        attr_accessor id: intelligent_tiering_id
+        attr_accessor filter: IntelligentTieringFilter
+        attr_accessor status: intelligent_tiering_status
+        attr_accessor tierings: tiering_list
+      end
+      class IntelligentTieringFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor and: IntelligentTieringAndOperator
+      end
+      class IntelligentTieringAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+      end
+      class Tiering
+        attr_accessor days: intelligent_tiering_days
+        attr_accessor access_tier: intelligent_tiering_access_tier
+      end
+      class GetBucketInventoryConfigurationOutput
+        attr_accessor inventory_configuration: InventoryConfiguration
+      end
+      class InventoryConfiguration
+        attr_accessor destination: InventoryDestination
+        attr_accessor is_enabled: is_enabled
+        attr_accessor filter: InventoryFilter
+        attr_accessor id: inventory_id
+        attr_accessor included_object_versions: inventory_included_object_versions
+        attr_accessor optional_fields: inventory_optional_fields
+        attr_accessor schedule: InventorySchedule
+      end
+      class InventoryDestination
+        attr_accessor s3_bucket_destination: InventoryS3BucketDestination
+      end
+      class InventoryS3BucketDestination
+        attr_accessor account_id: account_id
+        attr_accessor bucket: bucket_name
+        attr_accessor format: inventory_format
+        attr_accessor prefix: prefix
+        attr_accessor encryption: InventoryEncryption
+      end
+      class InventoryEncryption
+        attr_accessor sses3: SSES3
+        attr_accessor ssekms: SSEKMS
+      end
+      class SSES3
+      end
+      class SSEKMS
+        attr_accessor key_id: ssekms_key_id
+      end
+      class InventoryFilter
+        attr_accessor prefix: prefix
+      end
+      class InventorySchedule
+        attr_accessor frequency: inventory_frequency
+      end
+      class GetBucketLifecycleOutput
+        attr_accessor rules: rules
+      end
       class Rule
         attr_accessor expiration: LifecycleExpiration
-        attr_accessor id: ::String
-        attr_accessor prefix: ::String
-        attr_accessor status: ("Enabled" | "Disabled")
+        attr_accessor id: id
+        attr_accessor prefix: prefix
+        attr_accessor status: expiration_status
         attr_accessor transition: Transition
         attr_accessor noncurrent_version_transition: NoncurrentVersionTransition
         attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
         attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
       end
-      type rules = ::Array[Rule]
+      class LifecycleExpiration
+        attr_accessor date: date
+        attr_accessor days: days
+        attr_accessor expired_object_delete_marker: expired_object_delete_marker
+      end
+      class Transition
+        attr_accessor date: date
+        attr_accessor days: days
+        attr_accessor storage_class: transition_storage_class
+      end
+      class NoncurrentVersionTransition
+        attr_accessor noncurrent_days: days
+        attr_accessor storage_class: transition_storage_class
+        attr_accessor newer_noncurrent_versions: version_count
+      end
+      class NoncurrentVersionExpiration
+        attr_accessor noncurrent_days: days
+        attr_accessor newer_noncurrent_versions: version_count
+      end
+      class AbortIncompleteMultipartUpload
+        attr_accessor days_after_initiation: days_after_initiation
+      end
+      class GetBucketLifecycleConfigurationOutput
+        attr_accessor rules: lifecycle_rules
+      end
+      class LifecycleRule
+        attr_accessor expiration: LifecycleExpiration
+        attr_accessor id: id
+        attr_accessor prefix: prefix
+        attr_accessor filter: LifecycleRuleFilter
+        attr_accessor status: expiration_status
+        attr_accessor transitions: transition_list
+        attr_accessor noncurrent_version_transitions: noncurrent_version_transition_list
+        attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
+        attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
+      end
+      class LifecycleRuleFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor object_size_greater_than: object_size_greater_than_bytes
+        attr_accessor object_size_less_than: object_size_less_than_bytes
+        attr_accessor and: LifecycleRuleAndOperator
+      end
+      class LifecycleRuleAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+        attr_accessor object_size_greater_than: object_size_greater_than_bytes
+        attr_accessor object_size_less_than: object_size_less_than_bytes
+      end
+      class GetBucketLocationOutput
+        attr_accessor location_constraint: bucket_location_constraint
+      end
+      class GetBucketLoggingOutput
+        attr_accessor logging_enabled: LoggingEnabled
+      end
+      class LoggingEnabled
+        attr_accessor target_bucket: target_bucket
+        attr_accessor target_grants: target_grants
+        attr_accessor target_prefix: target_prefix
+      end
+      class TargetGrant
+        attr_accessor grantee: Grantee
+        attr_accessor permission: bucket_logs_permission
+      end
+      class GetBucketMetricsConfigurationOutput
+        attr_accessor metrics_configuration: MetricsConfiguration
+      end
+      class MetricsConfiguration
+        attr_accessor id: metrics_id
+        attr_accessor filter: MetricsFilter
+      end
+      class MetricsFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor access_point_arn: access_point_arn
+        attr_accessor and: MetricsAndOperator
+      end
+      class MetricsAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+        attr_accessor access_point_arn: access_point_arn
+      end
+      class NotificationConfigurationDeprecated
+        attr_accessor topic_configuration: TopicConfigurationDeprecated
+        attr_accessor queue_configuration: QueueConfigurationDeprecated
+        attr_accessor cloud_function_configuration: CloudFunctionConfiguration
+      end
+      class TopicConfigurationDeprecated
+        attr_accessor id: notification_id
+        attr_accessor events: event_list
+        attr_accessor event: event
+        attr_accessor topic: topic_arn
+      end
+      class QueueConfigurationDeprecated
+        attr_accessor id: notification_id
+        attr_accessor event: event
+        attr_accessor events: event_list
+        attr_accessor queue: queue_arn
+      end
+      class CloudFunctionConfiguration
+        attr_accessor id: notification_id
+        attr_accessor event: event
+        attr_accessor events: event_list
+        attr_accessor cloud_function: cloud_function
+        attr_accessor invocation_role: cloud_function_invocation_role
+      end
+      class NotificationConfiguration
+        attr_accessor topic_configurations: topic_configuration_list
+        attr_accessor queue_configurations: queue_configuration_list
+        attr_accessor lambda_function_configurations: lambda_function_configuration_list
+        attr_accessor event_bridge_configuration: EventBridgeConfiguration
+      end
+      class TopicConfiguration
+        attr_accessor id: notification_id
+        attr_accessor topic_arn: topic_arn
+        attr_accessor events: event_list
+        attr_accessor filter: NotificationConfigurationFilter
+      end
+      class NotificationConfigurationFilter
+        attr_accessor key: S3KeyFilter
+      end
       class S3KeyFilter
-        attr_accessor filter_rules: ::Array[FilterRule]
+        attr_accessor filter_rules: filter_rule_list
       end
-      class S3Location
-        attr_accessor bucket_name: ::String
-        attr_accessor prefix: ::String
-        attr_accessor encryption: Encryption
-        attr_accessor canned_acl: ("private" | "public-read" | "public-read-write" | "authenticated-read" | "aws-exec-read" | "bucket-owner-read" | "bucket-owner-full-control")
-        attr_accessor access_control_list: ::Array[Grant]
-        attr_accessor tagging: Tagging
-        attr_accessor user_metadata: ::Array[MetadataEntry]
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
+      class FilterRule
+        attr_accessor name: filter_rule_name
+        attr_accessor value: filter_rule_value
       end
-      type sse_customer_algorithm = ::String
-      type sse_customer_key = ::String
-      type sse_customer_key_md5 = ::String
-      class SSEKMS
-        attr_accessor key_id: ::String
+      class QueueConfiguration
+        attr_accessor id: notification_id
+        attr_accessor queue_arn: queue_arn
+        attr_accessor events: event_list
+        attr_accessor filter: NotificationConfigurationFilter
       end
-      type ssekms_encryption_context = ::String
-      type ssekms_key_id = ::String
-      class SSES3
+      class LambdaFunctionConfiguration
+        attr_accessor id: notification_id
+        attr_accessor lambda_function_arn: lambda_function_arn
+        attr_accessor events: event_list
+        attr_accessor filter: NotificationConfigurationFilter
       end
-      class ScanRange
-        attr_accessor start: ::Integer
-        attr_accessor end_: ::Integer
+      class EventBridgeConfiguration
+      end
+      class GetBucketOwnershipControlsOutput
+        attr_accessor ownership_controls: OwnershipControls
+      end
+      class OwnershipControls
+        attr_accessor rules: ownership_controls_rules
+      end
+      class OwnershipControlsRule
+        attr_accessor object_ownership: object_ownership
+      end
+      class GetBucketPolicyOutput
+        attr_accessor policy: policy
+      end
+      class GetBucketPolicyStatusOutput
+        attr_accessor policy_status: PolicyStatus
+      end
+      class PolicyStatus
+        attr_accessor is_public: is_public
+      end
+      type is_public = bool
+      class GetBucketReplicationOutput
+        attr_accessor replication_configuration: ReplicationConfiguration
+      end
+      class ReplicationConfiguration
+        attr_accessor role: role
+        attr_accessor rules: replication_rules
+      end
+      class ReplicationRule
+        attr_accessor id: id
+        attr_accessor priority: priority
+        attr_accessor prefix: prefix
+        attr_accessor filter: ReplicationRuleFilter
+        attr_accessor status: replication_rule_status
+        attr_accessor source_selection_criteria: SourceSelectionCriteria
+        attr_accessor existing_object_replication: ExistingObjectReplication
+        attr_accessor destination: Destination
+        attr_accessor delete_marker_replication: DeleteMarkerReplication
+      end
+      class ReplicationRuleFilter
+        attr_accessor prefix: prefix
+        attr_accessor tag: Tag
+        attr_accessor and: ReplicationRuleAndOperator
+      end
+      class ReplicationRuleAndOperator
+        attr_accessor prefix: prefix
+        attr_accessor tags: tag_set
+      end
+      class SourceSelectionCriteria
+        attr_accessor sse_kms_encrypted_objects: SseKmsEncryptedObjects
+        attr_accessor replica_modifications: ReplicaModifications
+      end
+      class SseKmsEncryptedObjects
+        attr_accessor status: sse_kms_encrypted_objects_status
+      end
+      class ReplicaModifications
+        attr_accessor status: replica_modifications_status
+      end
+      class ExistingObjectReplication
+        attr_accessor status: existing_object_replication_status
+      end
+      class Destination
+        attr_accessor bucket: bucket_name
+        attr_accessor account: account_id
+        attr_accessor storage_class: storage_class
+        attr_accessor access_control_translation: AccessControlTranslation
+        attr_accessor encryption_configuration: EncryptionConfiguration
+        attr_accessor replication_time: ReplicationTime
+        attr_accessor metrics: Metrics
+      end
+      class AccessControlTranslation
+        attr_accessor owner: owner_override
+      end
+      class EncryptionConfiguration
+        attr_accessor replica_kms_key_id: replica_kms_key_id
+      end
+      class ReplicationTime
+        attr_accessor status: replication_time_status
+        attr_accessor time: ReplicationTimeValue
+      end
+      class ReplicationTimeValue
+        attr_accessor minutes: minutes
+      end
+      class Metrics
+        attr_accessor status: metrics_status
+        attr_accessor event_threshold: ReplicationTimeValue
+      end
+      class DeleteMarkerReplication
+        attr_accessor status: delete_marker_replication_status
+      end
+      class GetBucketRequestPaymentOutput
+        attr_accessor payer: payer
+      end
+      class GetBucketTaggingOutput
+        attr_accessor tag_set: tag_set
+      end
+      class GetBucketVersioningOutput
+        attr_accessor status: bucket_versioning_status
+        attr_accessor mfa_delete: mfa_delete_status
+      end
+      type mfa_delete_status = ("Enabled" | "Disabled")
+      class GetBucketWebsiteOutput
+        attr_accessor redirect_all_requests_to: RedirectAllRequestsTo
+        attr_accessor index_document: IndexDocument
+        attr_accessor error_document: ErrorDocument
+        attr_accessor routing_rules: routing_rules
+      end
+      class RedirectAllRequestsTo
+        attr_accessor host_name: host_name
+        attr_accessor protocol: protocol
+      end
+      class IndexDocument
+        attr_accessor suffix: suffix
+      end
+      class ErrorDocument
+        attr_accessor key: object_key
+      end
+      class RoutingRule
+        attr_accessor condition: Condition
+        attr_accessor redirect: Redirect
+      end
+      class Condition
+        attr_accessor http_error_code_returned_equals: http_error_code_returned_equals
+        attr_accessor key_prefix_equals: key_prefix_equals
+      end
+      class Redirect
+        attr_accessor host_name: host_name
+        attr_accessor http_redirect_code: http_redirect_code
+        attr_accessor protocol: protocol
+        attr_accessor replace_key_prefix_with: replace_key_prefix_with
+        attr_accessor replace_key_with: replace_key_with
+      end
+      class GetObjectOutput
+        attr_accessor body: body
+        attr_accessor delete_marker: delete_marker
+        attr_accessor accept_ranges: accept_ranges
+        attr_accessor expiration: expiration
+        attr_accessor restore: restore
+        attr_accessor last_modified: last_modified
+        attr_accessor content_length: content_length
+        attr_accessor etag: etag
+        attr_accessor missing_meta: missing_meta
+        attr_accessor version_id: object_version_id
+        attr_accessor cache_control: cache_control
+        attr_accessor content_disposition: content_disposition
+        attr_accessor content_encoding: content_encoding
+        attr_accessor content_language: content_language
+        attr_accessor content_range: content_range
+        attr_accessor content_type: content_type
+        attr_accessor expires: expires
+        attr_accessor website_redirect_location: website_redirect_location
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor metadata: metadata
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor storage_class: storage_class
+        attr_accessor request_charged: request_charged
+        attr_accessor replication_status: replication_status
+        attr_accessor parts_count: parts_count
+        attr_accessor tag_count: tag_count
+        attr_accessor object_lock_mode: object_lock_mode
+        attr_accessor object_lock_retain_until_date: object_lock_retain_until_date
+        attr_accessor object_lock_legal_hold_status: object_lock_legal_hold_status
+      end
+      class GetObjectAclOutput
+        attr_accessor owner: Owner
+        attr_accessor grants: grants
+        attr_accessor request_charged: request_charged
+      end
+      class GetObjectLegalHoldOutput
+        attr_accessor legal_hold: ObjectLockLegalHold
+      end
+      class ObjectLockLegalHold
+        attr_accessor status: object_lock_legal_hold_status
+      end
+      class GetObjectLockConfigurationOutput
+        attr_accessor object_lock_configuration: ObjectLockConfiguration
+      end
+      class ObjectLockConfiguration
+        attr_accessor object_lock_enabled: object_lock_enabled
+        attr_accessor rule: ObjectLockRule
+      end
+      class ObjectLockRule
+        attr_accessor default_retention: DefaultRetention
+      end
+      class DefaultRetention
+        attr_accessor mode: object_lock_retention_mode
+        attr_accessor days: days
+        attr_accessor years: years
+      end
+      class GetObjectRetentionOutput
+        attr_accessor retention: ObjectLockRetention
+      end
+      class ObjectLockRetention
+        attr_accessor mode: object_lock_retention_mode
+        attr_accessor retain_until_date: date
+      end
+      class GetObjectTaggingOutput
+        attr_accessor version_id: object_version_id
+        attr_accessor tag_set: tag_set
+      end
+      class GetObjectTorrentOutput
+        attr_accessor body: body
+        attr_accessor request_charged: request_charged
+      end
+      class GetPublicAccessBlockOutput
+        attr_accessor public_access_block_configuration: PublicAccessBlockConfiguration
+      end
+      class PublicAccessBlockConfiguration
+        attr_accessor block_public_acls: setting
+        attr_accessor ignore_public_acls: setting
+        attr_accessor block_public_policy: setting
+        attr_accessor restrict_public_buckets: setting
+      end
+      class HeadObjectOutput
+        attr_accessor delete_marker: delete_marker
+        attr_accessor accept_ranges: accept_ranges
+        attr_accessor expiration: expiration
+        attr_accessor restore: restore
+        attr_accessor archive_status: archive_status
+        attr_accessor last_modified: last_modified
+        attr_accessor content_length: content_length
+        attr_accessor etag: etag
+        attr_accessor missing_meta: missing_meta
+        attr_accessor version_id: object_version_id
+        attr_accessor cache_control: cache_control
+        attr_accessor content_disposition: content_disposition
+        attr_accessor content_encoding: content_encoding
+        attr_accessor content_language: content_language
+        attr_accessor content_type: content_type
+        attr_accessor expires: expires
+        attr_accessor website_redirect_location: website_redirect_location
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor metadata: metadata
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor storage_class: storage_class
+        attr_accessor request_charged: request_charged
+        attr_accessor replication_status: replication_status
+        attr_accessor parts_count: parts_count
+        attr_accessor object_lock_mode: object_lock_mode
+        attr_accessor object_lock_retain_until_date: object_lock_retain_until_date
+        attr_accessor object_lock_legal_hold_status: object_lock_legal_hold_status
+      end
+      type archive_status = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
+      class ListBucketAnalyticsConfigurationsOutput
+        attr_accessor is_truncated: is_truncated
+        attr_accessor continuation_token: token
+        attr_accessor next_continuation_token: next_token
+        attr_accessor analytics_configuration_list: analytics_configuration_list
+      end
+      type is_truncated = bool
+      type next_token = ::String
+      type analytics_configuration_list = ::Array[AnalyticsConfiguration]
+      class ListBucketIntelligentTieringConfigurationsOutput
+        attr_accessor is_truncated: is_truncated
+        attr_accessor continuation_token: token
+        attr_accessor next_continuation_token: next_token
+        attr_accessor intelligent_tiering_configuration_list: intelligent_tiering_configuration_list
+      end
+      type intelligent_tiering_configuration_list = ::Array[IntelligentTieringConfiguration]
+      class ListBucketInventoryConfigurationsOutput
+        attr_accessor continuation_token: token
+        attr_accessor inventory_configuration_list: inventory_configuration_list
+        attr_accessor is_truncated: is_truncated
+        attr_accessor next_continuation_token: next_token
+      end
+      type inventory_configuration_list = ::Array[InventoryConfiguration]
+      class ListBucketMetricsConfigurationsOutput
+        attr_accessor is_truncated: is_truncated
+        attr_accessor continuation_token: token
+        attr_accessor next_continuation_token: next_token
+        attr_accessor metrics_configuration_list: metrics_configuration_list
+      end
+      type metrics_configuration_list = ::Array[MetricsConfiguration]
+      class ListBucketsOutput
+        attr_accessor buckets: buckets
+        attr_accessor owner: Owner
+      end
+      type buckets = ::Array[Bucket]
+      class Bucket
+        attr_accessor name: bucket_name
+        attr_accessor creation_date: creation_date
+      end
+      type creation_date = ::Time
+      class ListMultipartUploadsOutput
+        attr_accessor bucket: bucket_name
+        attr_accessor key_marker: key_marker
+        attr_accessor upload_id_marker: upload_id_marker
+        attr_accessor next_key_marker: next_key_marker
+        attr_accessor prefix: prefix
+        attr_accessor delimiter: delimiter
+        attr_accessor next_upload_id_marker: next_upload_id_marker
+        attr_accessor max_uploads: max_uploads
+        attr_accessor is_truncated: is_truncated
+        attr_accessor uploads: multipart_upload_list
+        attr_accessor common_prefixes: common_prefix_list
+        attr_accessor encoding_type: encoding_type
+      end
+      type next_key_marker = ::String
+      type next_upload_id_marker = ::String
+      type multipart_upload_list = ::Array[MultipartUpload]
+      class MultipartUpload
+        attr_accessor upload_id: multipart_upload_id
+        attr_accessor key: object_key
+        attr_accessor initiated: initiated
+        attr_accessor storage_class: storage_class
+        attr_accessor owner: Owner
+        attr_accessor initiator: Initiator
+      end
+      type initiated = ::Time
+      class Initiator
+        attr_accessor id: id
+        attr_accessor display_name: display_name
+      end
+      type common_prefix_list = ::Array[CommonPrefix]
+      class CommonPrefix
+        attr_accessor prefix: prefix
+      end
+      class ListObjectVersionsOutput
+        attr_accessor is_truncated: is_truncated
+        attr_accessor key_marker: key_marker
+        attr_accessor version_id_marker: version_id_marker
+        attr_accessor next_key_marker: next_key_marker
+        attr_accessor next_version_id_marker: next_version_id_marker
+        attr_accessor versions: object_version_list
+        attr_accessor delete_markers: delete_markers
+        attr_accessor name: bucket_name
+        attr_accessor prefix: prefix
+        attr_accessor delimiter: delimiter
+        attr_accessor max_keys: max_keys
+        attr_accessor common_prefixes: common_prefix_list
+        attr_accessor encoding_type: encoding_type
+      end
+      type next_version_id_marker = ::String
+      type object_version_list = ::Array[ObjectVersion]
+      class ObjectVersion
+        attr_accessor etag: etag
+        attr_accessor size: size
+        attr_accessor storage_class: object_version_storage_class
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor is_latest: is_latest
+        attr_accessor last_modified: last_modified
+        attr_accessor owner: Owner
+      end
+      type size = ::Integer
+      type object_version_storage_class = ("STANDARD")
+      type is_latest = bool
+      type delete_markers = ::Array[DeleteMarkerEntry]
+      class DeleteMarkerEntry
+        attr_accessor owner: Owner
+        attr_accessor key: object_key
+        attr_accessor version_id: object_version_id
+        attr_accessor is_latest: is_latest
+        attr_accessor last_modified: last_modified
+      end
+      class ListObjectsOutput
+        attr_accessor is_truncated: is_truncated
+        attr_accessor marker: marker
+        attr_accessor next_marker: next_marker
+        attr_accessor contents: object_list
+        attr_accessor name: bucket_name
+        attr_accessor prefix: prefix
+        attr_accessor delimiter: delimiter
+        attr_accessor max_keys: max_keys
+        attr_accessor common_prefixes: common_prefix_list
+        attr_accessor encoding_type: encoding_type
+      end
+      type next_marker = ::String
+      type object_list = ::Array[Object]
+      class Object
+        attr_accessor key: object_key
+        attr_accessor last_modified: last_modified
+        attr_accessor etag: etag
+        attr_accessor size: size
+        attr_accessor storage_class: object_storage_class
+        attr_accessor owner: Owner
+      end
+      type object_storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
+      class ListObjectsV2Output
+        attr_accessor is_truncated: is_truncated
+        attr_accessor contents: object_list
+        attr_accessor name: bucket_name
+        attr_accessor prefix: prefix
+        attr_accessor delimiter: delimiter
+        attr_accessor max_keys: max_keys
+        attr_accessor common_prefixes: common_prefix_list
+        attr_accessor encoding_type: encoding_type
+        attr_accessor key_count: key_count
+        attr_accessor continuation_token: token
+        attr_accessor next_continuation_token: next_token
+        attr_accessor start_after: start_after
+      end
+      type key_count = ::Integer
+      class ListPartsOutput
+        attr_accessor abort_date: abort_date
+        attr_accessor abort_rule_id: abort_rule_id
+        attr_accessor bucket: bucket_name
+        attr_accessor key: object_key
+        attr_accessor upload_id: multipart_upload_id
+        attr_accessor part_number_marker: part_number_marker
+        attr_accessor next_part_number_marker: next_part_number_marker
+        attr_accessor max_parts: max_parts
+        attr_accessor is_truncated: is_truncated
+        attr_accessor parts: parts
+        attr_accessor initiator: Initiator
+        attr_accessor owner: Owner
+        attr_accessor storage_class: storage_class
+        attr_accessor request_charged: request_charged
+      end
+      type next_part_number_marker = ::Integer
+      type parts = ::Array[Part]
+      class Part
+        attr_accessor part_number: part_number
+        attr_accessor last_modified: last_modified
+        attr_accessor etag: etag
+        attr_accessor size: size
+      end
+      class PutObjectOutput
+        attr_accessor expiration: expiration
+        attr_accessor etag: etag
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor version_id: object_version_id
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor ssekms_encryption_context: ssekms_encryption_context
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectAclOutput
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectLegalHoldOutput
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectLockConfigurationOutput
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectRetentionOutput
+        attr_accessor request_charged: request_charged
+      end
+      class PutObjectTaggingOutput
+        attr_accessor version_id: object_version_id
+      end
+      class RestoreObjectOutput
+        attr_accessor request_charged: request_charged
+        attr_accessor restore_output_path: restore_output_path
+      end
+      type restore_output_path = ::String
+      class SelectObjectContentOutput
+        attr_accessor payload: SelectObjectContentEventStream
       end
       class SelectObjectContentEventStream
         attr_accessor records: RecordsEvent
@@ -1869,249 +1290,78 @@ module Aws
         attr_accessor cont: ContinuationEvent
         attr_accessor end_: EndEvent
       end
-      class SelectObjectContentOutput
-        attr_accessor payload: SelectObjectContentEventStream
-      end
-      class SelectObjectContentRequest
-        attr_accessor bucket: ::String
-        attr_accessor key: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor expression: ::String
-        attr_accessor expression_type: ("SQL")
-        attr_accessor request_progress: RequestProgress
-        attr_accessor input_serialization: InputSerialization
-        attr_accessor output_serialization: OutputSerialization
-        attr_accessor scan_range: ScanRange
-        attr_accessor expected_bucket_owner: ::String
-      end
-      class SelectParameters
-        attr_accessor input_serialization: InputSerialization
-        attr_accessor expression_type: ("SQL")
-        attr_accessor expression: ::String
-        attr_accessor output_serialization: OutputSerialization
-      end
-      type server_side_encryption = ("AES256" | "aws:kms")
-      class ServerSideEncryptionByDefault
-        attr_accessor sse_algorithm: ("AES256" | "aws:kms")
-        attr_accessor kms_master_key_id: ::String
-      end
-      class ServerSideEncryptionConfiguration
-        attr_accessor rules: ::Array[ServerSideEncryptionRule]
-      end
-      class ServerSideEncryptionRule
-        attr_accessor apply_server_side_encryption_by_default: ServerSideEncryptionByDefault
-        attr_accessor bucket_key_enabled: bool
-      end
-      type server_side_encryption_rules = ::Array[ServerSideEncryptionRule]
-      type setting = bool
-      type size = ::Integer
-      type skip_validation = bool
-      class SourceSelectionCriteria
-        attr_accessor sse_kms_encrypted_objects: SseKmsEncryptedObjects
-        attr_accessor replica_modifications: ReplicaModifications
-      end
-      class SseKmsEncryptedObjects
-        attr_accessor status: ("Enabled" | "Disabled")
-      end
-      type sse_kms_encrypted_objects_status = ("Enabled" | "Disabled")
-      type start = ::Integer
-      type start_after = ::String
-      class Stats
-        attr_accessor bytes_scanned: ::Integer
-        attr_accessor bytes_processed: ::Integer
-        attr_accessor bytes_returned: ::Integer
+      class RecordsEvent
+        attr_accessor payload: body
       end
       class StatsEvent
         attr_accessor details: Stats
       end
-      type storage_class = ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-      class StorageClassAnalysis
-        attr_accessor data_export: StorageClassAnalysisDataExport
+      class Stats
+        attr_accessor bytes_scanned: bytes_scanned
+        attr_accessor bytes_processed: bytes_processed
+        attr_accessor bytes_returned: bytes_returned
       end
-      class StorageClassAnalysisDataExport
-        attr_accessor output_schema_version: ("V_1")
-        attr_accessor destination: AnalyticsExportDestination
+      type bytes_scanned = ::Integer
+      type bytes_processed = ::Integer
+      type bytes_returned = ::Integer
+      class ProgressEvent
+        attr_accessor details: Progress
       end
-      type storage_class_analysis_schema_version = ("V_1")
-      type suffix = ::String
-      class Tag
-        attr_accessor key: ::String
-        attr_accessor value: ::String
+      class Progress
+        attr_accessor bytes_scanned: bytes_scanned
+        attr_accessor bytes_processed: bytes_processed
+        attr_accessor bytes_returned: bytes_returned
       end
-      type tag_count = ::Integer
-      type tag_set = ::Array[Tag]
-      class Tagging
-        attr_accessor tag_set: ::Array[Tag]
+      class ContinuationEvent
       end
-      type tagging_directive = ("COPY" | "REPLACE")
-      type tagging_header = ::String
-      type target_bucket = ::String
-      class TargetGrant
-        attr_accessor grantee: Grantee
-        attr_accessor permission: ("FULL_CONTROL" | "READ" | "WRITE")
-      end
-      type target_grants = ::Array[TargetGrant]
-      type target_prefix = ::String
-      type tier = ("Standard" | "Bulk" | "Expedited")
-      class Tiering
-        attr_accessor days: ::Integer
-        attr_accessor access_tier: ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
-      end
-      type tiering_list = ::Array[Tiering]
-      type token = ::String
-      type topic_arn = ::String
-      class TopicConfiguration
-        attr_accessor id: ::String
-        attr_accessor topic_arn: ::String
-        attr_accessor events: ::Array[event]
-        attr_accessor filter: NotificationConfigurationFilter
-      end
-      class TopicConfigurationDeprecated
-        attr_accessor id: ::String
-        attr_accessor events: ::Array[event]
-        attr_accessor event: ("s3:ReducedRedundancyLostObject" | "s3:ObjectCreated:*" | "s3:ObjectCreated:Put" | "s3:ObjectCreated:Post" | "s3:ObjectCreated:Copy" | "s3:ObjectCreated:CompleteMultipartUpload" | "s3:ObjectRemoved:*" | "s3:ObjectRemoved:Delete" | "s3:ObjectRemoved:DeleteMarkerCreated" | "s3:ObjectRestore:*" | "s3:ObjectRestore:Post" | "s3:ObjectRestore:Completed" | "s3:Replication:*" | "s3:Replication:OperationFailedReplication" | "s3:Replication:OperationNotTracked" | "s3:Replication:OperationMissedThreshold" | "s3:Replication:OperationReplicatedAfterThreshold" | "s3:ObjectRestore:Delete" | "s3:LifecycleTransition" | "s3:IntelligentTiering" | "s3:ObjectAcl:Put" | "s3:LifecycleExpiration:*" | "s3:LifecycleExpiration:Delete" | "s3:LifecycleExpiration:DeleteMarkerCreated" | "s3:ObjectTagging:*" | "s3:ObjectTagging:Put" | "s3:ObjectTagging:Delete")
-        attr_accessor topic: ::String
-      end
-      type topic_configuration_list = ::Array[TopicConfiguration]
-      class Transition
-        attr_accessor date: ::Time
-        attr_accessor days: ::Integer
-        attr_accessor storage_class: ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
-      end
-      type transition_list = ::Array[Transition]
-      type transition_storage_class = ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
-      type type_ = ("CanonicalUser" | "AmazonCustomerByEmail" | "Group")
-      type uri = ::String
-      type upload_id_marker = ::String
-      class UploadPartCopyOutput
-        attr_accessor copy_source_version_id: ::String
-        attr_accessor copy_part_result: CopyPartResult
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_charged: ("requester")
-      end
-      class UploadPartCopyRequest
-        attr_accessor bucket: ::String
-        attr_accessor copy_source: ::String
-        attr_accessor copy_source_if_match: ::String
-        attr_accessor copy_source_if_modified_since: ::Time
-        attr_accessor copy_source_if_none_match: ::String
-        attr_accessor copy_source_if_unmodified_since: ::Time
-        attr_accessor copy_source_range: ::String
-        attr_accessor key: ::String
-        attr_accessor part_number: ::Integer
-        attr_accessor upload_id: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor copy_source_sse_customer_algorithm: ::String
-        attr_accessor copy_source_sse_customer_key: ::String
-        attr_accessor copy_source_sse_customer_key_md5: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
-        attr_accessor expected_source_bucket_owner: ::String
+      class EndEvent
       end
       class UploadPartOutput
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor etag: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor bucket_key_enabled: bool
-        attr_accessor request_charged: ("requester")
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor etag: etag
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
       end
-      class UploadPartRequest
-        attr_accessor body: ::IO
-        attr_accessor bucket: ::String
-        attr_accessor content_length: ::Integer
-        attr_accessor content_md5: ::String
-        attr_accessor key: ::String
-        attr_accessor part_number: ::Integer
-        attr_accessor upload_id: ::String
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor sse_customer_key: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor request_payer: ("requester")
-        attr_accessor expected_bucket_owner: ::String
+      class UploadPartCopyOutput
+        attr_accessor copy_source_version_id: copy_source_version_id
+        attr_accessor copy_part_result: CopyPartResult
+        attr_accessor server_side_encryption: server_side_encryption
+        attr_accessor sse_customer_algorithm: sse_customer_algorithm
+        attr_accessor sse_customer_key_md5: sse_customer_key_md5
+        attr_accessor ssekms_key_id: ssekms_key_id
+        attr_accessor bucket_key_enabled: bucket_key_enabled
+        attr_accessor request_charged: request_charged
       end
-      type user_metadata = ::Array[MetadataEntry]
-      type value = ::String
-      type version_count = ::Integer
-      type version_id_marker = ::String
-      class VersioningConfiguration
-        attr_accessor mfa_delete: ("Enabled" | "Disabled")
-        attr_accessor status: ("Enabled" | "Suspended")
+      class CopyPartResult
+        attr_accessor etag: etag
+        attr_accessor last_modified: last_modified
       end
-      class WebsiteConfiguration
-        attr_accessor error_document: ErrorDocument
-        attr_accessor index_document: IndexDocument
-        attr_accessor redirect_all_requests_to: RedirectAllRequestsTo
-        attr_accessor routing_rules: ::Array[RoutingRule]
-      end
-      type website_redirect_location = ::String
-      class WriteGetObjectResponseRequest
-        attr_accessor request_route: ::String
-        attr_accessor request_token: ::String
-        attr_accessor body: ::IO
-        attr_accessor status_code: ::Integer
-        attr_accessor error_code: ::String
-        attr_accessor error_message: ::String
-        attr_accessor accept_ranges: ::String
-        attr_accessor cache_control: ::String
-        attr_accessor content_disposition: ::String
-        attr_accessor content_encoding: ::String
-        attr_accessor content_language: ::String
-        attr_accessor content_length: ::Integer
-        attr_accessor content_range: ::String
-        attr_accessor content_type: ::String
-        attr_accessor delete_marker: bool
-        attr_accessor etag: ::String
-        attr_accessor expires: ::Time
-        attr_accessor expiration: ::String
-        attr_accessor last_modified: ::Time
-        attr_accessor missing_meta: ::Integer
-        attr_accessor metadata: ::Hash[metadata_key, metadata_value]
-        attr_accessor object_lock_mode: ("GOVERNANCE" | "COMPLIANCE")
-        attr_accessor object_lock_legal_hold_status: ("ON" | "OFF")
-        attr_accessor object_lock_retain_until_date: ::Time
-        attr_accessor parts_count: ::Integer
-        attr_accessor replication_status: ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
-        attr_accessor request_charged: ("requester")
-        attr_accessor restore: ::String
-        attr_accessor server_side_encryption: ("AES256" | "aws:kms")
-        attr_accessor sse_customer_algorithm: ::String
-        attr_accessor ssekms_key_id: ::String
-        attr_accessor sse_customer_key_md5: ::String
-        attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
-        attr_accessor tag_count: ::Integer
-        attr_accessor version_id: ::String
-        attr_accessor bucket_key_enabled: bool
-      end
-      type years = ::Integer
     end
     module Errors
-      class BucketAlreadyExists < RuntimeError
+      class StorageClass < ::RuntimeError
       end
-      class BucketAlreadyOwnedByYou < RuntimeError
+      class IntelligentTieringAccessTier < ::RuntimeError
       end
-      class InvalidObjectState < RuntimeError
+      class BucketAlreadyExists < ::RuntimeError
+      end
+      class BucketAlreadyOwnedByYou < ::RuntimeError
+      end
+      class InvalidObjectState < ::RuntimeError
         attr_accessor storage_class: ("STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR")
         attr_accessor access_tier: ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
       end
-      class NoSuchBucket < RuntimeError
+      class NoSuchBucket < ::RuntimeError
       end
-      class NoSuchKey < RuntimeError
+      class NoSuchKey < ::RuntimeError
       end
-      class NoSuchUpload < RuntimeError
+      class NoSuchUpload < ::RuntimeError
       end
-      class ObjectAlreadyInActiveTierError < RuntimeError
+      class ObjectAlreadyInActiveTierError < ::RuntimeError
       end
-      class ObjectNotInActiveTierError < RuntimeError
+      class ObjectNotInActiveTierError < ::RuntimeError
       end
     end
   end

--- a/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs
+++ b/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs
@@ -118,7 +118,7 @@ module Aws
       type abort_rule_id = ::String
       type accelerate_configuration = { status: bucket_accelerate_status? }
       type accept_ranges = ::String
-      type access_control_policy = { grants: grants?, owner: owner? }
+      type access_control_policy = { grants: grants_input?, owner: owner? }
       class AccessControlTranslation
         attr_accessor owner: owner_override
       end
@@ -134,16 +134,16 @@ module Aws
       type allowed_origins = ::Array[allowed_origin]
       class AnalyticsAndOperator
         attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
+        attr_accessor tags: tag_set_output
       end
-      type analytics_and_operator = { prefix: prefix?, tags: tag_set? }
+      type analytics_and_operator = { prefix: prefix?, tags: tag_set_input? }
       class AnalyticsConfiguration
         attr_accessor id: analytics_id
         attr_accessor filter: AnalyticsFilter
         attr_accessor storage_class_analysis: StorageClassAnalysis
       end
       type analytics_configuration = { id: analytics_id, filter: analytics_filter?, storage_class_analysis: storage_class_analysis }
-      type analytics_configuration_list = ::Array[AnalyticsConfiguration]
+      type analytics_configuration_list_output = ::Array[AnalyticsConfiguration]
       class AnalyticsExportDestination
         attr_accessor s3_bucket_destination: AnalyticsS3BucketDestination
       end
@@ -172,7 +172,7 @@ module Aws
       type bucket_accelerate_status = ("Enabled" | "Suspended")
       type bucket_canned_acl = ("private" | "public-read" | "public-read-write" | "authenticated-read")
       type bucket_key_enabled = bool
-      type bucket_lifecycle_configuration = { rules: lifecycle_rules }
+      type bucket_lifecycle_configuration = { rules: lifecycle_rules_input }
       type bucket_location_constraint = ("af-south-1" | "ap-east-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "EU" | "eu-central-1" | "eu-north-1" | "eu-south-1" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "me-south-1" | "sa-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2")
       type bucket_logging_status = { logging_enabled: logging_enabled? }
       type bucket_logs_permission = ("FULL_CONTROL" | "READ" | "WRITE")
@@ -183,7 +183,7 @@ module Aws
       type bytes_processed = ::Integer
       type bytes_returned = ::Integer
       type bytes_scanned = ::Integer
-      type cors_configuration = { cors_rules: cors_rules }
+      type cors_configuration = { cors_rules: cors_rules_input }
       class CORSRule
         attr_accessor id: id
         attr_accessor allowed_headers: allowed_headers
@@ -193,7 +193,8 @@ module Aws
         attr_accessor max_age_seconds: max_age_seconds
       end
       type cors_rule = { id: id?, allowed_headers: allowed_headers?, allowed_methods: allowed_methods, allowed_origins: allowed_origins, expose_headers: expose_headers?, max_age_seconds: max_age_seconds? }
-      type cors_rules = ::Array[CORSRule]
+      type cors_rules_output = ::Array[CORSRule]
+      type cors_rules_input = ::Array[cors_rule]
       type csv_input = { file_header_info: file_header_info?, comments: comments?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character?, allow_quoted_record_delimiter: allow_quoted_record_delimiter? }
       type csv_output = { quote_fields: quote_fields?, quote_escape_character: quote_escape_character?, record_delimiter: record_delimiter?, field_delimiter: field_delimiter?, quote_character: quote_character? }
       type cache_control = ::String
@@ -403,7 +404,8 @@ module Aws
         attr_accessor value: filter_rule_value
       end
       type filter_rule = { name: filter_rule_name?, value: filter_rule_value? }
-      type filter_rule_list = ::Array[FilterRule]
+      type filter_rule_list_output = ::Array[FilterRule]
+      type filter_rule_list_input = ::Array[filter_rule]
       type filter_rule_name = ("prefix" | "suffix")
       type filter_rule_value = ::String
       class GetBucketAccelerateConfigurationOutput
@@ -411,13 +413,13 @@ module Aws
       end
       class GetBucketAclOutput
         attr_accessor owner: Owner
-        attr_accessor grants: grants
+        attr_accessor grants: grants_output
       end
       class GetBucketAnalyticsConfigurationOutput
         attr_accessor analytics_configuration: AnalyticsConfiguration
       end
       class GetBucketCorsOutput
-        attr_accessor cors_rules: cors_rules
+        attr_accessor cors_rules: cors_rules_output
       end
       class GetBucketEncryptionOutput
         attr_accessor server_side_encryption_configuration: ServerSideEncryptionConfiguration
@@ -429,10 +431,10 @@ module Aws
         attr_accessor inventory_configuration: InventoryConfiguration
       end
       class GetBucketLifecycleConfigurationOutput
-        attr_accessor rules: lifecycle_rules
+        attr_accessor rules: lifecycle_rules_output
       end
       class GetBucketLifecycleOutput
-        attr_accessor rules: rules
+        attr_accessor rules: rules_output
       end
       class GetBucketLocationOutput
         attr_accessor location_constraint: bucket_location_constraint
@@ -459,7 +461,7 @@ module Aws
         attr_accessor payer: payer
       end
       class GetBucketTaggingOutput
-        attr_accessor tag_set: tag_set
+        attr_accessor tag_set: tag_set_output
       end
       class GetBucketVersioningOutput
         attr_accessor status: bucket_versioning_status
@@ -469,11 +471,11 @@ module Aws
         attr_accessor redirect_all_requests_to: RedirectAllRequestsTo
         attr_accessor index_document: IndexDocument
         attr_accessor error_document: ErrorDocument
-        attr_accessor routing_rules: routing_rules
+        attr_accessor routing_rules: routing_rules_output
       end
       class GetObjectAclOutput
         attr_accessor owner: Owner
-        attr_accessor grants: grants
+        attr_accessor grants: grants_output
         attr_accessor request_charged: request_charged
       end
       class GetObjectLegalHoldOutput
@@ -522,7 +524,7 @@ module Aws
       end
       class GetObjectTaggingOutput
         attr_accessor version_id: object_version_id
-        attr_accessor tag_set: tag_set
+        attr_accessor tag_set: tag_set_output
       end
       class GetObjectTorrentOutput
         attr_accessor body: body
@@ -550,7 +552,8 @@ module Aws
         attr_accessor uri: uri
       end
       type grantee = { display_name: display_name?, email_address: email_address?, id: id?, type: type_, uri: uri? }
-      type grants = ::Array[Grant]
+      type grants_output = ::Array[Grant]
+      type grants_input = ::Array[grant]
       class HeadObjectOutput
         attr_accessor delete_marker: delete_marker
         attr_accessor accept_ranges: accept_ranges
@@ -604,17 +607,17 @@ module Aws
       type intelligent_tiering_access_tier = ("ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS")
       class IntelligentTieringAndOperator
         attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
+        attr_accessor tags: tag_set_output
       end
-      type intelligent_tiering_and_operator = { prefix: prefix?, tags: tag_set? }
+      type intelligent_tiering_and_operator = { prefix: prefix?, tags: tag_set_input? }
       class IntelligentTieringConfiguration
         attr_accessor id: intelligent_tiering_id
         attr_accessor filter: IntelligentTieringFilter
         attr_accessor status: intelligent_tiering_status
-        attr_accessor tierings: tiering_list
+        attr_accessor tierings: tiering_list_output
       end
-      type intelligent_tiering_configuration = { id: intelligent_tiering_id, filter: intelligent_tiering_filter?, status: intelligent_tiering_status, tierings: tiering_list }
-      type intelligent_tiering_configuration_list = ::Array[IntelligentTieringConfiguration]
+      type intelligent_tiering_configuration = { id: intelligent_tiering_id, filter: intelligent_tiering_filter?, status: intelligent_tiering_status, tierings: tiering_list_input }
+      type intelligent_tiering_configuration_list_output = ::Array[IntelligentTieringConfiguration]
       type intelligent_tiering_days = ::Integer
       class IntelligentTieringFilter
         attr_accessor prefix: prefix
@@ -634,7 +637,7 @@ module Aws
         attr_accessor schedule: InventorySchedule
       end
       type inventory_configuration = { destination: inventory_destination, is_enabled: is_enabled, filter: inventory_filter?, id: inventory_id, included_object_versions: inventory_included_object_versions, optional_fields: inventory_optional_fields?, schedule: inventory_schedule }
-      type inventory_configuration_list = ::Array[InventoryConfiguration]
+      type inventory_configuration_list_output = ::Array[InventoryConfiguration]
       class InventoryDestination
         attr_accessor s3_bucket_destination: InventoryS3BucketDestination
       end
@@ -685,9 +688,10 @@ module Aws
         attr_accessor filter: NotificationConfigurationFilter
       end
       type lambda_function_configuration = { id: notification_id?, lambda_function_arn: lambda_function_arn, events: event_list, filter: notification_configuration_filter? }
-      type lambda_function_configuration_list = ::Array[LambdaFunctionConfiguration]
+      type lambda_function_configuration_list_output = ::Array[LambdaFunctionConfiguration]
+      type lambda_function_configuration_list_input = ::Array[lambda_function_configuration]
       type last_modified = ::Time
-      type lifecycle_configuration = { rules: rules }
+      type lifecycle_configuration = { rules: rules_input }
       class LifecycleExpiration
         attr_accessor date: date
         attr_accessor days: days
@@ -700,19 +704,19 @@ module Aws
         attr_accessor prefix: prefix
         attr_accessor filter: LifecycleRuleFilter
         attr_accessor status: expiration_status
-        attr_accessor transitions: transition_list
-        attr_accessor noncurrent_version_transitions: noncurrent_version_transition_list
+        attr_accessor transitions: transition_list_output
+        attr_accessor noncurrent_version_transitions: noncurrent_version_transition_list_output
         attr_accessor noncurrent_version_expiration: NoncurrentVersionExpiration
         attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
       end
-      type lifecycle_rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix?, filter: lifecycle_rule_filter?, status: expiration_status, transitions: transition_list?, noncurrent_version_transitions: noncurrent_version_transition_list?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
+      type lifecycle_rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix?, filter: lifecycle_rule_filter?, status: expiration_status, transitions: transition_list_input?, noncurrent_version_transitions: noncurrent_version_transition_list_input?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
       class LifecycleRuleAndOperator
         attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
+        attr_accessor tags: tag_set_output
         attr_accessor object_size_greater_than: object_size_greater_than_bytes
         attr_accessor object_size_less_than: object_size_less_than_bytes
       end
-      type lifecycle_rule_and_operator = { prefix: prefix?, tags: tag_set?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes? }
+      type lifecycle_rule_and_operator = { prefix: prefix?, tags: tag_set_input?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes? }
       class LifecycleRuleFilter
         attr_accessor prefix: prefix
         attr_accessor tag: Tag
@@ -721,22 +725,23 @@ module Aws
         attr_accessor and: LifecycleRuleAndOperator
       end
       type lifecycle_rule_filter = { prefix: prefix?, tag: tag?, object_size_greater_than: object_size_greater_than_bytes?, object_size_less_than: object_size_less_than_bytes?, and: lifecycle_rule_and_operator? }
-      type lifecycle_rules = ::Array[LifecycleRule]
+      type lifecycle_rules_output = ::Array[LifecycleRule]
+      type lifecycle_rules_input = ::Array[lifecycle_rule]
       class ListBucketAnalyticsConfigurationsOutput
         attr_accessor is_truncated: is_truncated
         attr_accessor continuation_token: token
         attr_accessor next_continuation_token: next_token
-        attr_accessor analytics_configuration_list: analytics_configuration_list
+        attr_accessor analytics_configuration_list: analytics_configuration_list_output
       end
       class ListBucketIntelligentTieringConfigurationsOutput
         attr_accessor is_truncated: is_truncated
         attr_accessor continuation_token: token
         attr_accessor next_continuation_token: next_token
-        attr_accessor intelligent_tiering_configuration_list: intelligent_tiering_configuration_list
+        attr_accessor intelligent_tiering_configuration_list: intelligent_tiering_configuration_list_output
       end
       class ListBucketInventoryConfigurationsOutput
         attr_accessor continuation_token: token
-        attr_accessor inventory_configuration_list: inventory_configuration_list
+        attr_accessor inventory_configuration_list: inventory_configuration_list_output
         attr_accessor is_truncated: is_truncated
         attr_accessor next_continuation_token: next_token
       end
@@ -744,7 +749,7 @@ module Aws
         attr_accessor is_truncated: is_truncated
         attr_accessor continuation_token: token
         attr_accessor next_continuation_token: next_token
-        attr_accessor metrics_configuration_list: metrics_configuration_list
+        attr_accessor metrics_configuration_list: metrics_configuration_list_output
       end
       class ListBucketsOutput
         attr_accessor buckets: buckets
@@ -825,10 +830,10 @@ module Aws
       type location_prefix = ::String
       class LoggingEnabled
         attr_accessor target_bucket: target_bucket
-        attr_accessor target_grants: target_grants
+        attr_accessor target_grants: target_grants_output
         attr_accessor target_prefix: target_prefix
       end
-      type logging_enabled = { target_bucket: target_bucket, target_grants: target_grants?, target_prefix: target_prefix }
+      type logging_enabled = { target_bucket: target_bucket, target_grants: target_grants_input?, target_prefix: target_prefix }
       type mfa = ::String
       type mfa_delete = ("Enabled" | "Disabled")
       type mfa_delete_status = ("Enabled" | "Disabled")
@@ -850,16 +855,16 @@ module Aws
       type metrics = { status: metrics_status, event_threshold: replication_time_value? }
       class MetricsAndOperator
         attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
+        attr_accessor tags: tag_set_output
         attr_accessor access_point_arn: access_point_arn
       end
-      type metrics_and_operator = { prefix: prefix?, tags: tag_set?, access_point_arn: access_point_arn? }
+      type metrics_and_operator = { prefix: prefix?, tags: tag_set_input?, access_point_arn: access_point_arn? }
       class MetricsConfiguration
         attr_accessor id: metrics_id
         attr_accessor filter: MetricsFilter
       end
       type metrics_configuration = { id: metrics_id, filter: metrics_filter? }
-      type metrics_configuration_list = ::Array[MetricsConfiguration]
+      type metrics_configuration_list_output = ::Array[MetricsConfiguration]
       class MetricsFilter
         attr_accessor prefix: prefix
         attr_accessor tag: Tag
@@ -898,14 +903,15 @@ module Aws
         attr_accessor newer_noncurrent_versions: version_count
       end
       type noncurrent_version_transition = { noncurrent_days: days?, storage_class: transition_storage_class?, newer_noncurrent_versions: version_count? }
-      type noncurrent_version_transition_list = ::Array[NoncurrentVersionTransition]
+      type noncurrent_version_transition_list_output = ::Array[NoncurrentVersionTransition]
+      type noncurrent_version_transition_list_input = ::Array[noncurrent_version_transition]
       class NotificationConfiguration
-        attr_accessor topic_configurations: topic_configuration_list
-        attr_accessor queue_configurations: queue_configuration_list
-        attr_accessor lambda_function_configurations: lambda_function_configuration_list
+        attr_accessor topic_configurations: topic_configuration_list_output
+        attr_accessor queue_configurations: queue_configuration_list_output
+        attr_accessor lambda_function_configurations: lambda_function_configuration_list_output
         attr_accessor event_bridge_configuration: EventBridgeConfiguration
       end
-      type notification_configuration = { topic_configurations: topic_configuration_list?, queue_configurations: queue_configuration_list?, lambda_function_configurations: lambda_function_configuration_list?, event_bridge_configuration: event_bridge_configuration? }
+      type notification_configuration = { topic_configurations: topic_configuration_list_input?, queue_configurations: queue_configuration_list_input?, lambda_function_configurations: lambda_function_configuration_list_input?, event_bridge_configuration: event_bridge_configuration? }
       class NotificationConfigurationDeprecated
         attr_accessor topic_configuration: TopicConfigurationDeprecated
         attr_accessor queue_configuration: QueueConfigurationDeprecated
@@ -981,14 +987,15 @@ module Aws
       type owner = { display_name: display_name?, id: id? }
       type owner_override = ("Destination")
       class OwnershipControls
-        attr_accessor rules: ownership_controls_rules
+        attr_accessor rules: ownership_controls_rules_output
       end
-      type ownership_controls = { rules: ownership_controls_rules }
+      type ownership_controls = { rules: ownership_controls_rules_input }
       class OwnershipControlsRule
         attr_accessor object_ownership: object_ownership
       end
       type ownership_controls_rule = { object_ownership: object_ownership }
-      type ownership_controls_rules = ::Array[OwnershipControlsRule]
+      type ownership_controls_rules_output = ::Array[OwnershipControlsRule]
+      type ownership_controls_rules_input = ::Array[ownership_controls_rule]
       type parquet_input = ::Hash[untyped, untyped]
       class Part
         attr_accessor part_number: part_number
@@ -1066,7 +1073,8 @@ module Aws
         attr_accessor queue: queue_arn
       end
       type queue_configuration_deprecated = { id: notification_id?, event: event?, events: event_list?, queue: queue_arn? }
-      type queue_configuration_list = ::Array[QueueConfiguration]
+      type queue_configuration_list_output = ::Array[QueueConfiguration]
+      type queue_configuration_list_input = ::Array[queue_configuration]
       type quiet = bool
       type quote_character = ::String
       type quote_escape_character = ::String
@@ -1099,9 +1107,9 @@ module Aws
       type replica_modifications_status = ("Enabled" | "Disabled")
       class ReplicationConfiguration
         attr_accessor role: role
-        attr_accessor rules: replication_rules
+        attr_accessor rules: replication_rules_output
       end
-      type replication_configuration = { role: role, rules: replication_rules }
+      type replication_configuration = { role: role, rules: replication_rules_input }
       class ReplicationRule
         attr_accessor id: id
         attr_accessor priority: priority
@@ -1116,9 +1124,9 @@ module Aws
       type replication_rule = { id: id?, priority: priority?, prefix: prefix?, filter: replication_rule_filter?, status: replication_rule_status, source_selection_criteria: source_selection_criteria?, existing_object_replication: existing_object_replication?, destination: destination, delete_marker_replication: delete_marker_replication? }
       class ReplicationRuleAndOperator
         attr_accessor prefix: prefix
-        attr_accessor tags: tag_set
+        attr_accessor tags: tag_set_output
       end
-      type replication_rule_and_operator = { prefix: prefix?, tags: tag_set? }
+      type replication_rule_and_operator = { prefix: prefix?, tags: tag_set_input? }
       class ReplicationRuleFilter
         attr_accessor prefix: prefix
         attr_accessor tag: Tag
@@ -1126,7 +1134,8 @@ module Aws
       end
       type replication_rule_filter = { prefix: prefix?, tag: tag?, and: replication_rule_and_operator? }
       type replication_rule_status = ("Enabled" | "Disabled")
-      type replication_rules = ::Array[ReplicationRule]
+      type replication_rules_output = ::Array[ReplicationRule]
+      type replication_rules_input = ::Array[replication_rule]
       type replication_status = ("COMPLETE" | "PENDING" | "FAILED" | "REPLICA")
       class ReplicationTime
         attr_accessor status: replication_time_status
@@ -1164,7 +1173,8 @@ module Aws
         attr_accessor redirect: Redirect
       end
       type routing_rule = { condition: condition?, redirect: redirect }
-      type routing_rules = ::Array[RoutingRule]
+      type routing_rules_output = ::Array[RoutingRule]
+      type routing_rules_input = ::Array[routing_rule]
       class Rule
         attr_accessor expiration: LifecycleExpiration
         attr_accessor id: id
@@ -1176,12 +1186,13 @@ module Aws
         attr_accessor abort_incomplete_multipart_upload: AbortIncompleteMultipartUpload
       end
       type rule = { expiration: lifecycle_expiration?, id: id?, prefix: prefix, status: expiration_status, transition: transition?, noncurrent_version_transition: noncurrent_version_transition?, noncurrent_version_expiration: noncurrent_version_expiration?, abort_incomplete_multipart_upload: abort_incomplete_multipart_upload? }
-      type rules = ::Array[Rule]
+      type rules_output = ::Array[Rule]
+      type rules_input = ::Array[rule]
       class S3KeyFilter
-        attr_accessor filter_rules: filter_rule_list
+        attr_accessor filter_rules: filter_rule_list_output
       end
-      type s3_key_filter = { filter_rules: filter_rule_list? }
-      type s3_location = { bucket_name: bucket_name, prefix: location_prefix, encryption: encryption?, canned_acl: object_canned_acl?, access_control_list: grants?, tagging: tagging?, user_metadata: user_metadata?, storage_class: storage_class? }
+      type s3_key_filter = { filter_rules: filter_rule_list_input? }
+      type s3_location = { bucket_name: bucket_name, prefix: location_prefix, encryption: encryption?, canned_acl: object_canned_acl?, access_control_list: grants_input?, tagging: tagging?, user_metadata: user_metadata?, storage_class: storage_class? }
       type sse_customer_algorithm = ::String
       type sse_customer_key = ::String
       type sse_customer_key_md5 = ::String
@@ -1213,15 +1224,16 @@ module Aws
       end
       type server_side_encryption_by_default = { sse_algorithm: server_side_encryption, kms_master_key_id: ssekms_key_id? }
       class ServerSideEncryptionConfiguration
-        attr_accessor rules: server_side_encryption_rules
+        attr_accessor rules: server_side_encryption_rules_output
       end
-      type server_side_encryption_configuration = { rules: server_side_encryption_rules }
+      type server_side_encryption_configuration = { rules: server_side_encryption_rules_input }
       class ServerSideEncryptionRule
         attr_accessor apply_server_side_encryption_by_default: ServerSideEncryptionByDefault
         attr_accessor bucket_key_enabled: bucket_key_enabled
       end
       type server_side_encryption_rule = { apply_server_side_encryption_by_default: server_side_encryption_by_default?, bucket_key_enabled: bucket_key_enabled? }
-      type server_side_encryption_rules = ::Array[ServerSideEncryptionRule]
+      type server_side_encryption_rules_output = ::Array[ServerSideEncryptionRule]
+      type server_side_encryption_rules_input = ::Array[server_side_encryption_rule]
       type setting = bool
       type size = ::Integer
       type skip_validation = bool
@@ -1263,8 +1275,9 @@ module Aws
       end
       type tag = { key: object_key, value: value }
       type tag_count = ::Integer
-      type tag_set = ::Array[Tag]
-      type tagging = { tag_set: tag_set }
+      type tag_set_output = ::Array[Tag]
+      type tag_set_input = ::Array[tag]
+      type tagging = { tag_set: tag_set_input }
       type tagging_directive = ("COPY" | "REPLACE")
       type tagging_header = ::String
       type target_bucket = ::String
@@ -1273,7 +1286,8 @@ module Aws
         attr_accessor permission: bucket_logs_permission
       end
       type target_grant = { grantee: grantee?, permission: bucket_logs_permission? }
-      type target_grants = ::Array[TargetGrant]
+      type target_grants_output = ::Array[TargetGrant]
+      type target_grants_input = ::Array[target_grant]
       type target_prefix = ::String
       type tier = ("Standard" | "Bulk" | "Expedited")
       class Tiering
@@ -1281,7 +1295,8 @@ module Aws
         attr_accessor access_tier: intelligent_tiering_access_tier
       end
       type tiering = { days: intelligent_tiering_days, access_tier: intelligent_tiering_access_tier }
-      type tiering_list = ::Array[Tiering]
+      type tiering_list_output = ::Array[Tiering]
+      type tiering_list_input = ::Array[tiering]
       type token = ::String
       type topic_arn = ::String
       class TopicConfiguration
@@ -1298,14 +1313,16 @@ module Aws
         attr_accessor topic: topic_arn
       end
       type topic_configuration_deprecated = { id: notification_id?, events: event_list?, event: event?, topic: topic_arn? }
-      type topic_configuration_list = ::Array[TopicConfiguration]
+      type topic_configuration_list_output = ::Array[TopicConfiguration]
+      type topic_configuration_list_input = ::Array[topic_configuration]
       class Transition
         attr_accessor date: date
         attr_accessor days: days
         attr_accessor storage_class: transition_storage_class
       end
       type transition = { date: date?, days: days?, storage_class: transition_storage_class? }
-      type transition_list = ::Array[Transition]
+      type transition_list_output = ::Array[Transition]
+      type transition_list_input = ::Array[transition]
       type transition_storage_class = ("GLACIER" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "DEEP_ARCHIVE" | "GLACIER_IR")
       type type_ = ("CanonicalUser" | "AmazonCustomerByEmail" | "Group")
       type uri = ::String
@@ -1334,7 +1351,7 @@ module Aws
       type version_count = ::Integer
       type version_id_marker = ::String
       type versioning_configuration = { mfa_delete: mfa_delete?, status: bucket_versioning_status? }
-      type website_configuration = { error_document: error_document?, index_document: index_document?, redirect_all_requests_to: redirect_all_requests_to?, routing_rules: routing_rules? }
+      type website_configuration = { error_document: error_document?, index_document: index_document?, redirect_all_requests_to: redirect_all_requests_to?, routing_rules: routing_rules_input? }
       type website_redirect_location = ::String
       type years = ::Integer
     end

--- a/gems/aws-sdk-s3/1/_scripts/test
+++ b/gems/aws-sdk-s3/1/_scripts/test
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'
+	'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r aws-sdk-core:3 -r aws-sdk-s3:1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/aws-sdk-s3/1/_test/test.rb
+++ b/gems/aws-sdk-s3/1/_test/test.rb
@@ -10,11 +10,12 @@ end
 
 begin
   resp = Aws::S3::Client.new.get_object(bucket: 'test', key: 'test')
-  resp.body.read
-rescue Aws::S3::Errors::InvalidObjectState => e
+  resp.body.read # check streaming
+rescue Aws::S3::Errors::InvalidObjectState => e # check Errors
   e.storage_class.downcase
 end
 
+# check simple input
 resp = client.put_object(
   bucket: 'test',
   key: 'test',
@@ -22,21 +23,27 @@ resp = client.put_object(
 )
 resp.etag.tr('', '')
 
-resp = client.complete_multipart_upload(
-  bucket: "examplebucket",
-  key: "bigobject",
-  multipart_upload: {
-    parts: [
+# check CORSRules input and output type
+client.put_bucket_cors(
+  bucket: "BucketName", # required
+  cors_configuration: { # required
+    cors_rules: [ # required
       {
-        etag: "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
-        part_number: 1,
-      },
-      {
-        etag: "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
-        part_number: 2,
+        id: "ID",
+        allowed_headers: ["AllowedHeader"],
+        allowed_methods: ["AllowedMethod"], # required
+        allowed_origins: ["AllowedOrigin"], # required
+        # expose_headers: ["ExposeHeader"], # check option
+        max_age_seconds: 1,
       },
     ],
   },
-  upload_id: "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP3WA60CEg--",
+  content_md5: "ContentMD5",
+  expected_bucket_owner: "AccountId",
 )
-resp.location.upcase
+resp = client.get_bucket_cors(
+  bucket: "BucketName", # required
+  expected_bucket_owner: "AccountId",
+)
+resp.cors_rules[0].allowed_headers[0].upcase
+

--- a/gems/aws-sdk-s3/1/_test/test.rb
+++ b/gems/aws-sdk-s3/1/_test/test.rb
@@ -22,3 +22,21 @@ resp = client.put_object(
 )
 resp.etag.tr('', '')
 
+resp = client.complete_multipart_upload(
+  bucket: "examplebucket",
+  key: "bigobject",
+  multipart_upload: {
+    parts: [
+      {
+        etag: "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
+        part_number: 1,
+      },
+      {
+        etag: "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
+        part_number: 2,
+      },
+    ],
+  },
+  upload_id: "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP3WA60CEg--",
+)
+resp.location.upcase

--- a/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs
+++ b/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs
@@ -31,268 +31,157 @@ module Aws
       def untag_queue: (queue_url: Types::string, tag_keys: Types::tag_key_list) -> Aws::EmptyStructure
     end
     module Types
+      # inputs
+      type string = ::String
       type aws_account_id_list = ::Array[string]
       type action_name_list = ::Array[string]
-      class AddPermissionRequest
-        attr_accessor queue_url: ::String
-        attr_accessor label: ::String
-        attr_accessor aws_account_ids: ::Array[string]
-        attr_accessor actions: ::Array[string]
-      end
-      type attribute_name_list = ::Array[queue_attribute_name]
-      class BatchResultErrorEntry
-        attr_accessor id: ::String
-        attr_accessor sender_fault: bool
-        attr_accessor code: ::String
-        attr_accessor message: ::String
-      end
-      type batch_result_error_entry_list = ::Array[BatchResultErrorEntry]
-      type binary = ::IO
-      type binary_list = ::Array[binary]
-      type boolean = bool
-      type boxed_integer = ::Integer
-      class ChangeMessageVisibilityBatchRequest
-        attr_accessor queue_url: ::String
-        attr_accessor entries: ::Array[ChangeMessageVisibilityBatchRequestEntry]
-      end
-      class ChangeMessageVisibilityBatchRequestEntry
-        attr_accessor id: ::String
-        attr_accessor receipt_handle: ::String
-        attr_accessor visibility_timeout: ::Integer
-      end
-      type change_message_visibility_batch_request_entry_list = ::Array[ChangeMessageVisibilityBatchRequestEntry]
-      class ChangeMessageVisibilityBatchResult
-        attr_accessor successful: ::Array[ChangeMessageVisibilityBatchResultEntry]
-        attr_accessor failed: ::Array[BatchResultErrorEntry]
-      end
-      class ChangeMessageVisibilityBatchResultEntry
-        attr_accessor id: ::String
-      end
-      type change_message_visibility_batch_result_entry_list = ::Array[ChangeMessageVisibilityBatchResultEntry]
-      class ChangeMessageVisibilityRequest
-        attr_accessor queue_url: ::String
-        attr_accessor receipt_handle: ::String
-        attr_accessor visibility_timeout: ::Integer
-      end
-      class CreateQueueRequest
-        attr_accessor queue_name: ::String
-        attr_accessor attributes: ::Hash[queue_attribute_name, string]
-        attr_accessor tags: ::Hash[tag_key, tag_value]
-      end
-      class CreateQueueResult
-        attr_accessor queue_url: ::String
-      end
-      class DeleteMessageBatchRequest
-        attr_accessor queue_url: ::String
-        attr_accessor entries: ::Array[DeleteMessageBatchRequestEntry]
-      end
-      class DeleteMessageBatchRequestEntry
-        attr_accessor id: ::String
-        attr_accessor receipt_handle: ::String
-      end
-      type delete_message_batch_request_entry_list = ::Array[DeleteMessageBatchRequestEntry]
-      class DeleteMessageBatchResult
-        attr_accessor successful: ::Array[DeleteMessageBatchResultEntry]
-        attr_accessor failed: ::Array[BatchResultErrorEntry]
-      end
-      class DeleteMessageBatchResultEntry
-        attr_accessor id: ::String
-      end
-      type delete_message_batch_result_entry_list = ::Array[DeleteMessageBatchResultEntry]
-      class DeleteMessageRequest
-        attr_accessor queue_url: ::String
-        attr_accessor receipt_handle: ::String
-      end
-      class DeleteQueueRequest
-        attr_accessor queue_url: ::String
-      end
-      class GetQueueAttributesRequest
-        attr_accessor queue_url: ::String
-        attr_accessor attribute_names: ::Array[queue_attribute_name]
-      end
-      class GetQueueAttributesResult
-        attr_accessor attributes: ::Hash[queue_attribute_name, string]
-      end
-      class GetQueueUrlRequest
-        attr_accessor queue_name: ::String
-        attr_accessor queue_owner_aws_account_id: ::String
-      end
-      class GetQueueUrlResult
-        attr_accessor queue_url: ::String
-      end
       type integer = ::Integer
-      class ListDeadLetterSourceQueuesRequest
-        attr_accessor queue_url: ::String
-        attr_accessor next_token: ::String
-        attr_accessor max_results: ::Integer
-      end
-      class ListDeadLetterSourceQueuesResult
-        attr_accessor queue_urls: ::Array[string]
-        attr_accessor next_token: ::String
-      end
-      class ListQueueTagsRequest
-        attr_accessor queue_url: ::String
-      end
-      class ListQueueTagsResult
-        attr_accessor tags: ::Hash[tag_key, tag_value]
-      end
-      class ListQueuesRequest
-        attr_accessor queue_name_prefix: ::String
-        attr_accessor next_token: ::String
-        attr_accessor max_results: ::Integer
-      end
-      class ListQueuesResult
-        attr_accessor queue_urls: ::Array[string]
-        attr_accessor next_token: ::String
-      end
-      class Message
-        attr_accessor message_id: ::String
-        attr_accessor receipt_handle: ::String
-        attr_accessor md5_of_body: ::String
-        attr_accessor body: ::String
-        attr_accessor attributes: ::Hash[message_system_attribute_name, string]
-        attr_accessor md5_of_message_attributes: ::String
-        attr_accessor message_attributes: ::Hash[string, MessageAttributeValue]
-      end
-      type message_attribute_name = ::String
-      type message_attribute_name_list = ::Array[message_attribute_name]
-      class MessageAttributeValue
-        attr_accessor string_value: ::String
-        attr_accessor binary_value: ::IO
-        attr_accessor string_list_values: ::Array[string]
-        attr_accessor binary_list_values: ::Array[binary]
-        attr_accessor data_type: ::String
-      end
-      type message_body_attribute_map = ::Hash[string, MessageAttributeValue]
-      type message_body_system_attribute_map = ::Hash[message_system_attribute_name_for_sends, MessageSystemAttributeValue]
-      type message_list = ::Array[Message]
-      type message_system_attribute_map = ::Hash[message_system_attribute_name, string]
-      type message_system_attribute_name = ("SenderId" | "SentTimestamp" | "ApproximateReceiveCount" | "ApproximateFirstReceiveTimestamp" | "SequenceNumber" | "MessageDeduplicationId" | "MessageGroupId" | "AWSTraceHeader")
-      type message_system_attribute_name_for_sends = ("AWSTraceHeader")
-      class MessageSystemAttributeValue
-        attr_accessor string_value: ::String
-        attr_accessor binary_value: ::IO
-        attr_accessor string_list_values: ::Array[string]
-        attr_accessor binary_list_values: ::Array[binary]
-        attr_accessor data_type: ::String
-      end
-      class PurgeQueueRequest
-        attr_accessor queue_url: ::String
-      end
+      type change_message_visibility_batch_request_entry_list = ::Array[change_message_visibility_batch_request_entry]
+      type change_message_visibility_batch_request_entry = { id: string, receipt_handle: string, visibility_timeout: integer? }
       type queue_attribute_map = ::Hash[queue_attribute_name, string]
       type queue_attribute_name = ("All" | "Policy" | "VisibilityTimeout" | "MaximumMessageSize" | "MessageRetentionPeriod" | "ApproximateNumberOfMessages" | "ApproximateNumberOfMessagesNotVisible" | "CreatedTimestamp" | "LastModifiedTimestamp" | "QueueArn" | "ApproximateNumberOfMessagesDelayed" | "DelaySeconds" | "ReceiveMessageWaitTimeSeconds" | "RedrivePolicy" | "FifoQueue" | "ContentBasedDeduplication" | "KmsMasterKeyId" | "KmsDataKeyReusePeriodSeconds" | "DeduplicationScope" | "FifoThroughputLimit" | "RedriveAllowPolicy" | "SqsManagedSseEnabled")
+      type tag_map = ::Hash[tag_key, tag_value]
+      type tag_key = ::String
+      type tag_value = ::String
+      type delete_message_batch_request_entry_list = ::Array[delete_message_batch_request_entry]
+      type delete_message_batch_request_entry = { id: string, receipt_handle: string }
+      type attribute_name_list = ::Array[queue_attribute_name]
+      type token = ::String
+      type boxed_integer = ::Integer
+      type message_attribute_name_list = ::Array[message_attribute_name]
+      type message_attribute_name = ::String
+      type message_body_attribute_map = ::Hash[string, message_attribute_value]
+      type message_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
+      type binary = ::String
+      type string_list = ::Array[string]
+      type binary_list = ::Array[binary]
+      type message_body_system_attribute_map = ::Hash[message_system_attribute_name_for_sends, message_system_attribute_value]
+      type message_system_attribute_name_for_sends = ("AWSTraceHeader")
+      type message_system_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
+      type send_message_batch_request_entry_list = ::Array[send_message_batch_request_entry]
+      type send_message_batch_request_entry = { id: string, message_body: string, delay_seconds: integer?, message_attributes: message_body_attribute_map?, message_system_attributes: message_body_system_attribute_map?, message_deduplication_id: string?, message_group_id: string? }
+      type tag_key_list = ::Array[tag_key]
+      # outputs
+      class ChangeMessageVisibilityBatchResult
+        attr_accessor successful: change_message_visibility_batch_result_entry_list
+        attr_accessor failed: batch_result_error_entry_list
+      end
+      type change_message_visibility_batch_result_entry_list = ::Array[ChangeMessageVisibilityBatchResultEntry]
+      class ChangeMessageVisibilityBatchResultEntry
+        attr_accessor id: string
+      end
+      type batch_result_error_entry_list = ::Array[BatchResultErrorEntry]
+      class BatchResultErrorEntry
+        attr_accessor id: string
+        attr_accessor sender_fault: boolean
+        attr_accessor code: string
+        attr_accessor message: string
+      end
+      type boolean = bool
+      class CreateQueueResult
+        attr_accessor queue_url: string
+      end
+      class DeleteMessageBatchResult
+        attr_accessor successful: delete_message_batch_result_entry_list
+        attr_accessor failed: batch_result_error_entry_list
+      end
+      type delete_message_batch_result_entry_list = ::Array[DeleteMessageBatchResultEntry]
+      class DeleteMessageBatchResultEntry
+        attr_accessor id: string
+      end
+      class GetQueueAttributesResult
+        attr_accessor attributes: queue_attribute_map
+      end
+      class GetQueueUrlResult
+        attr_accessor queue_url: string
+      end
+      class ListDeadLetterSourceQueuesResult
+        attr_accessor queue_urls: queue_url_list
+        attr_accessor next_token: token
+      end
       type queue_url_list = ::Array[string]
-      class ReceiveMessageRequest
-        attr_accessor queue_url: ::String
-        attr_accessor attribute_names: ::Array[queue_attribute_name]
-        attr_accessor message_attribute_names: ::Array[message_attribute_name]
-        attr_accessor max_number_of_messages: ::Integer
-        attr_accessor visibility_timeout: ::Integer
-        attr_accessor wait_time_seconds: ::Integer
-        attr_accessor receive_request_attempt_id: ::String
+      class ListQueueTagsResult
+        attr_accessor tags: tag_map
+      end
+      class ListQueuesResult
+        attr_accessor queue_urls: queue_url_list
+        attr_accessor next_token: token
       end
       class ReceiveMessageResult
-        attr_accessor messages: ::Array[Message]
+        attr_accessor messages: message_list
       end
-      class RemovePermissionRequest
-        attr_accessor queue_url: ::String
-        attr_accessor label: ::String
+      type message_list = ::Array[Message]
+      class Message
+        attr_accessor message_id: string
+        attr_accessor receipt_handle: string
+        attr_accessor md5_of_body: string
+        attr_accessor body: string
+        attr_accessor attributes: message_system_attribute_map
+        attr_accessor md5_of_message_attributes: string
+        attr_accessor message_attributes: message_body_attribute_map
       end
-      class SendMessageBatchRequest
-        attr_accessor queue_url: ::String
-        attr_accessor entries: ::Array[SendMessageBatchRequestEntry]
-      end
-      class SendMessageBatchRequestEntry
-        attr_accessor id: ::String
-        attr_accessor message_body: ::String
-        attr_accessor delay_seconds: ::Integer
-        attr_accessor message_attributes: ::Hash[string, MessageAttributeValue]
-        attr_accessor message_system_attributes: ::Hash[message_system_attribute_name_for_sends, MessageSystemAttributeValue]
-        attr_accessor message_deduplication_id: ::String
-        attr_accessor message_group_id: ::String
-      end
-      type send_message_batch_request_entry_list = ::Array[SendMessageBatchRequestEntry]
-      class SendMessageBatchResult
-        attr_accessor successful: ::Array[SendMessageBatchResultEntry]
-        attr_accessor failed: ::Array[BatchResultErrorEntry]
-      end
-      class SendMessageBatchResultEntry
-        attr_accessor id: ::String
-        attr_accessor message_id: ::String
-        attr_accessor md5_of_message_body: ::String
-        attr_accessor md5_of_message_attributes: ::String
-        attr_accessor md5_of_message_system_attributes: ::String
-        attr_accessor sequence_number: ::String
-      end
-      type send_message_batch_result_entry_list = ::Array[SendMessageBatchResultEntry]
-      class SendMessageRequest
-        attr_accessor queue_url: ::String
-        attr_accessor message_body: ::String
-        attr_accessor delay_seconds: ::Integer
-        attr_accessor message_attributes: ::Hash[string, MessageAttributeValue]
-        attr_accessor message_system_attributes: ::Hash[message_system_attribute_name_for_sends, MessageSystemAttributeValue]
-        attr_accessor message_deduplication_id: ::String
-        attr_accessor message_group_id: ::String
+      type message_system_attribute_map = ::Hash[message_system_attribute_name, string]
+      type message_system_attribute_name = ("SenderId" | "SentTimestamp" | "ApproximateReceiveCount" | "ApproximateFirstReceiveTimestamp" | "SequenceNumber" | "MessageDeduplicationId" | "MessageGroupId" | "AWSTraceHeader")
+      class MessageAttributeValue
+        attr_accessor string_value: string
+        attr_accessor binary_value: binary
+        attr_accessor string_list_values: string_list
+        attr_accessor binary_list_values: binary_list
+        attr_accessor data_type: string
       end
       class SendMessageResult
-        attr_accessor md5_of_message_body: ::String
-        attr_accessor md5_of_message_attributes: ::String
-        attr_accessor md5_of_message_system_attributes: ::String
-        attr_accessor message_id: ::String
-        attr_accessor sequence_number: ::String
+        attr_accessor md5_of_message_body: string
+        attr_accessor md5_of_message_attributes: string
+        attr_accessor md5_of_message_system_attributes: string
+        attr_accessor message_id: string
+        attr_accessor sequence_number: string
       end
-      class SetQueueAttributesRequest
-        attr_accessor queue_url: ::String
-        attr_accessor attributes: ::Hash[queue_attribute_name, string]
+      class SendMessageBatchResult
+        attr_accessor successful: send_message_batch_result_entry_list
+        attr_accessor failed: batch_result_error_entry_list
       end
-      type string = ::String
-      type string_list = ::Array[string]
-      type tag_key = ::String
-      type tag_key_list = ::Array[tag_key]
-      type tag_map = ::Hash[tag_key, tag_value]
-      class TagQueueRequest
-        attr_accessor queue_url: ::String
-        attr_accessor tags: ::Hash[tag_key, tag_value]
-      end
-      type tag_value = ::String
-      type token = ::String
-      class UntagQueueRequest
-        attr_accessor queue_url: ::String
-        attr_accessor tag_keys: ::Array[tag_key]
+      type send_message_batch_result_entry_list = ::Array[SendMessageBatchResultEntry]
+      class SendMessageBatchResultEntry
+        attr_accessor id: string
+        attr_accessor message_id: string
+        attr_accessor md5_of_message_body: string
+        attr_accessor md5_of_message_attributes: string
+        attr_accessor md5_of_message_system_attributes: string
+        attr_accessor sequence_number: string
       end
     end
     module Errors
-      class BatchEntryIdsNotDistinct < RuntimeError
+      class BatchEntryIdsNotDistinct < ::RuntimeError
       end
-      class BatchRequestTooLong < RuntimeError
+      class BatchRequestTooLong < ::RuntimeError
       end
-      class EmptyBatchRequest < RuntimeError
+      class EmptyBatchRequest < ::RuntimeError
       end
-      class InvalidAttributeName < RuntimeError
+      class InvalidAttributeName < ::RuntimeError
       end
-      class InvalidBatchEntryId < RuntimeError
+      class InvalidBatchEntryId < ::RuntimeError
       end
-      class InvalidIdFormat < RuntimeError
+      class InvalidIdFormat < ::RuntimeError
       end
-      class InvalidMessageContents < RuntimeError
+      class InvalidMessageContents < ::RuntimeError
       end
-      class MessageNotInflight < RuntimeError
+      class MessageNotInflight < ::RuntimeError
       end
-      class OverLimit < RuntimeError
+      class OverLimit < ::RuntimeError
       end
-      class PurgeQueueInProgress < RuntimeError
+      class PurgeQueueInProgress < ::RuntimeError
       end
-      class QueueDeletedRecently < RuntimeError
+      class QueueDeletedRecently < ::RuntimeError
       end
-      class QueueDoesNotExist < RuntimeError
+      class QueueDoesNotExist < ::RuntimeError
       end
-      class QueueNameExists < RuntimeError
+      class QueueNameExists < ::RuntimeError
       end
-      class ReceiptHandleIsInvalid < RuntimeError
+      class ReceiptHandleIsInvalid < ::RuntimeError
       end
-      class TooManyEntriesInBatchRequest < RuntimeError
+      class TooManyEntriesInBatchRequest < ::RuntimeError
       end
-      class UnsupportedOperation < RuntimeError
+      class UnsupportedOperation < ::RuntimeError
       end
     end
   end

--- a/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs
+++ b/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs
@@ -31,75 +31,54 @@ module Aws
       def untag_queue: (queue_url: Types::string, tag_keys: Types::tag_key_list) -> Aws::EmptyStructure
     end
     module Types
-      # inputs
-      type string = ::String
       type aws_account_id_list = ::Array[string]
       type action_name_list = ::Array[string]
-      type integer = ::Integer
-      type change_message_visibility_batch_request_entry_list = ::Array[change_message_visibility_batch_request_entry]
-      type change_message_visibility_batch_request_entry = { id: string, receipt_handle: string, visibility_timeout: integer? }
-      type queue_attribute_map = ::Hash[queue_attribute_name, string]
-      type queue_attribute_name = ("All" | "Policy" | "VisibilityTimeout" | "MaximumMessageSize" | "MessageRetentionPeriod" | "ApproximateNumberOfMessages" | "ApproximateNumberOfMessagesNotVisible" | "CreatedTimestamp" | "LastModifiedTimestamp" | "QueueArn" | "ApproximateNumberOfMessagesDelayed" | "DelaySeconds" | "ReceiveMessageWaitTimeSeconds" | "RedrivePolicy" | "FifoQueue" | "ContentBasedDeduplication" | "KmsMasterKeyId" | "KmsDataKeyReusePeriodSeconds" | "DeduplicationScope" | "FifoThroughputLimit" | "RedriveAllowPolicy" | "SqsManagedSseEnabled")
-      type tag_map = ::Hash[tag_key, tag_value]
-      type tag_key = ::String
-      type tag_value = ::String
-      type delete_message_batch_request_entry_list = ::Array[delete_message_batch_request_entry]
-      type delete_message_batch_request_entry = { id: string, receipt_handle: string }
       type attribute_name_list = ::Array[queue_attribute_name]
-      type token = ::String
-      type boxed_integer = ::Integer
-      type message_attribute_name_list = ::Array[message_attribute_name]
-      type message_attribute_name = ::String
-      type message_body_attribute_map = ::Hash[string, message_attribute_value]
-      type message_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
-      type binary = ::String
-      type string_list = ::Array[string]
-      type binary_list = ::Array[binary]
-      type message_body_system_attribute_map = ::Hash[message_system_attribute_name_for_sends, message_system_attribute_value]
-      type message_system_attribute_name_for_sends = ("AWSTraceHeader")
-      type message_system_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
-      type send_message_batch_request_entry_list = ::Array[send_message_batch_request_entry]
-      type send_message_batch_request_entry = { id: string, message_body: string, delay_seconds: integer?, message_attributes: message_body_attribute_map?, message_system_attributes: message_body_system_attribute_map?, message_deduplication_id: string?, message_group_id: string? }
-      type tag_key_list = ::Array[tag_key]
-      # outputs
-      class ChangeMessageVisibilityBatchResult
-        attr_accessor successful: change_message_visibility_batch_result_entry_list
-        attr_accessor failed: batch_result_error_entry_list
-      end
-      type change_message_visibility_batch_result_entry_list = ::Array[ChangeMessageVisibilityBatchResultEntry]
-      class ChangeMessageVisibilityBatchResultEntry
-        attr_accessor id: string
-      end
-      type batch_result_error_entry_list = ::Array[BatchResultErrorEntry]
       class BatchResultErrorEntry
         attr_accessor id: string
         attr_accessor sender_fault: boolean
         attr_accessor code: string
         attr_accessor message: string
       end
+      type batch_result_error_entry_list = ::Array[BatchResultErrorEntry]
+      type binary = ::String
+      type binary_list = ::Array[binary]
       type boolean = bool
+      type boxed_integer = ::Integer
+      type change_message_visibility_batch_request_entry = { id: string, receipt_handle: string, visibility_timeout: integer? }
+      type change_message_visibility_batch_request_entry_list = ::Array[change_message_visibility_batch_request_entry]
+      class ChangeMessageVisibilityBatchResult
+        attr_accessor successful: change_message_visibility_batch_result_entry_list
+        attr_accessor failed: batch_result_error_entry_list
+      end
+      class ChangeMessageVisibilityBatchResultEntry
+        attr_accessor id: string
+      end
+      type change_message_visibility_batch_result_entry_list = ::Array[ChangeMessageVisibilityBatchResultEntry]
       class CreateQueueResult
         attr_accessor queue_url: string
       end
+      type delete_message_batch_request_entry = { id: string, receipt_handle: string }
+      type delete_message_batch_request_entry_list = ::Array[delete_message_batch_request_entry]
       class DeleteMessageBatchResult
         attr_accessor successful: delete_message_batch_result_entry_list
         attr_accessor failed: batch_result_error_entry_list
       end
-      type delete_message_batch_result_entry_list = ::Array[DeleteMessageBatchResultEntry]
       class DeleteMessageBatchResultEntry
         attr_accessor id: string
       end
+      type delete_message_batch_result_entry_list = ::Array[DeleteMessageBatchResultEntry]
       class GetQueueAttributesResult
         attr_accessor attributes: queue_attribute_map
       end
       class GetQueueUrlResult
         attr_accessor queue_url: string
       end
+      type integer = ::Integer
       class ListDeadLetterSourceQueuesResult
         attr_accessor queue_urls: queue_url_list
         attr_accessor next_token: token
       end
-      type queue_url_list = ::Array[string]
       class ListQueueTagsResult
         attr_accessor tags: tag_map
       end
@@ -107,10 +86,6 @@ module Aws
         attr_accessor queue_urls: queue_url_list
         attr_accessor next_token: token
       end
-      class ReceiveMessageResult
-        attr_accessor messages: message_list
-      end
-      type message_list = ::Array[Message]
       class Message
         attr_accessor message_id: string
         attr_accessor receipt_handle: string
@@ -120,8 +95,8 @@ module Aws
         attr_accessor md5_of_message_attributes: string
         attr_accessor message_attributes: message_body_attribute_map
       end
-      type message_system_attribute_map = ::Hash[message_system_attribute_name, string]
-      type message_system_attribute_name = ("SenderId" | "SentTimestamp" | "ApproximateReceiveCount" | "ApproximateFirstReceiveTimestamp" | "SequenceNumber" | "MessageDeduplicationId" | "MessageGroupId" | "AWSTraceHeader")
+      type message_attribute_name = ::String
+      type message_attribute_name_list = ::Array[message_attribute_name]
       class MessageAttributeValue
         attr_accessor string_value: string
         attr_accessor binary_value: binary
@@ -129,18 +104,26 @@ module Aws
         attr_accessor binary_list_values: binary_list
         attr_accessor data_type: string
       end
-      class SendMessageResult
-        attr_accessor md5_of_message_body: string
-        attr_accessor md5_of_message_attributes: string
-        attr_accessor md5_of_message_system_attributes: string
-        attr_accessor message_id: string
-        attr_accessor sequence_number: string
+      type message_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
+      type message_body_attribute_map = ::Hash[string, MessageAttributeValue]
+      type message_body_system_attribute_map = ::Hash[message_system_attribute_name_for_sends, message_system_attribute_value]
+      type message_list = ::Array[Message]
+      type message_system_attribute_map = ::Hash[message_system_attribute_name, string]
+      type message_system_attribute_name = ("SenderId" | "SentTimestamp" | "ApproximateReceiveCount" | "ApproximateFirstReceiveTimestamp" | "SequenceNumber" | "MessageDeduplicationId" | "MessageGroupId" | "AWSTraceHeader")
+      type message_system_attribute_name_for_sends = ("AWSTraceHeader")
+      type message_system_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
+      type queue_attribute_map = ::Hash[queue_attribute_name, string]
+      type queue_attribute_name = ("All" | "Policy" | "VisibilityTimeout" | "MaximumMessageSize" | "MessageRetentionPeriod" | "ApproximateNumberOfMessages" | "ApproximateNumberOfMessagesNotVisible" | "CreatedTimestamp" | "LastModifiedTimestamp" | "QueueArn" | "ApproximateNumberOfMessagesDelayed" | "DelaySeconds" | "ReceiveMessageWaitTimeSeconds" | "RedrivePolicy" | "FifoQueue" | "ContentBasedDeduplication" | "KmsMasterKeyId" | "KmsDataKeyReusePeriodSeconds" | "DeduplicationScope" | "FifoThroughputLimit" | "RedriveAllowPolicy" | "SqsManagedSseEnabled")
+      type queue_url_list = ::Array[string]
+      class ReceiveMessageResult
+        attr_accessor messages: message_list
       end
+      type send_message_batch_request_entry = { id: string, message_body: string, delay_seconds: integer?, message_attributes: message_body_attribute_map?, message_system_attributes: message_body_system_attribute_map?, message_deduplication_id: string?, message_group_id: string? }
+      type send_message_batch_request_entry_list = ::Array[send_message_batch_request_entry]
       class SendMessageBatchResult
         attr_accessor successful: send_message_batch_result_entry_list
         attr_accessor failed: batch_result_error_entry_list
       end
-      type send_message_batch_result_entry_list = ::Array[SendMessageBatchResultEntry]
       class SendMessageBatchResultEntry
         attr_accessor id: string
         attr_accessor message_id: string
@@ -149,6 +132,21 @@ module Aws
         attr_accessor md5_of_message_system_attributes: string
         attr_accessor sequence_number: string
       end
+      type send_message_batch_result_entry_list = ::Array[SendMessageBatchResultEntry]
+      class SendMessageResult
+        attr_accessor md5_of_message_body: string
+        attr_accessor md5_of_message_attributes: string
+        attr_accessor md5_of_message_system_attributes: string
+        attr_accessor message_id: string
+        attr_accessor sequence_number: string
+      end
+      type string = ::String
+      type string_list = ::Array[string]
+      type tag_key = ::String
+      type tag_key_list = ::Array[tag_key]
+      type tag_map = ::Hash[tag_key, tag_value]
+      type tag_value = ::String
+      type token = ::String
     end
     module Errors
       class BatchEntryIdsNotDistinct < ::RuntimeError

--- a/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs
+++ b/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs
@@ -24,7 +24,7 @@ module Aws
       def purge_queue: (queue_url: Types::string) -> Aws::EmptyStructure
       def receive_message: (queue_url: Types::string, ?attribute_names: Types::attribute_name_list, ?message_attribute_names: Types::message_attribute_name_list, ?max_number_of_messages: Types::integer, ?visibility_timeout: Types::integer, ?wait_time_seconds: Types::integer, ?receive_request_attempt_id: Types::string) -> Types::ReceiveMessageResult
       def remove_permission: (queue_url: Types::string, label: Types::string) -> Aws::EmptyStructure
-      def send_message: (queue_url: Types::string, message_body: Types::string, ?delay_seconds: Types::integer, ?message_attributes: Types::message_body_attribute_map, ?message_system_attributes: Types::message_body_system_attribute_map, ?message_deduplication_id: Types::string, ?message_group_id: Types::string) -> Types::SendMessageResult
+      def send_message: (queue_url: Types::string, message_body: Types::string, ?delay_seconds: Types::integer, ?message_attributes: Types::message_body_attribute_map_input, ?message_system_attributes: Types::message_body_system_attribute_map, ?message_deduplication_id: Types::string, ?message_group_id: Types::string) -> Types::SendMessageResult
       def send_message_batch: (queue_url: Types::string, entries: Types::send_message_batch_request_entry_list) -> Types::SendMessageBatchResult
       def set_queue_attributes: (queue_url: Types::string, attributes: Types::queue_attribute_map) -> Aws::EmptyStructure
       def tag_queue: (queue_url: Types::string, tags: Types::tag_map) -> Aws::EmptyStructure
@@ -93,7 +93,7 @@ module Aws
         attr_accessor body: string
         attr_accessor attributes: message_system_attribute_map
         attr_accessor md5_of_message_attributes: string
-        attr_accessor message_attributes: message_body_attribute_map
+        attr_accessor message_attributes: message_body_attribute_map_output
       end
       type message_attribute_name = ::String
       type message_attribute_name_list = ::Array[message_attribute_name]
@@ -105,7 +105,8 @@ module Aws
         attr_accessor data_type: string
       end
       type message_attribute_value = { string_value: string?, binary_value: binary?, string_list_values: string_list?, binary_list_values: binary_list?, data_type: string }
-      type message_body_attribute_map = ::Hash[string, MessageAttributeValue]
+      type message_body_attribute_map_output = ::Hash[string, MessageAttributeValue]
+      type message_body_attribute_map_input = ::Hash[string, message_attribute_value]
       type message_body_system_attribute_map = ::Hash[message_system_attribute_name_for_sends, message_system_attribute_value]
       type message_list = ::Array[Message]
       type message_system_attribute_map = ::Hash[message_system_attribute_name, string]
@@ -118,7 +119,7 @@ module Aws
       class ReceiveMessageResult
         attr_accessor messages: message_list
       end
-      type send_message_batch_request_entry = { id: string, message_body: string, delay_seconds: integer?, message_attributes: message_body_attribute_map?, message_system_attributes: message_body_system_attribute_map?, message_deduplication_id: string?, message_group_id: string? }
+      type send_message_batch_request_entry = { id: string, message_body: string, delay_seconds: integer?, message_attributes: message_body_attribute_map_input?, message_system_attributes: message_body_system_attribute_map?, message_deduplication_id: string?, message_group_id: string? }
       type send_message_batch_request_entry_list = ::Array[send_message_batch_request_entry]
       class SendMessageBatchResult
         attr_accessor successful: send_message_batch_result_entry_list

--- a/gems/aws-sdk-sqs/1/_scripts/test
+++ b/gems/aws-sdk-sqs/1/_scripts/test
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'
+	'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r aws-sdk-core:3 -r aws-sdk-sqs:1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/aws-sdk-sqs/1/_test/test.rb
+++ b/gems/aws-sdk-sqs/1/_test/test.rb
@@ -14,3 +14,35 @@ attributes = client.get_queue_attributes(
 attributes.attributes.each do |key, value|
   puts "#{key}: #{value}"
 end
+
+resp = client.send_message_batch(
+  queue_url: "String", # required
+  entries: [ # required
+    {
+      id: "String", # required
+      message_body: "String", # required
+      delay_seconds: 1,
+      message_attributes: {
+        "String" => {
+          string_value: "String",
+          binary_value: "data",
+          string_list_values: ["String"],
+          binary_list_values: ["data"],
+          data_type: "String", # required
+        },
+      },
+      message_system_attributes: {
+        "AWSTraceHeader" => {
+          string_value: "String",
+          binary_value: "data",
+          string_list_values: ["String"],
+          binary_list_values: ["data"],
+          data_type: "String", # required
+        },
+      },
+      message_deduplication_id: "String",
+      message_group_id: "String",
+    },
+  ],
+)
+resp.successful[0].id.upcase

--- a/generators/aws-sdk/Rakefile
+++ b/generators/aws-sdk/Rakefile
@@ -1,35 +1,26 @@
 root = File.expand_path("../..")
+src = File.expand_path("_src")
 
 gems = {
   'aws-sdk-s3' => {
-    api_url: "https://raw.githubusercontent.com/aws/aws-sdk-ruby/version-3/apis/s3/2006-03-01/api-2.json",
-    tmp_file: "tmp/apis_s3_2006-03-01_api-2.json",
+    api_path: "#{src}/apis/s3/2006-03-01/api-2.json",
     rbs_path: "#{root}/gems/aws-sdk-s3/1/2006-03-01_api-2.rbs",
   },
   'aws-sdk-sqs' => {
-    api_url: "https://raw.githubusercontent.com/aws/aws-sdk-ruby/version-3/apis/sqs/2012-11-05/api-2.json",
-    tmp_file: "tmp/apis_sqs_2012-11-05_api-2.json",
+    api_path: "#{src}/apis/sqs/2012-11-05/api-2.json",
     rbs_path: "#{root}/gems/aws-sdk-sqs/1/2012-11-05_api-2.rbs",
   }
 }
 
 gems.each do |gem, config|
-  config => { api_url:, tmp_file:, rbs_path: }
+  config => { api_path:, rbs_path: }
 
-  file tmp_file => ['tmp'] do
-    sh "curl -o #{tmp_file} #{api_url}"
-  end
-
-  file rbs_path => [tmp_file, 'aws_client_types_generator.rb'] do
+  file rbs_path => ['aws_client_types_generator.rb'] do
     mkdir_p File.dirname(rbs_path)
-    ruby "aws_client_types_generator.rb #{tmp_file} > #{rbs_path}"
+    ruby "aws_client_types_generator.rb #{api_path} > #{rbs_path}"
   end  
 
   task gem => rbs_path
-end
-
-file 'tmp' do
-  sh "mkdir -p tmp"
 end
 
 task :aws => gems.keys

--- a/generators/aws-sdk/aws_client_types_generator.rb
+++ b/generators/aws-sdk/aws_client_types_generator.rb
@@ -169,7 +169,7 @@ class AwsClientTypesGenerator
       end
     when "integer", "long"
       "::Integer"
-    when "double"
+    when "float", "double"
       "::Float"
     when "timestamp"
       case shape_body["timestampFormat"]

--- a/generators/aws-sdk/aws_client_types_generator.rb
+++ b/generators/aws-sdk/aws_client_types_generator.rb
@@ -11,56 +11,221 @@ Dir["#{$GEMS_DIR}/*"].each do |dir|
   $:.unshift("#{dir}/lib")
 end
 
-require 'build_tools'
 require 'aws-sdk-core'
 require 'aws-sdk-code-generator'
 require 'json'
 require 'rbs'
-
-# Minimal Hack
-class AwsSdkCodeGenerator::Views::ClientClass
-  def render
-    self
-  end
-end
 
 using Module.new {
   refine String do
     def underscore
       AwsSdkCodeGenerator::Underscore.underscore(self)
     end
+
+    def escape
+      RBS::Parser::KEYWORDS.key?(self) ? "#{self}_" : self
+    end
   end
 }
 
 class AwsClientTypesGenerator
+  class Shape
+    INDENT = " " * 6
+
+    attr_reader :name, :kind, :generator, :streaming
+    attr_accessor :request
+    def initialize(name:, kind:, generator:, request:, streaming:)
+      @name = name
+      @kind = kind
+      @generator = generator
+      @request = request
+      @streaming = streaming
+    end
+
+    def assert_input!
+      unless kind == :input
+        raise "#{name} should be input shape"
+      end
+    end
+
+    def fetch_body
+      generator.api.fetch("shapes").fetch(name)
+    end
+
+    def as_keyword_arguments(from:)
+      shape_body = fetch_body
+      members = shape_body["members"]
+      required = shape_body["required"]
+      type_prefix = case from
+        when :operations
+          "Types::"
+        when :types
+          ""
+        else
+          raise from
+        end
+      params = members.map do |member_name, member_body|
+        member_shape_name = member_body["shape"]
+        member_shape = generator.fetch_shapes(member_shape_name).first
+        if from == :types
+          opt_prefix = ""
+          opt_suffix = required&.include?(member_name) ? "" : "?"
+        else
+          opt_prefix = required&.include?(member_name) ? "" : "?"
+          opt_suffix = ""
+        end
+        "#{opt_prefix}#{member_name.underscore}: #{type_prefix}#{member_shape.underscore_name}#{opt_suffix}"
+      end
+      params.join(", ")
+    end
+
+    def rbs_name
+      if structure? && !input?
+        name
+      else
+        underscore_name
+      end
+    end
+
+    def to_rbs
+      shape_body = fetch_body
+      case type = shape_body["type"]
+      when "string"
+        if shape_body["enum"]
+          "(#{shape_body["enum"].map { "\"#{_1}\"" }.join(" | ")})"
+        else
+          "::String"
+        end
+      when "integer", "long"
+        "::Integer"
+      when "float", "double"
+        "::Float"
+      when "timestamp"
+        case shape_body["timestampFormat"]
+        when "iso8601", "rfc822", nil
+          "::Time"
+        else
+          raise [name, shape_body].inspect
+        end
+      when "list"
+        shape = generator.fetch_shapes(shape_body.fetch("member").fetch("shape")).find { |s| s.kind == kind }
+        "::Array[#{shape.rbs_name}]"
+      when "map"
+        key_shape = generator.fetch_shapes(shape_body.fetch("key").fetch("shape")).find { |s| s.kind == kind }
+        value_shape = generator.fetch_shapes(shape_body.fetch("value").fetch("shape")).find { |s| s.kind == kind }
+        "::Hash[#{key_shape.rbs_name}, #{value_shape.rbs_name}]"
+      when "structure"
+        rbs_name
+      when "boolean"
+        "bool"
+      when "blob"
+        if streaming
+          "::IO"
+        else
+          "::String"
+        end
+      else
+        raise "unimplemented shape type #{type} on #{name}"
+      end
+    end
+
+    def underscore_name
+      name.underscore.escape
+    end
+
+    def structure?
+      fetch_body.fetch("type") == "structure"
+    end
+
+    def rbs_as_input
+      rbs = if structure?
+        args = as_keyword_arguments(from: :types)
+        if args.empty?
+          # rbs does not supported empty record
+          "::Hash[untyped, untyped]"
+        else
+          "{ #{args} }"
+        end
+      else
+        to_rbs
+      end
+      return if generator.printed[underscore_name]
+      generator.printed[underscore_name] = true
+      "#{INDENT}type #{underscore_name} = #{rbs}"
+    end
+
+    def rbs_as_output
+      body = fetch_body
+      case body.fetch("type")
+      when "structure"
+        return if generator.printed[name]
+        generator.printed[name] = true
+        result = +"#{INDENT}class #{name}\n"
+        body["members"]&.each do |member_name, member_body|
+          shape = generator.fetch_shapes(member_body["shape"]).find(&:output?)
+          raise "#{member_body["shape"]} shape by output not found" unless shape
+          rbs = if shape.structure?
+            shape.name
+          else
+            shape.underscore_name
+          end
+          result << "#{INDENT}  attr_accessor #{member_name.underscore.escape}: #{rbs}\n"
+        end
+        result << "#{INDENT}end\n"
+        result
+      else
+        return if generator.printed[underscore_name]
+        generator.printed[underscore_name] = true
+        "#{INDENT}type #{underscore_name} = #{to_rbs}"
+      end
+    end
+
+    def rbs_as_exception
+      return if generator.printed[name]
+      generator.printed[name] = true
+      body = fetch_body
+      result = +"#{INDENT}class #{name} < ::RuntimeError\n"
+      body["members"]&.each do |member_name, member_body|
+        shape = generator.fetch_shapes(member_body["shape"]).find(&:exception?)
+        raise "#{member_body["shape"]} shape by exception not found" unless shape
+        result << "#{INDENT}  attr_accessor #{member_name.underscore.escape}: #{shape.to_rbs}\n"
+      end
+      result << "#{INDENT}end\n"
+      result
+    end
+
+    def input? = kind == :input
+    def output? = kind == :output
+    def exception? = kind == :exception
+  end
+
+  attr_reader :shape_table, :api, :printed
+
   def initialize(path)
+    @shape_table = {}
+    @printed = {}
     @api = File.open(path) do |file|
       JSON.parse(file.read)
     end
-  end
-
-  def escape(key)
-    RBS::Parser::KEYWORDS.key?(key) ? "#{key}_" : key
-  end
-
-  def types(name)
-    if RBS::Parser::KEYWORDS.key?(name)
-      name
-    else
-      "Types::#{name}"
+    @api.fetch("operations").each do |_key, body|
+      body.dig("input", "shape")&.tap do |name|
+        walk_as(kind: :input, name: name).tap do |root_shape|
+          root_shape.request = true
+        end
+      end
+      body.dig("output", "shape")&.then do |name|
+        walk_as(kind: :output, name: name)
+      end
+    end
+    @api.fetch("shapes").each do |key, body|
+      if body.fetch("type") == "structure" && body["exception"]
+        walk_as(kind: :exception, name: key)
+      end
     end
   end
 
-  def type(name, types_prefix: false)
-    if structure?(name)
-      name
-    else
-      escape(name.underscore)
-    end.then { types_prefix ? types(_1) : _1 }
-  end
-
-  def structure?(name)
-    @api.dig("shapes", name, "type") == "structure"
+  def inspect
+    "#<AwsClientTypesGenerator:#{object_id}>"
   end
 
   def service_id
@@ -95,7 +260,7 @@ class AwsClientTypesGenerator
           when nil
             raise opt.inspect
           else
-            opt.doc_type.to_s
+            opt.doc_type
           end
         end
       [opt.name, "?#{opt.name}: #{type}#{opt.required ? "" : "?"}", opt.doc_type]
@@ -106,6 +271,67 @@ class AwsClientTypesGenerator
       warn("Duprecate client option: `#{grouped[name].map { |g| g.values_at(0, 2) }}`", uplevel: 0)
     end
     buffer.uniq { |b| b[0] }.map { |b| b[1] }
+  end
+
+  def shape_body(shape_name)
+    @api["shapes"].fetch(shape_name)
+  end
+
+  def walk_as(kind:, name:, streaming: false)
+    root_shape = add_shape(name: name, kind: kind, streaming: streaming)
+    body = shape_body(name)
+    case body.fetch("type")
+    when "structure"
+      body.fetch("members").each do |_member_name, member_body|
+        walk_as(kind: kind, name: member_body.fetch("shape"), streaming: member_body["streaming"])
+      end
+    when "list"
+      walk_as(kind: kind, name: body.fetch("member").fetch("shape"))
+    when "map"
+      walk_as(kind: kind, name: body.fetch("key").fetch("shape"))
+      walk_as(kind: kind, name: body.fetch("value").fetch("shape"))
+    end
+    root_shape
+  end
+
+  def add_shape(name:, kind:, streaming:)
+    new_shape = Shape.new(
+      name: name,
+      kind: kind,
+      generator: self,
+      request: nil,
+      streaming: streaming,
+    )
+    if @shape_table[name]
+      if !@shape_table[name].any? { _1.kind == kind }
+        @shape_table[name] << new_shape
+      end
+    else
+      @shape_table[name] = [new_shape]
+    end
+    new_shape
+  end
+
+  def fetch_shapes(shape_name)
+    @shape_table.fetch(shape_name)
+  end
+
+  def input_shapes
+    @shape_table.flat_map do |_shape_name, shapes|
+      shapes.select(&:input?)
+    end
+  end
+
+  def output_shapes
+    @shape_table.flat_map do |_shape_name, shapes|
+      shapes.select(&:output?)
+    end
+  end
+
+  def exception_shapes
+    @shape_table.flat_map do |_shape_name, shapes|
+      shapes.select(&:exception?)
+    end
   end
 
   def write(io)
@@ -123,91 +349,34 @@ class AwsClientTypesGenerator
     io.puts "    class Client"
     io.puts "      def self.new: (#{client_options.join(", ")}) -> instance"
     @api["operations"].each do |key, body|
-      input = body.dig("input", "shape")&.then { |i| shape_to_kwargs(i, allow_opt: true, types_prefix: true) }
-      output = body.dig("output", "shape")&.then { |o| types(o) } || "Aws::EmptyStructure"
-      name = body["name"].underscore
-      io.puts "      def #{name}: (#{input}) -> #{output}"
+      name = body.fetch("name").underscore
+      input_shape = body.dig("input", "shape")&.then { fetch_shapes(_1).find(&:input?).as_keyword_arguments(from: :operations) }
+      output_shape = body.dig("output", "shape")&.then { "Types::#{_1}" } || "Aws::EmptyStructure"
+      io.puts "      def #{name}: (#{input_shape}) -> #{output_shape}"
     end
     io.puts "    end"
     io.puts "    module Types"
-    @api["shapes"].each do |key, body|
-      if body["type"] == "structure"
-        next if body["exception"]
-        io.puts "      class #{key}"
-        body["members"]&.each do |member_name, member_body|
-          io.puts "        attr_accessor #{escape(member_name.underscore)}: #{shape_to_rbs_type(member_body["shape"], types_prefix: false)}"
-        end
-        io.puts "      end"
-      else
-        io.puts "      type #{escape(key.underscore)} = #{shape_to_rbs_type(key, types_prefix: false)}"
+    io.puts "      # inputs"
+    input_shapes.each do |shape|
+      if !shape.request
+        shape.rbs_as_input&.then { io.puts(_1) }
       end
+    end
+    io.puts "      # outputs"
+    output_shapes.each do |shape|
+      shape.rbs_as_output&.then { io.puts(_1) }
     end
     io.puts "    end"
     io.puts "    module Errors"
-    @api["shapes"].each do |key, body|
-      if body["type"] == "structure" && body["exception"]
-        io.puts "      class #{key} < RuntimeError"
-        body["members"]&.each do |member_name, member_body|
-          io.puts "        attr_accessor #{escape(member_name.underscore)}: #{shape_to_rbs_type(member_body["shape"], types_prefix: true)}"
-        end
-        io.puts "      end"
+    exception_shapes.tap do |shapes|
+      next if shapes.empty?
+      shapes.each do |shape|
+        shape.rbs_as_exception&.then { io.puts(_1) }
       end
     end
     io.puts "    end"
     io.puts "  end"
     io.puts "end"
-  end
-
-  def shape_to_rbs_type(shape_name, types_prefix: false)
-    shape_body = @api["shapes"][shape_name]
-    case type = shape_body["type"]
-    when "string"
-      if shape_body["enum"]
-        "(#{shape_body["enum"].map { "\"#{_1}\"" }.join(" | ")})"
-      else
-        "::String"
-      end
-    when "integer", "long"
-      "::Integer"
-    when "float", "double"
-      "::Float"
-    when "timestamp"
-      case shape_body["timestampFormat"]
-      when "iso8601", "rfc822", nil
-        "::Time"
-      else
-        raise [shape_name, shape_body].inspect
-      end
-    when "list"
-      "::Array[#{type(shape_body["member"]["shape"], types_prefix: types_prefix)}]"
-    when "map"
-      key_type = type(shape_body["key"]["shape"], types_prefix: types_prefix)
-      value_type = type(shape_body["value"]["shape"], types_prefix: types_prefix)
-      "::Hash[#{key_type}, #{value_type}]"
-    when "structure"
-      shape_name
-    when "boolean"
-      "bool"
-    when "blob"
-      "::IO"
-    else
-      raise "unimplemented shape type #{type} on #{shape_name}"
-    end
-  end
-
-  def shape_to_kwargs(shape_name, allow_opt: false, types_prefix: false)
-    shape_body = @api["shapes"].fetch(shape_name)
-    members = shape_body["members"]
-    raise if members.empty?
-    required = shape_body["required"]
-    params = members.map do |member_name, member_body|
-      member_shape_name = member_body["shape"]
-      member_type = type(member_shape_name, types_prefix: types_prefix)
-      prefix = (required && required.include?(member_name)) ? "" : "?"
-      prefix = allow_opt ? prefix : ""
-      "#{prefix}#{member_name.underscore}: #{member_type}"
-    end
-    params.join(", ")
   end
 end
 

--- a/generators/aws-sdk/aws_client_types_generator.rb
+++ b/generators/aws-sdk/aws_client_types_generator.rb
@@ -356,22 +356,25 @@ class AwsClientTypesGenerator
     end
     io.puts "    end"
     io.puts "    module Types"
-    io.puts "      # inputs"
-    input_shapes.each do |shape|
-      if !shape.request
-        shape.rbs_as_input&.then { io.puts(_1) }
+    @api.fetch("shapes").each do |key, _body|
+      fetch_shapes(key).each do |shape|
+        case shape.kind
+        when :input
+          if !shape.request
+            shape.rbs_as_input&.then { io.puts(_1) }
+          end
+        when :output
+          shape.rbs_as_output&.then { io.puts(_1) }
+        end
       end
-    end
-    io.puts "      # outputs"
-    output_shapes.each do |shape|
-      shape.rbs_as_output&.then { io.puts(_1) }
     end
     io.puts "    end"
     io.puts "    module Errors"
-    exception_shapes.tap do |shapes|
-      next if shapes.empty?
-      shapes.each do |shape|
-        shape.rbs_as_exception&.then { io.puts(_1) }
+    @api.fetch("shapes").each do |key, _body|
+      fetch_shapes(key).each do |shape|
+        if shape.exception?
+          shape.rbs_as_exception&.then { io.puts(_1) }
+        end
       end
     end
     io.puts "    end"


### PR DESCRIPTION
Currently, there is an error in the case of using Hash with nested input arguments such as `Aws::S3::Client#complete_multipart_upload`.

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#complete_multipart_upload-instance_method

As a feature of aws-sdk, `structure` had two implications.

- If the input argument is a `structure`, it expects a Hash
- If the output is a `structure`, return with a dedicated class instance

In the existing rbs type, the input argument was also type-checked as a dedicated class instance.

I had to make some major changes to the generator to fix this problem.
(*.rbs file was generated automatically.)

Also, I added `_scripts/test` file to support CI.