### PR TITLE
Fix duplicate definition

### DIFF
--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -6109,10 +6109,6 @@ end
 
 class Time
   include DateAndTime::Compatibility
-
-  # Either return +self+ or the time in the local system timezone depending
-  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
-  def to_time: () -> untyped
 end
 
 class Time


### PR DESCRIPTION
Fix https://github.com/ruby/gem_rbs_collection/issues/177

In rails add `Time#to_time` from https://github.com/rails/rails/pull/28147 for compatibility.
gems/railties/6.0/_scripts/generate.rb output this signature.
But, In rbs 2.6.0 added `Time#to_time` signature in date library.
So, Remove the gem_rbs_collection side, since the expected signatures for both are the same.