### PR TITLE
[activesupport] More accurate type for #try

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -5,8 +5,12 @@ require 'active_support/all'
 42.to_s(:phone)
 
 5.try(:to_s)
-5.try(:round, 2)
+5.try('round', 2)
 5.try(:tap) { |n| n.to_s }
+5.try { p 'hello' }
+5.try { |n| p n }
 nil.try(:to_s)
-nil.try(:round, 2)
+nil.try('round', 2)
 nil.try(:tap) { |n| n.to_s }
+nil.try { p 'hello' }
+nil.try { |n| p n }

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -192,15 +192,24 @@ end
 
 module ActiveSupport
   module Tryable : BasicObject
-    def try: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+    def try: [T] () { (self) -> T } -> T # When yield self
+           | [T] () { () -> T } -> T # When instance_eval
+           | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
-    def try!: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+    def try!: [T] () { (self) -> T } -> T # When yield self
+            | [T] () { () -> T } -> T # When instance_eval
+            | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
   end
 end
 
 class NilClass
-  def try: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+    def try: () { (untyped) -> untyped } -> nil
+           | () { () -> untyped } -> nil
+           | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
 
-  def try!: (?Symbol method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+    def try!: () { (untyped) -> untyped } -> nil
+            | () { () -> untyped } -> nil
+            | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+
 end
 


### PR DESCRIPTION
This PR improves `try` method types.

Note that the type definition of `NilClass#try` is more strict than the implementation. `nil.try` raises no error but the type definition rejects it.
I think the strict behavior is better because it is the same behavior as `ActiveSupport::Tryable#try`. Usually `try`'s receiver is an optional value, so these interface should be the same.