### PR TITLE
Add some module methods for `Aws` in aws-sdk-core

### DIFF
--- a/gems/aws-sdk-core/3/aws.rbs
+++ b/gems/aws-sdk-core/3/aws.rbs
@@ -1,0 +1,4 @@
+module Aws
+  def self.config: () -> Hash[Symbol, untyped]
+  def self.use_bundled_cert!: () -> String
+end


### PR DESCRIPTION
This PR add some methods for Aws root module: `config` and `use_bundled_cert!`

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws.html

(I found some other methods, but I'm not sure how to use them...)