### PR TITLE
Add some type declaration to Redis gem

### DIFF
--- a/gems/redis/4.2/_test/get_set.rb
+++ b/gems/redis/4.2/_test/get_set.rb
@@ -5,3 +5,7 @@ redis.set("mykey", "hello world")
 
 redis.get("mykey")
 # => "hello world"
+
+Redis.current.set(:mykey, 'hello world')
+
+Redis.current.get(:mykey)

--- a/gems/redis/4.2/_test/get_set.rb
+++ b/gems/redis/4.2/_test/get_set.rb
@@ -6,6 +6,8 @@ redis.set("mykey", "hello world")
 redis.get("mykey")
 # => "hello world"
 
-Redis.current.set(:mykey, 'hello world')
+redis.set(:other_key, 'hello world')
+# => "OK"
 
-Redis.current.get(:mykey)
+redis.get(:other_key)
+# => "hello world"

--- a/gems/redis/4.2/redis.rbs
+++ b/gems/redis/4.2/redis.rbs
@@ -6,6 +6,8 @@ class Redis
   type node = String
             | { host: String?, port: Integer?, db: Integer?, password: String?, path: String?, url: String? }
 
+  def self.current: () -> Redis
+
   # Create a new client instance
   #
   # @param [Hash] options

--- a/gems/redis/4.2/redis.rbs
+++ b/gems/redis/4.2/redis.rbs
@@ -6,8 +6,6 @@ class Redis
   type node = String
             | { host: String?, port: Integer?, db: Integer?, password: String?, path: String?, url: String? }
 
-  def self.current: () -> Redis
-
   # Create a new client instance
   #
   # @param [Hash] options

--- a/gems/redis/4.2/redis.rbs
+++ b/gems/redis/4.2/redis.rbs
@@ -66,13 +66,13 @@ class Redis
   #   - `:xx => true`: Only set the key if it already exist.
   #   - `:keepttl => true`: Retain the time to live associated with the key.
   # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
-  def set: (String key, top value, ?ex: Integer?, ?px: Integer?, ?nx: boolish, ?xx: boolish, ?keepttl: boolish) -> (String | bool)
+  def set: ((String | Symbol) key, top value, ?ex: Integer?, ?px: Integer?, ?nx: boolish, ?xx: boolish, ?keepttl: boolish) -> (String | bool)
 
   # Get the value of a key.
   #
   # @param [String] key
   # @return [String]
-  def get: (String key) -> String?
+  def get: ((String | Symbol) key) -> String?
 
 
   # Set one or more values.


### PR DESCRIPTION
The current type of the first argument `key` of `Redis#set, get` is only `String`, but Symbol is also used as `key` in some cases.

```ruby
redis = Redis.new

redis.set(:mykey, 'hello world')  # => 'OK'
redis.get(:mykey)  # => 'hello world'
```

Therefore, modify each method so that Symbol can also be used as the first argument `key`.

<hr>

In some cases, the above methods are also used with `Redis.current`.
`Redis.current` returns a Redis instance.

```ruby
Redis.current.set(:mykey, 'hello world')  # => 'OK'
Redis.current.get(:mykey)  # => 'hello world'
```

The `Redis.current` type declaration did not seem to be there yet, so I will add it.