### PR TITLE
Add #count type definitions to activerecord

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -17843,7 +17843,8 @@ module ActiveRecord
     #
     # Note: not all valid {Relation#select}[rdoc-ref:QueryMethods#select] expressions are valid #count expressions. The specifics differ
     # between databases. In invalid cases, an error from the database is thrown.
-    def count: (?untyped? column_name) -> untyped
+    def count: (?(::String | ::Symbol)? column_name) -> ::Integer
+             | () { (untyped) -> boolish } -> ::Integer
 
     # Calculates the average value on a given column. Returns +nil+ if there's
     # no row. See #calculate for examples with options.


### PR DESCRIPTION
Added type definition for `ActiveRecord::Calculations#count`.
Also, made it possible to accept blocks.