### PR TITLE
Add an RBS file for bcrypt-ruby

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "gems/delayed_job_active_record/4.1/_src"]
 	path = gems/delayed_job_active_record/4.1/_src
 	url = https://github.com/collectiveidea/delayed_job_active_record.git
+[submodule "gems/bcrypt/3.1/_src"]
+	path = gems/bcrypt/3.1/_src
+	url = https://github.com/bcrypt-ruby/bcrypt-ruby.git

--- a/gems/bcrypt/3.1/_scripts/test
+++ b/gems/bcrypt/3.1/_scripts/test
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'
+	'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r bcrypt:3.1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/bcrypt/3.1/_test/Steepfile
+++ b/gems/bcrypt/3.1/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "bcrypt"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/bcrypt/3.1/_test/test.rb
+++ b/gems/bcrypt/3.1/_test/test.rb
@@ -1,0 +1,33 @@
+require "bcrypt"
+
+raw_password = 'password123'
+
+# BCrypt::Password
+hashed_password = BCrypt::Password.create(raw_password, { cost: 4 })
+BCrypt::Password.valid_hash?(hashed_password)
+BCrypt::Password.valid_hash?(hashed_password.to_s)
+
+BCrypt::Password.new(hashed_password)
+BCrypt::Password.new(hashed_password.to_s)
+
+hashed_password == raw_password
+hashed_password == raw_password.to_s
+
+# BCrypt::Engine
+BCrypt::Engine.cost = 5
+BCrypt::Engine.cost < 10
+salt = BCrypt::Engine.generate_salt(4)
+BCrypt::Engine.hash_secret(raw_password, salt)
+BCrypt::Engine.valid_salt?("invalid salt")
+BCrypt::Engine.valid_secret?("password")
+BCrypt::Engine.calibrate(100)
+BCrypt::Engine.autodetect_cost(salt)
+
+# BCrypt::Error
+begin
+  raise BCrypt::Errors::InvalidSalt
+  raise BCrypt::Errors::InvalidHash
+  raise BCrypt::Errors::InvalidCost
+  raise BCrypt::Errors::InvalidSecret
+rescue
+end

--- a/gems/bcrypt/3.1/bcrypt.rbs
+++ b/gems/bcrypt/3.1/bcrypt.rbs
@@ -1,0 +1,45 @@
+module BCrypt
+  class Password < String
+    attr_reader checksum: String
+    attr_reader salt: String
+    attr_reader version: String
+    attr_reader cost: Integer
+    def self.create: (_ToS secret, {cost: _ToI} options) -> BCrypt::Password
+    def self.valid_hash?: (String h) -> bool
+    def initialize: (String raw_hash) -> void
+    def ==: (_ToS secret) -> bool
+  end
+
+  class Engine
+    DEFAULT_COST: Integer
+    MIN_COST: Integer
+    MAX_COST: Integer
+    MAX_SECRET_BYTESIZE: Integer
+    MAX_SALT_LENGTH: Integer
+
+    def self.cost: -> Integer
+    def self.cost=: (Integer cost) -> Integer
+    def self.hash_secret: (_ToS secret, String salt, ?untyped _) -> String
+    def self.generate_salt: (?_ToI cost) -> String
+    def self.valid_salt?: (String salt) -> bool
+    def self.valid_secret?: (Object secret) -> bool
+    def self.calibrate: (Numeric upper_time_limit_in_ms) -> Integer
+    def self.autodetect_cost: (String salt) -> Integer
+  end
+
+  class Error < StandardError
+  end
+  module Errors
+    class InvalidSalt < Error
+    end
+
+    class InvalidHash < Error
+    end
+
+    class InvalidCost < Error
+    end
+
+    class InvalidSecret < Error
+    end
+  end
+end

--- a/gems/bcrypt/3.1/manifest.yaml
+++ b/gems/bcrypt/3.1/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: openssl


### PR DESCRIPTION
## Description
This PR adds an RBS file for [bcrypt-ruby](https://rubygems.org/gems/bcrypt-ruby).

## Checklist

- [x] Generate files with the `bin/init_new_gem` command.
- [x] Write standard libraries used in the gem to a manifest.yaml
- [x] Pass type checks with Steep through general usage of the gem.
