### PR TITLE
Add RBS for enumerize gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "gems/active_decorator/1.4/_src"]
 	path = gems/active_decorator/1.4/_src
 	url = https://github.com/amatsuda/active_decorator.git
+[submodule "gems/enumerize/2.5/_src"]
+	path = gems/enumerize/2.5/_src
+	url = https://github.com/brainspec/enumerize.git

--- a/gems/enumerize/2.5/README.md
+++ b/gems/enumerize/2.5/README.md
@@ -1,4 +1,4 @@
-# RBS for config gem
+# RBS for enumerize gem
 
 The directory that defines the RBS files for the [enumerize](https://github.com/brainspec/enumerize) gem.
 

--- a/gems/enumerize/2.5/README.md
+++ b/gems/enumerize/2.5/README.md
@@ -1,0 +1,42 @@
+# RBS for config gem
+
+The directory that defines the RBS files for the [enumerize](https://github.com/brainspec/enumerize) gem.
+
+## Usage
+
+### enumerize method
+
+The most common use cases for this gem would be:
+
+```rb
+# user.rb
+require 'enumerize'
+
+class User
+  extend Enumerize
+
+  enumerize :role, in: %i(user admin)
+end
+```
+
+In this case, the RBS file should be written as follows:
+
+```
+# user.rbs
+class User
+  extend Enumerize
+  extend Enumerize::Base::ClassMethods
+end
+```
+
+Note that `Enumerize::Base::ClassMethods` is also necessary.
+
+## Why do we need additional `extend` to RBS file?
+
+Take the `enumerize` method as an example. Because this method is dynamically defined in the calling class.
+[enumerize/base\.rb at d4438ecf8f90a24b8fb0e84b9d4338ae4a236352 · brainspec/enumerize](https://github.com/brainspec/enumerize/blob/d4438ecf8f90a24b8fb0e84b9d4338ae4a236352/lib/enumerize/base.rb#L6)
+
+Therefore, simply writing `extend Enumerize` in the RBS file does not define the `enumerize` method.
+
+Currently, RBS doesn't have any features to include/extend modules dynamically, so this problem can occur with other methods.
+In such cases, check the source of the method definition and include/extend it in the RBS file.

--- a/gems/enumerize/2.5/_scripts/test
+++ b/gems/enumerize/2.5/_scripts/test
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'
+	'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r enumerize:2.5 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/enumerize/2.5/_test/Steepfile
+++ b/gems/enumerize/2.5/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "enumerize"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/enumerize/2.5/_test/test.rb
+++ b/gems/enumerize/2.5/_test/test.rb
@@ -1,0 +1,7 @@
+require 'enumerize'
+
+class User
+  extend Enumerize
+
+  enumerize :role, in: %i(user admin)
+end

--- a/gems/enumerize/2.5/_test/test.rbs
+++ b/gems/enumerize/2.5/_test/test.rbs
@@ -1,0 +1,4 @@
+class User
+  extend Enumerize
+  extend Enumerize::Base::ClassMethods
+end

--- a/gems/enumerize/2.5/enumerize-generated.rbs
+++ b/gems/enumerize/2.5/enumerize-generated.rbs
@@ -1,0 +1,526 @@
+module Enumerize
+  module Scope
+  end
+
+  def self.included: (untyped base) -> untyped
+
+  def self.extended: (untyped base) -> untyped
+end
+
+module Enumerize
+  module ActiveModelAttributesSupport
+    def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+    module InstanceMethods
+      # https://github.com/brainspec/enumerize/issues/74
+      def write_attribute: (untyped attr_name, untyped value, *untyped options) -> untyped
+    end
+
+    class Type < ActiveModel::Type::Value
+      def type: () -> :enumerize
+
+      def initialize: (untyped attr) -> void
+
+      def serialize: (untyped value) -> untyped
+
+      def deserialize: (untyped value) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module ActiveRecordSupport
+    def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+    module InstanceMethods
+      # https://github.com/brainspec/enumerize/issues/74
+      def write_attribute: (untyped attr_name, untyped value, *untyped options) -> untyped
+
+      # Support multiple enumerized attributes
+      def becomes: (untyped klass) -> untyped
+
+      def reload: (?untyped? options) -> untyped
+    end
+
+    module RelationMethods
+      def update_all: (untyped updates) -> untyped
+    end
+
+    class Type < ActiveRecord::Type::Value
+      def initialize: (untyped attr, untyped subtype) -> void
+
+      def serialize: (untyped value) -> untyped
+
+      alias type_cast_for_database serialize
+
+      def deserialize: (untyped value) -> untyped
+
+      alias type_cast_from_database deserialize
+
+      def as_json: (?untyped? options) -> untyped
+
+      def encode_with: (untyped coder) -> untyped
+
+      def init_with: (untyped coder) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  class Attribute
+    attr_reader klass: untyped
+
+    attr_reader name: untyped
+
+    attr_reader values: untyped
+
+    attr_reader default_value: untyped
+
+    attr_reader i18n_scope: untyped
+
+    attr_reader skip_validations_value: untyped
+
+    def initialize: (untyped klass, untyped name, ?::Hash[untyped, untyped] options) -> void
+
+    def find_default_value: (untyped value) -> untyped
+
+    def find_value: (untyped value) -> (untyped | nil)
+
+    def find_values: (*untyped values) -> untyped
+
+    def each_value: () { (untyped) -> untyped } -> untyped
+
+    def i18n_scopes: () -> untyped
+
+    def options: (?::Hash[untyped, untyped] options) -> untyped
+
+    def respond_to_missing?: (untyped method, ?bool include_private) -> untyped
+
+    def define_methods!: (untyped mod) -> untyped
+
+    private
+
+    def method_missing: (untyped method) -> untyped
+  end
+
+  module Multiple
+    def find_default_value: (untyped value) -> untyped
+
+    def define_methods!: (untyped mod) -> untyped
+  end
+end
+
+module Enumerize
+  class AttributeMap
+    attr_reader attributes: untyped
+
+    def initialize: () -> void
+
+    def []: (untyped name) -> untyped
+
+    def <<: (untyped attr) -> untyped
+
+    def each: () { (untyped) -> untyped } -> untyped
+
+    def empty?: () -> untyped
+
+    def add_dependant: (untyped dependant) -> untyped
+  end
+end
+
+module Enumerize
+  module Base
+    def self.included: (untyped base) -> untyped
+
+    module ClassMethods
+      def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      def enumerized_attributes: () -> untyped
+
+      module Hook
+        def inherited: (untyped subclass) -> untyped
+      end
+
+      private
+
+      def _enumerize_module: () -> untyped
+    end
+
+    def initialize: (*untyped args, **untyped kwargs) -> void
+
+    def read_attribute_for_validation: (untyped key) -> untyped
+
+    private
+
+    def _enumerized_values_for_validation: () -> untyped
+
+    def _validate_enumerized_attributes: () -> untyped
+
+    def _set_default_value_for_enumerized_attributes: () -> untyped
+  end
+end
+
+module Enumerize
+  module Hooks
+    module FormtasticFormBuilderExtension
+      def input: (untyped method, ?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Hooks
+    module SequelDataset
+      def literal_append: (untyped sql, untyped v) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Hooks
+    module SimpleFormBuilderExtension
+      def input: (untyped attribute_name, ?::Hash[untyped, untyped] options) ?{ () -> untyped } -> untyped
+
+      def input_field: (untyped attribute_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      private
+
+      def add_input_options_for_enumerized_attribute: (untyped attribute_name, untyped options) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Hooks
+    module UniquenessValidator
+      def validate_each: (untyped record, untyped name, untyped value) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Integrations
+    module RailsAdmin
+      def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Integrations
+    module RSpec
+      def enumerize: (untyped attr) -> untyped
+    end
+  end
+end
+
+module RSpec
+  module Matchers
+    include Enumerize::Integrations::RSpec
+  end
+end
+
+module Enumerize
+  module Integrations
+    module RSpec
+      class Matcher
+        def initialize: (untyped expected_attr) -> void
+
+        def in: (*untyped expected_values) -> self
+
+        def with_default: (untyped expected_default) -> self
+
+        def with_i18n_scope: (untyped expected_i18n_scope) -> self
+
+        def with_predicates: (untyped expected_predicates) -> self
+
+        def with_multiple: (untyped expected_multiple) -> self
+
+        def with_scope: (untyped expected_scope) -> self
+
+        def failure_message: () -> ::String
+
+        def failure_message_when_negated: () -> ::String
+
+        def description: () -> untyped
+
+        def matches?: (untyped subject) -> untyped
+
+        private
+
+        attr_accessor expected_attr: untyped
+
+        attr_accessor expected_values: untyped
+
+        attr_accessor subject: untyped
+
+        attr_accessor expected_default: untyped
+
+        attr_accessor expected_i18n_scope: untyped
+
+        attr_accessor expected_predicates: untyped
+
+        attr_accessor expected_multiple: untyped
+
+        attr_accessor expected_scope: untyped
+
+        def expectation: () -> ::String
+
+        def matches_attribute?: () -> untyped
+
+        def matches_values?: () -> untyped
+
+        def matches_array_values?: () -> untyped
+
+        def matches_hash_values?: () -> (nil | untyped)
+
+        def matches_default_value?: () -> untyped
+
+        def matches_i18n_scope?: () -> untyped
+
+        def matches_predicates?: () -> untyped
+
+        def matches_multiple?: () -> untyped
+
+        def matches_scope?: () -> untyped
+
+        def sorted_values: () -> untyped
+
+        def enumerized_values: () -> untyped
+
+        def enumerized_default: () -> untyped
+
+        def enumerized_value_hash: () -> untyped
+
+        def attributes: () -> untyped
+
+        def subject_class: () -> untyped
+
+        def quote_values: (untyped values) -> untyped
+      end
+    end
+  end
+end
+
+module Enumerize
+  class Module < ::Module
+    attr_reader _class_methods: untyped
+
+    def initialize: () -> void
+
+    def included: (untyped klass) -> untyped
+
+    def dependent_eval: () ?{ () -> untyped } -> untyped
+  end
+end
+
+module Enumerize
+  module ModuleAttributes
+    def included: (untyped base) -> untyped
+  end
+end
+
+module Enumerize
+  module MongoidSupport
+    def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+    module InstanceMethods
+      def reload: () -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Predicatable
+    def respond_to_missing?: (untyped method, ?bool include_private) -> untyped
+
+    private
+
+    def method_missing: (untyped method, *untyped args) ?{ () -> untyped } -> untyped
+
+    def predicate_method?: (untyped method) -> untyped
+  end
+end
+
+module Enumerize
+  # Predicate methods.
+  #
+  # Basic usage:
+  #
+  #     class User
+  #       extend Enumerize
+  #       enumerize :sex, in: %w(male female), predicates: true
+  #     end
+  #
+  #     user = User.new
+  #
+  #     user.male?   # => false
+  #     user.female? # => false
+  #
+  #     user.sex = 'male'
+  #
+  #     user.male?   # => true
+  #     user.female? # => false
+  #
+  # Using prefix:
+  #
+  #     class User
+  #       extend Enumerize
+  #       enumerize :sex, in: %w(male female), predicates: { prefix: true }
+  #     end
+  #
+  #     user = User.new
+  #     user.sex = 'female'
+  #     user.sex_female? # => true
+  #
+  # Use <tt>only</tt> and <tt>except</tt> options to specify what values create
+  # predicate methods for.
+  module Predicates
+    def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+    class Builder
+      def initialize: (untyped attr, untyped options) -> void
+
+      def values: () -> untyped
+
+      def names: () -> untyped
+
+      def build: (untyped klass) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Scope
+    module ActiveRecord
+      def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      private
+
+      def _define_activerecord_scope_methods!: (untyped name, untyped options) -> untyped
+
+      def _define_activerecord_shallow_scopes!: (untyped attribute_name) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Scope
+    module Mongoid
+      def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      private
+
+      def _define_mongoid_scope_methods!: (untyped name, untyped options) -> untyped
+
+      def _define_mongoid_shallow_scopes!: (untyped attribute_name) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module Scope
+    module Sequel
+      def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      private
+
+      def _define_sequel_scope_methods!: (untyped name, untyped options) -> untyped
+
+      def _define_sequel_shallow_scopes!: (untyped attribute_name) -> untyped
+    end
+  end
+end
+
+module Enumerize
+  module SequelSupport
+    def enumerize: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+    private
+
+    module InstanceMethods
+      def validate: () -> untyped
+
+      def _set_default_value_for_enumerized_attributes: () -> untyped
+    end
+  end
+end
+
+module Enumerize
+  class Set
+    include Predicatable
+
+    attr_reader values: untyped
+
+    def initialize: (untyped obj, untyped attr, untyped values) -> void
+
+    def <<: (untyped value) -> untyped
+
+    alias push <<
+
+    def to_ary: () -> untyped
+
+    def texts: () -> untyped
+
+    def ==: (untyped other) -> (false | untyped)
+
+    alias eql? ==
+
+    def include?: (untyped value) -> untyped
+
+    def delete: (untyped value) -> untyped
+
+    def inspect: () -> ::String
+
+    def encode_with: (untyped coder) -> untyped
+
+    private
+
+    def predicate_call: (untyped value) -> untyped
+
+    def mutate!: () -> untyped
+  end
+end
+
+module Enumerize
+  module Utils
+    def self.call_if_callable: (untyped value, ?untyped? param) -> untyped
+  end
+end
+
+module Enumerize
+  class Value < String
+    include Predicatable
+
+    attr_reader value: untyped
+
+    def initialize: (untyped attr, untyped name, ?untyped? value) -> void
+
+    def text: () -> (untyped | nil)
+
+    def ==: (untyped other) -> untyped
+
+    def encode_with: (untyped coder) -> untyped
+
+    private
+
+    def predicate_call: (untyped value) -> untyped
+  end
+end
+
+module Enumerize
+  VERSION: ::String
+end
+
+module Sequel
+  module Plugins
+    module Enumerize
+      # Depend on the def_dataset_method plugin
+      def self.apply: (untyped model) -> (untyped | nil)
+
+      module InstanceMethods
+        def self.included: (untyped base) -> untyped
+      end
+    end
+  end
+end

--- a/gems/enumerize/2.5/patch.rbs
+++ b/gems/enumerize/2.5/patch.rbs
@@ -1,0 +1,13 @@
+module ActiveModel
+  module Type
+    class Value
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class Value
+    end
+  end
+end


### PR DESCRIPTION
Add type definitions for [enumerize gem](https://github.com/brainspec/enumerize).
The type definitions to be added are those generated by the `rbs prototype rb` command.

```shell
$ rbs prototype rb gems/enumerize/2.5/_src/lib/**/*.rb >> gems/enumerize/2.5/enumerize-generated.rbs
```

Sorry for the small amount of tests...
I can't find any cases where other methods are used for projects, and this is the only one.