### PR TITLE
Fix `unscoped` in ActiveRecord; allow without block

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -144,6 +144,8 @@ module ActiveRecord
     def self.default_scope_override=: (untyped) -> untyped
     def default_scope_override: () -> untyped
 
+    def self.unscoped: () -> untyped | ...
+
     def self.cache_timestamp_format: () -> untyped
     def self.cache_timestamp_format?: () -> bool
     def self.cache_timestamp_format=: (untyped) -> untyped


### PR DESCRIPTION
`unscoped` class method in ActiveRecord can be called without block.

ref. https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-unscoped

So this PR fixes it.
