### PR TITLE
Fix ActiveRecord; allow omission of some blocks

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -471,3 +471,13 @@ module ActiveRecord
     extend Associations::ClassMethods
   end
 end
+
+module ActiveRecord
+  module Associations
+    class CollectionProxy
+      def build: (?::Hash[untyped, untyped] attributes) -> untyped | ...
+      def create: (?::Hash[untyped, untyped] attributes) -> untyped | ...
+      def create!: (?::Hash[untyped, untyped] attributes) -> untyped | ...
+    end
+  end
+end


### PR DESCRIPTION
In CollectionProxy of ActiveRecord, we can use `build`, `create` and `create!` without blocks.

```ruby
person.pets.build(name: 'Fancy-Fancy')
# => #<Pet id: nil, name: "Fancy-Fancy", person_id: 1>
```

https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-build

This PR overrides the current definition so that there is no need for the block.