### PR TITLE
Fix signature of ActiveSupport

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -3,3 +3,10 @@ require 'active_support/all'
 # Test ActiveSupport::NumericWithFormat
 42.to_s
 42.to_s(:phone)
+
+5.try(:to_s)
+5.try(:round, 2)
+5.try(:tap) { |n| n.to_s }
+nil.try(:to_s)
+nil.try(:round, 2)
+nil.try(:tap) { |n| n.to_s }

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -4948,40 +4948,12 @@ class Hash[unchecked out K, unchecked out V]
   alias to_param to_query
 end
 
-module ActiveSupport
-  module Tryable : BasicObject
-    # nodoc:
-    def try: (?untyped? method_name, *untyped args) { (untyped) -> untyped } -> untyped
-
-    def try!: (?untyped? method_name, *untyped args) { (untyped) -> untyped } -> untyped
-  end
-end
-
 class Object
   include ActiveSupport::Tryable
 end
 
 class Delegator
   include ActiveSupport::Tryable
-end
-
-class NilClass
-  # Calling +try+ on +nil+ always returns +nil+.
-  # It becomes especially helpful when navigating through associations that may return +nil+.
-  #
-  #   nil.try(:name) # => nil
-  #
-  # Without +try+
-  #   @person && @person.children.any? && @person.children.first.name
-  #
-  # With +try+
-  #   @person.try(:children).try(:first).try(:name)
-  def try: (?untyped? method_name, *untyped args) -> nil
-
-  # Calling +try!+ on +nil+ always returns +nil+.
-  #
-  #   nil.try!(:name) # => nil
-  def try!: (?untyped? method_name, *untyped args) -> nil
 end
 
 class Object

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -189,3 +189,18 @@ end
 class BigDecimal
   prepend ActiveSupport::NumericWithFormat
 end
+
+module ActiveSupport
+  module Tryable : BasicObject
+    def try: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+
+    def try!: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  end
+end
+
+class NilClass
+  def try: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+
+  def try!: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+end
+


### PR DESCRIPTION
It allows for a block to be passed