### PR TITLE
Add link to ruby/rbs on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Naming note:** This repository was called `gem_rbs` before. We have renamed the repository to make it more clear that this is a collection of RBS files for gems.
 
-RBS is a standard type signature syntax for Ruby programs.
+[RBS](https://github.com/ruby/rbs) is a standard type signature syntax for Ruby programs.
 This is a community managed collection of RBS files for gems which ships without RBS.
 
 ## Loading RBS from the repository


### PR DESCRIPTION
I think it's helpful to add a link to the [`ruby/rbs`](https://github.com/ruby/rbs) repository, especially for people unfamiliar with RBS.