### PR TITLE
Add .gitattributes to resolve conflict easily

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitmodules merge=union
+.github/CODEOWNERS merge=union


### PR DESCRIPTION
By this change we can merge PRs without conflict even if .gitmodule or CODEOWNERS have changes