### PR TITLE
Fix type error on resource class `#new`

### DIFF
--- a/gems/aws-sdk-ec2/1/classic_address.rbs
+++ b/gems/aws-sdk-ec2/1/classic_address.rbs
@@ -10,7 +10,7 @@ module Aws
     class ClassicAddress
       # identifiers
 
-      def initialize: (public_ip: String, client: Client) -> void
+      def initialize: (public_ip: String, ?client: Client, **untyped) -> void
       def public_ip: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/dhcp_options.rbs
+++ b/gems/aws-sdk-ec2/1/dhcp_options.rbs
@@ -10,7 +10,7 @@ module Aws
     class DhcpOptions
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/image.rbs
+++ b/gems/aws-sdk-ec2/1/image.rbs
@@ -10,7 +10,7 @@ module Aws
     class Image
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/instance.rbs
+++ b/gems/aws-sdk-ec2/1/instance.rbs
@@ -10,7 +10,7 @@ module Aws
     class Instance
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/internet_gateway.rbs
+++ b/gems/aws-sdk-ec2/1/internet_gateway.rbs
@@ -10,7 +10,7 @@ module Aws
     class InternetGateway
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/key_pair.rbs
+++ b/gems/aws-sdk-ec2/1/key_pair.rbs
@@ -10,7 +10,7 @@ module Aws
     class KeyPair
       # identifiers
 
-      def initialize: (name: String, client: Client) -> void
+      def initialize: (name: String, ?client: Client, **untyped) -> void
       def name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/key_pair_info.rbs
+++ b/gems/aws-sdk-ec2/1/key_pair_info.rbs
@@ -10,7 +10,7 @@ module Aws
     class KeyPairInfo
       # identifiers
 
-      def initialize: (name: String, client: Client) -> void
+      def initialize: (name: String, ?client: Client, **untyped) -> void
       def name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/nat_gateway.rbs
+++ b/gems/aws-sdk-ec2/1/nat_gateway.rbs
@@ -10,7 +10,7 @@ module Aws
     class NatGateway
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/network_acl.rbs
+++ b/gems/aws-sdk-ec2/1/network_acl.rbs
@@ -10,7 +10,7 @@ module Aws
     class NetworkAcl
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/network_interface.rbs
+++ b/gems/aws-sdk-ec2/1/network_interface.rbs
@@ -10,7 +10,7 @@ module Aws
     class NetworkInterface
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/network_interface_association.rbs
+++ b/gems/aws-sdk-ec2/1/network_interface_association.rbs
@@ -10,7 +10,7 @@ module Aws
     class NetworkInterfaceAssociation
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/placement_group.rbs
+++ b/gems/aws-sdk-ec2/1/placement_group.rbs
@@ -10,7 +10,7 @@ module Aws
     class PlacementGroup
       # identifiers
 
-      def initialize: (name: String, client: Client) -> void
+      def initialize: (name: String, ?client: Client, **untyped) -> void
       def name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/route.rbs
+++ b/gems/aws-sdk-ec2/1/route.rbs
@@ -10,7 +10,7 @@ module Aws
     class Route
       # identifiers
 
-      def initialize: (route_table_id: String, destination_cidr_block: String, client: Client) -> void
+      def initialize: (route_table_id: String, destination_cidr_block: String, ?client: Client, **untyped) -> void
       def route_table_id: () -> String
       def destination_cidr_block: () -> String
 

--- a/gems/aws-sdk-ec2/1/route_table.rbs
+++ b/gems/aws-sdk-ec2/1/route_table.rbs
@@ -10,7 +10,7 @@ module Aws
     class RouteTable
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/route_table_association.rbs
+++ b/gems/aws-sdk-ec2/1/route_table_association.rbs
@@ -10,7 +10,7 @@ module Aws
     class RouteTableAssociation
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/security_group.rbs
+++ b/gems/aws-sdk-ec2/1/security_group.rbs
@@ -10,7 +10,7 @@ module Aws
     class SecurityGroup
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/snapshot.rbs
+++ b/gems/aws-sdk-ec2/1/snapshot.rbs
@@ -10,7 +10,7 @@ module Aws
     class Snapshot
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/subnet.rbs
+++ b/gems/aws-sdk-ec2/1/subnet.rbs
@@ -10,7 +10,7 @@ module Aws
     class Subnet
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/tag.rbs
+++ b/gems/aws-sdk-ec2/1/tag.rbs
@@ -10,7 +10,7 @@ module Aws
     class Tag
       # identifiers
 
