### PR TITLE
Fix the bin/init_new_gem command's shebang

### DIFF
--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -1,4 +1,4 @@
-#!ruby
+#!/usr/bin/env ruby
 
 require 'pathname'
 


### PR DESCRIPTION
## Description
The `bin/init_new_gem` command does not work in my environment.  So I fixed the shebang to be the same as the `bin/run` command &  the `bin/test` command.

## Environment
- OS: macOS Big Sur Version 11.6
- Shell: GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin20)
- rbenv: 1.2.0
- ruby: ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin20]

## Actual behavior

```
$ bin/init_new_gem
bash: bin/init_new_gem: ruby: bad interpreter: No such file or directory
```

## Expected behavior

```
$ bin/init_new_gem 
Generate a boilerplate for a new gem RBS.

Usage: bin/init_new_gem GEM_NAME
```



