### PR TITLE
Fix `ActiveModel#validates_with`; block argument can be omitted

### DIFF
--- a/gems/activemodel/6.0/activemodel-generated.rbs
+++ b/gems/activemodel/6.0/activemodel-generated.rbs
@@ -3739,7 +3739,7 @@ module ActiveModel
       #       options[:my_custom_key] # => "my custom value"
       #     end
       #   end
-      def validates_with: (*untyped args) { () -> untyped } -> untyped
+      def validates_with: (*untyped args) ?{ () -> untyped } -> untyped
     end
 
     # Passes the record off to the class or classes specified and allows them


### PR DESCRIPTION
Without this fix, I got `[error] The method cannot be called without a block` with Validator class.