### PR TITLE
Assign @pocke as a global code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
+# The core maintainer owns all files
+# except files which have code owners.
+*                    @pocke
+
 # Maintainer of individual gems (alphabetical order)
 /gems/ast            @pocke
 /gems/aws-sdk-*      @ksss


### PR DESCRIPTION
This PR assigns me as a global code owner.

It is necessary to avoid merging a PR by a collaborator who is not assigned to the file.
