### PR TITLE
Remove minitest gem because it doesn't depend on minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gem "rbs"
 gem "steep"
-gem "minitest"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest
   rake
   rbs
   steep


### PR DESCRIPTION
Close #170 