-      def initialize: (resource_id: String, key: String, value: String, client: Client) -> void
+      def initialize: (resource_id: String, key: String, value: String, ?client: Client, **untyped) -> void
       def resource_id: () -> String
       def key: () -> String
       def value: () -> String

--- a/gems/aws-sdk-ec2/1/volume.rbs
+++ b/gems/aws-sdk-ec2/1/volume.rbs
@@ -10,7 +10,7 @@ module Aws
     class Volume
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/vpc.rbs
+++ b/gems/aws-sdk-ec2/1/vpc.rbs
@@ -10,7 +10,7 @@ module Aws
     class Vpc
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/vpc_address.rbs
+++ b/gems/aws-sdk-ec2/1/vpc_address.rbs
@@ -10,7 +10,7 @@ module Aws
     class VpcAddress
       # identifiers
 
-      def initialize: (allocation_id: String, client: Client) -> void
+      def initialize: (allocation_id: String, ?client: Client, **untyped) -> void
       def allocation_id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-ec2/1/vpc_peering_connection.rbs
+++ b/gems/aws-sdk-ec2/1/vpc_peering_connection.rbs
@@ -10,7 +10,7 @@ module Aws
     class VpcPeeringConnection
       # identifiers
 
-      def initialize: (id: String, client: Client) -> void
+      def initialize: (id: String, ?client: Client, **untyped) -> void
       def id: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/_test/resource_test.rb
+++ b/gems/aws-sdk-s3/1/_test/resource_test.rb
@@ -9,6 +9,9 @@ puts '# Resource'
 
 puts '## Low level api'
 
+Aws::S3::Bucket.new(name: 'a', stub_responses: true)
+Aws::S3::Object.new(bucket_name: 'a', key: 'b', stub_responses: true)
+
 # @type var batches: Array[Array[Aws::S3::Object]]
 batches = [[]]
 collection = Aws::S3::Object::Collection.new(batches)

--- a/gems/aws-sdk-s3/1/bucket.rbs
+++ b/gems/aws-sdk-s3/1/bucket.rbs
@@ -10,7 +10,7 @@ module Aws
     class Bucket
       # identifiers
 
-      def initialize: (name: String, client: Client) -> void
+      def initialize: (name: String, ?client: Client, **untyped) -> void
       def name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_acl.rbs
+++ b/gems/aws-sdk-s3/1/bucket_acl.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketAcl
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_cors.rbs
+++ b/gems/aws-sdk-s3/1/bucket_cors.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketCors
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_lifecycle.rbs
+++ b/gems/aws-sdk-s3/1/bucket_lifecycle.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketLifecycle
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_lifecycle_configuration.rbs
+++ b/gems/aws-sdk-s3/1/bucket_lifecycle_configuration.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketLifecycleConfiguration
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_logging.rbs
+++ b/gems/aws-sdk-s3/1/bucket_logging.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketLogging
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_notification.rbs
+++ b/gems/aws-sdk-s3/1/bucket_notification.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketNotification
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_policy.rbs
+++ b/gems/aws-sdk-s3/1/bucket_policy.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketPolicy
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_request_payment.rbs
+++ b/gems/aws-sdk-s3/1/bucket_request_payment.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketRequestPayment
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_tagging.rbs
+++ b/gems/aws-sdk-s3/1/bucket_tagging.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketTagging
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_versioning.rbs
+++ b/gems/aws-sdk-s3/1/bucket_versioning.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketVersioning
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/bucket_website.rbs
+++ b/gems/aws-sdk-s3/1/bucket_website.rbs
@@ -10,7 +10,7 @@ module Aws
     class BucketWebsite
       # identifiers
 
