### PR TITLE
Allow some methods of `ActiveRecord::Relation` to accept optional block arguments

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -19731,16 +19731,16 @@ module ActiveRecord
     def empty?: () -> untyped
 
     # Returns true if there are no records.
-    def none?: () -> untyped
+    def none?: () ?{ (untyped) -> bool } -> bool
 
     # Returns true if there are any records.
-    def any?: () -> untyped
+    def any?: () ?{ (untyped) -> bool } -> bool
 
     # Returns true if there is exactly one record.
-    def one?: () -> untyped
+    def one?: () ?{ (untyped) -> bool } -> bool
 
     # Returns true if there is more than one record.
-    def many?: () -> untyped
+    def many?: () ?{ (untyped) -> bool } -> bool
 
     # Returns a stable cache key that can be used to identify this query.
     # The cache key is built with a fingerprint of the SQL query.

--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -19731,16 +19731,16 @@ module ActiveRecord
     def empty?: () -> untyped
 
     # Returns true if there are no records.
-    def none?: () ?{ (untyped) -> bool } -> bool
+    def none?: () ?{ (untyped) -> boolish } -> bool
 
     # Returns true if there are any records.
-    def any?: () ?{ (untyped) -> bool } -> bool
+    def any?: () ?{ (untyped) -> boolish } -> bool
 
     # Returns true if there is exactly one record.
-    def one?: () ?{ (untyped) -> bool } -> bool
+    def one?: () ?{ (untyped) -> boolish } -> bool
 
     # Returns true if there is more than one record.
-    def many?: () ?{ (untyped) -> bool } -> bool
+    def many?: () ?{ (untyped) -> boolish } -> bool
 
     # Returns a stable cache key that can be used to identify this query.
     # The cache key is built with a fingerprint of the SQL query.


### PR DESCRIPTION
The following cases will result in an error when `steep check` is run:
```ruby
class User < ApplicationRecord
  has_many :messages
  
  def replied?
    messages.any? {|message| message.replied_at.exists?}
  end
end

class Message < ApplicationRecord
  belongs_to :user
end
```

```
$ bundle exec steep check

[error] The method cannot be called with a block
│ Diagnostic ID: Ruby::UnexpectedBlockGiven
│
└     messages.any? {|message| message.replied_at.exists?}
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The cause is that `ActiveRecord::Relation#any?` is a type definition that does not accept blocks.
So, this PR modifies the type definition so that `ActiveRecord::Relation#any?` can optionally accept blocks.
In addition, the return types of methods and blocks are also modified.

Similarly, modify `#none?`, `#one?`, and `#many?`.