### PR TITLE
Fix `scope` in ActiveRecord; allow `scope :foo, lambda {...}`

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -40,6 +40,7 @@ module ActiveRecord
 
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, ^(*untyped) -> untyped ) -> void
+                  | (Symbol, Proc) -> void
                   | (Symbol) { (*untyped) -> untyped } -> void
     def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -39,9 +39,7 @@ module ActiveRecord
     extend ::ActiveSupport::Callbacks::ClassMethods
 
     def self.abstract_class=: (bool) -> void
-    def self.scope: (Symbol, ^(*untyped) -> untyped ) -> void
-                  | (Symbol, Proc) -> void
-                  | (Symbol) { (*untyped) -> untyped } -> void
+    def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void
     def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void


### PR DESCRIPTION
`scope` in ActiveRecord can be used with Symbol and lambda, such as `scope :opened, lambda { ..... }`.
This PR allows it.