### PR TITLE
[activesupport] Remove Class#subclasses

### DIFF
--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -2359,15 +2359,6 @@ class Class
   #   class D < C; end
   #   C.descendants # => [B, A, D]
   def descendants: () -> untyped
-
-  # Returns an array with the direct children of +self+.
-  #
-  #   class Foo; end
-  #   class Bar < Foo; end
-  #   class Baz < Bar; end
-  #
-  #   Foo.subclasses # => [Bar]
-  def subclasses: () -> untyped
 end
 
 class Date


### PR DESCRIPTION
The method has been added to the core since Ruby 3.1, and RBS also add
the method to Class. So it causes an error when loading activesupport
gem with RBS v2.1.0. This patch removes the duplicated method definition
from activesupport.