### PR TITLE
Allow optional block for `#find_or_create_by`

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -19655,12 +19655,12 @@ module ActiveRecord
     # be the case that you end up with two similar records.
     #
     # If this might be a problem for your application, please see #create_or_find_by.
-    def find_or_create_by: (untyped attributes) { () -> untyped } -> untyped
+    def find_or_create_by: (untyped attributes) ?{ () -> untyped } -> untyped
 
     # Like #find_or_create_by, but calls
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
     # is raised if the created record is invalid.
-    def find_or_create_by!: (untyped attributes) { () -> untyped } -> untyped
+    def find_or_create_by!: (untyped attributes) ?{ () -> untyped } -> untyped
 
     # Attempts to create a record with the given attributes in a table that has a unique constraint
     # on one or several of its columns. If a row already exists with one or several of these


### PR DESCRIPTION
`ActiveRecord::Relation#find_or_create_by(!)` type definition requires a block.
If we try to run without blocks, we will get the following error:

```
[error] The method cannot be called without a block
│ Diagnostic ID: Ruby::RequiredBlockMissing
│
└     users.find_or_create_by!(nickname: fugakkbn)
```

However, since there are cases where it is called without a block, this PR makes the change to make the block optional.