### PR TITLE
Fix ActiveRecord; allow omission of blocks in default_scope

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -272,6 +272,10 @@ module ActiveRecord
 
     attr_accessor self.index_nested_attribute_errors: untyped
     def index_nested_attribute_errors: () -> untyped
+
+    private
+
+    def self.default_scope: (?untyped? scope) -> untyped | ...
   end
 end
 


### PR DESCRIPTION
This PR is similar to #135 and allows class method blocks to be omitted.

In this case, `default_scope` is changed.