-      def initialize: (bucket_name: String, client: Client) -> void
+      def initialize: (bucket_name: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
 
       # data_attribute

--- a/gems/aws-sdk-s3/1/multipart_upload.rbs
+++ b/gems/aws-sdk-s3/1/multipart_upload.rbs
@@ -10,7 +10,7 @@ module Aws
     class MultipartUpload
       # identifiers
 
-      def initialize: (bucket_name: String, object_key: String, id: String, client: Client) -> void
+      def initialize: (bucket_name: String, object_key: String, id: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
       def object_key: () -> String
       def id: () -> String

--- a/gems/aws-sdk-s3/1/multipart_upload_part.rbs
+++ b/gems/aws-sdk-s3/1/multipart_upload_part.rbs
@@ -10,7 +10,7 @@ module Aws
     class MultipartUploadPart
       # identifiers
 
-      def initialize: (bucket_name: String, object_key: String, multipart_upload_id: String, part_number: String, client: Client) -> void
+      def initialize: (bucket_name: String, object_key: String, multipart_upload_id: String, part_number: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
       def object_key: () -> String
       def multipart_upload_id: () -> String

--- a/gems/aws-sdk-s3/1/object.rbs
+++ b/gems/aws-sdk-s3/1/object.rbs
@@ -10,7 +10,7 @@ module Aws
     class Object
       # identifiers
 
-      def initialize: (bucket_name: String, key: String, client: Client) -> void
+      def initialize: (bucket_name: String, key: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
       def key: () -> String
 

--- a/gems/aws-sdk-s3/1/object_acl.rbs
+++ b/gems/aws-sdk-s3/1/object_acl.rbs
@@ -10,7 +10,7 @@ module Aws
     class ObjectAcl
       # identifiers
 
-      def initialize: (bucket_name: String, object_key: String, client: Client) -> void
+      def initialize: (bucket_name: String, object_key: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
       def object_key: () -> String
 

--- a/gems/aws-sdk-s3/1/object_summary.rbs
+++ b/gems/aws-sdk-s3/1/object_summary.rbs
@@ -10,7 +10,7 @@ module Aws
     class ObjectSummary
       # identifiers
 
-      def initialize: (bucket_name: String, key: String, client: Client) -> void
+      def initialize: (bucket_name: String, key: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
       def key: () -> String
 

--- a/gems/aws-sdk-s3/1/object_version.rbs
+++ b/gems/aws-sdk-s3/1/object_version.rbs
@@ -10,7 +10,7 @@ module Aws
     class ObjectVersion
       # identifiers
 
-      def initialize: (bucket_name: String, object_key: String, id: String, client: Client) -> void
+      def initialize: (bucket_name: String, object_key: String, id: String, ?client: Client, **untyped) -> void
       def bucket_name: () -> String
       def object_key: () -> String
       def id: () -> String

--- a/gems/aws-sdk-sqs/1/message.rbs
+++ b/gems/aws-sdk-sqs/1/message.rbs
@@ -10,7 +10,7 @@ module Aws
     class Message
       # identifiers
 
-      def initialize: (queue_url: String, receipt_handle: String, client: Client) -> void
+      def initialize: (queue_url: String, receipt_handle: String, ?client: Client, **untyped) -> void
       def queue_url: () -> String
       def receipt_handle: () -> String
 

--- a/gems/aws-sdk-sqs/1/queue.rbs
+++ b/gems/aws-sdk-sqs/1/queue.rbs
@@ -10,7 +10,7 @@ module Aws
     class Queue
       # identifiers
 
-      def initialize: (url: String, client: Client) -> void
+      def initialize: (url: String, ?client: Client, **untyped) -> void
       def url: () -> String
 
       # data_attribute

--- a/generators/aws-sdk-rbs-generator/lib/aws-sdk-rbs-generator/views/resource_class.rb
+++ b/generators/aws-sdk-rbs-generator/lib/aws-sdk-rbs-generator/views/resource_class.rb
@@ -22,7 +22,7 @@ module AwsSdkRbsGenerator
         @resource = resource
         @service_name = @service.name
         args = @resource.fetch(:identifiers, []).map { |i| "#{i[:name].underscore}: String" }
-        args << "client: Client"
+        args << "?client: Client, **untyped"
         @initialize_arguments = args.join(", ")
         @identifiers = @resource.fetch(:identifiers, []).map do |identifier|
           MethodSignature.new(


### PR DESCRIPTION
Fix the problem that the following valid code causes a type error.

```rb
Aws::S3::Bucket.new(name: 'a')
#=> More keyword arguments are required: client(Ruby::InsufficientKeywordArguments)
```

The client option is very long and duplicated.
Also, since this is a low-level API, the type is not that important.
If we want to make the type strict, we can use the `client` option,
otherwise, make the type untyped to avoid errors.