### PR TITLE
Fix `TimeWithZone`; support `DateAndTime::Calculations`

### DIFF
--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -74,6 +74,8 @@ module ActiveSupport
   end
 
   class TimeWithZone
+    include DateAndTime::Calculations
+
     # class_eval
     def year: () -> Integer
     def mon: () -> Integer


### PR DESCRIPTION
`ActiveSupport::TimeWithZone` supports `DateAndTime::Calculations` through method_missing.

```ruby
> Time.zone.now.class
=> ActiveSupport::TimeWithZone
> Time.zone.now.yesterday
=> Sat, 19 Mar 2022 02:16:45.979101000 UTC +00:00
```