### PR TITLE
Add RBS for holidays gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "gems/enumerize/2.5/_src"]
 	path = gems/enumerize/2.5/_src
 	url = https://github.com/brainspec/enumerize.git
+[submodule "gems/holidays/8.4/_src"]
+	path = gems/holidays/8.4/_src
+	url = https://github.com/holidays/holidays.git

--- a/gems/holidays/8.4/_scripts/test
+++ b/gems/holidays/8.4/_scripts/test
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'
+	'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r holidays:8.4 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/holidays/8.4/_test/Steepfile
+++ b/gems/holidays/8.4/_test/Steepfile
@@ -1,0 +1,13 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "holidays"
+
+  library "date"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/holidays/8.4/_test/test.rb
+++ b/gems/holidays/8.4/_test/test.rb
@@ -1,0 +1,9 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "holidays"
+
+
+Holidays.on(Date.civil(2022, 8, 11), :jp)
+
+Holidays.between(Date.civil(2022, 8, 10), Date.civil(2022, 8, 12), :jp)

--- a/gems/holidays/8.4/holidays-generated.rbs
+++ b/gems/holidays/8.4/holidays-generated.rbs
@@ -1,0 +1,2221 @@
+# encoding: utf-8
+module Holidays
+  REGIONS: ::Array[:ar | :at | :au | :au_nsw | :au_vic | :au_qld | :au_nt | :au_act | :au_sa | :au_wa | :au_tas | :au_tas_south | :au_qld_cairns | :au_qld_brisbane | :au_tas_north | :au_vic_melbourne | :be_fr | :be_nl | :br | :bg_en | :bg_bg | :ca | :ca_qc | :ca_ab | :ca_sk | :ca_on | :ca_bc | :ca_nb | :ca_mb | :ca_ns | :ca_pe | :ca_nl | :ca_nt | :ca_nu | :ca_yt | :us | :ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_ne | :ch_ge | :ch_ju | :ch_vs | :ch | :cl | :co | :cr | :cz | :dk | :de | :de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn_sorbian | :de_th_cath | :de_sn | :de_st | :de_be | :de_by_cath | :de_by_augsburg | :de_bb | :de_mv | :de_th | :de_hb | :de_hh | :de_ni | :de_sh | :ecbtarget | :ee | :el | :es_pv | :es_na | :es_an | :es_ib | :es_cm | :es_mu | :es_m | :es_ar | :es_cl | :es_cn | :es_lo | :es_ga | :es_ce | :es_o | :es_ex | :es | :es_ct | :es_v | :es_vc | :federalreserve | :federalreservebanks | :fedex | :fi | :fr_a | :fr_m | :fr | :gb | :gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy | :gb_sct | :gb_con | :im | :gb_iom | :ge | :hr | :hk | :hu | :ie | :is | :it | :it_ve | :it_tv | :it_vr | :it_pd | :it_fi | :it_ge | :it_to | :it_rm | :it_vi | :it_bl | :it_ro | :kr | :kz | :li | :lt | :lv | :ma | :mt_mt | :mt_en | :mx | :mx_pue | :nerc | :nl | :lu | :no | :nyse | :nz | :nz_sl | :nz_we | :nz_ak | :nz_nl | :nz_ne | :nz_ot | :nz_ta | :nz_sc | :nz_hb | :nz_mb | :nz_ca | :nz_ch | :nz_wl | :pe | :ph | :pl | :pt | :pt_li | :pt_po | :ro | :rs_cyrl | :rs_la | :ru | :se | :tn | :tr | :ua | :us_fl | :us_la | :us_ct | :us_de | :us_gu | :us_hi | :us_in | :us_ky | :us_nj | :us_nc | :us_nd | :us_pr | :us_tn | :us_ms | :us_id | :us_ar | :us_tx | :us_dc | :us_md | :us_va | :us_vt | :us_ak | :us_ca | :us_me | :us_ma | :us_al | :us_ga | :us_ne | :us_mo | :us_sc | :us_wv | :us_vi | :us_ut | :us_ri | :us_az | :us_co | :us_il | :us_mt | :us_nm | :us_ny | :us_oh | :us_pa | :us_mi | :us_mn | :us_nv | :us_or | :us_sd | :us_wa | :us_wi | :us_wy | :us_ia | :us_ks | :us_nh | :us_ok | :unitednations | :ups | :za | :ve | :sk | :si | :jp | :vi | :sg | :my | :th | :ng]
+
+  PARENT_REGION_LOOKUP: { ar: :ar, at: :at, au: :au, au_nsw: :au, au_vic: :au, au_qld: :au, au_nt: :au, au_act: :au, au_sa: :au, au_wa: :au, au_tas: :au, au_tas_south: :au, au_qld_cairns: :au, au_qld_brisbane: :au, au_tas_north: :au, au_vic_melbourne: :au, be_fr: :be_fr, be_nl: :be_nl, br: :br, bg_en: :bg, bg_bg: :bg, ca: :ca, ca_qc: :ca, ca_ab: :ca, ca_sk: :ca, ca_on: :ca, ca_bc: :ca, ca_nb: :ca, ca_mb: :ca, ca_ns: :ca, ca_pe: :ca, ca_nl: :ca, ca_nt: :ca, ca_nu: :ca, ca_yt: :ca, us: :us, ch_zh: :ch, ch_be: :ch, ch_lu: :ch, ch_ur: :ch, ch_sz: :ch, ch_ow: :ch, ch_nw: :ch, ch_gl: :ch, ch_zg: :ch, ch_fr: :ch, ch_so: :ch, ch_bs: :ch, ch_bl: :ch, ch_sh: :ch, ch_ar: :ch, ch_ai: :ch, ch_sg: :ch, ch_gr: :ch, ch_ag: :ch, ch_tg: :ch, ch_ti: :ch, ch_vd: :ch, ch_ne: :ch, ch_ge: :ch, ch_ju: :ch, ch_vs: :ch, ch: :ch, cl: :cl, co: :co, cr: :cr, cz: :cz, dk: :dk, de: :de, de_bw: :de, de_by: :de, de_he: :de, de_nw: :de, de_rp: :de, de_sl: :de, de_sn_sorbian: :de, de_th_cath: :de, de_sn: :de, de_st: :de, de_be: :de, de_by_cath: :de, de_by_augsburg: :de, de_bb: :de, de_mv: :de, de_th: :de, de_hb: :de, de_hh: :de, de_ni: :de, de_sh: :de, ecbtarget: :ecbtarget, ee: :ee, el: :el, es_pv: :es, es_na: :es, es_an: :es, es_ib: :es, es_cm: :es, es_mu: :es, es_m: :es, es_ar: :es, es_cl: :es, es_cn: :es, es_lo: :es, es_ga: :es, es_ce: :es, es_o: :es, es_ex: :es, es: :es, es_ct: :es, es_v: :es, es_vc: :es, federalreserve: :federalreserve, federalreservebanks: :federalreservebanks, fedex: :fedex, fi: :fi, fr_a: :fr, fr_m: :fr, fr: :fr, gb: :gb, gb_eng: :gb, gb_wls: :gb, gb_eaw: :gb, gb_nir: :gb, je: :gb, gb_jsy: :gb, gg: :gb, gb_gsy: :gb, gb_sct: :gb, gb_con: :gb, im: :gb, gb_iom: :gb, ge: :ge, hr: :hr, hk: :hk, hu: :hu, ie: :ie, is: :is, it: :it, it_ve: :it, it_tv: :it, it_vr: :it, it_pd: :it, it_fi: :it, it_ge: :it, it_to: :it, it_rm: :it, it_vi: :it, it_bl: :it, it_ro: :it, kr: :kr, kz: :kz, li: :li, lt: :lt, lv: :lv, ma: :ma, mt_mt: :mt_mt, mt_en: :mt_en, mx: :mx, mx_pue: :mx, nerc: :nerc, nl: :nl, lu: :lu, no: :no, nyse: :nyse, nz: :nz, nz_sl: :nz, nz_we: :nz, nz_ak: :nz, nz_nl: :nz, nz_ne: :nz, nz_ot: :nz, nz_ta: :nz, nz_sc: :nz, nz_hb: :nz, nz_mb: :nz, nz_ca: :nz, nz_ch: :nz, nz_wl: :nz, pe: :pe, ph: :ph, pl: :pl, pt: :pt, pt_li: :pt, pt_po: :pt, ro: :ro, rs_cyrl: :rs_cyrl, rs_la: :rs_la, ru: :ru, se: :se, tn: :tn, tr: :tr, ua: :ua, us_fl: :us, us_la: :us, us_ct: :us, us_de: :us, us_gu: :us, us_hi: :us, us_in: :us, us_ky: :us, us_nj: :us, us_nc: :us, us_nd: :us, us_pr: :us, us_tn: :us, us_ms: :us, us_id: :us, us_ar: :us, us_tx: :us, us_dc: :us, us_md: :us, us_va: :us, us_vt: :us, us_ak: :us, us_ca: :us, us_me: :us, us_ma: :us, us_al: :us, us_ga: :us, us_ne: :us, us_mo: :us, us_sc: :us, us_wv: :us, us_vi: :us, us_ut: :us, us_ri: :us, us_az: :us, us_co: :us, us_il: :us, us_mt: :us, us_nm: :us, us_ny: :us, us_oh: :us, us_pa: :us, us_mi: :us, us_mn: :us, us_nv: :us, us_or: :us, us_sd: :us, us_wa: :us, us_wi: :us, us_wy: :us, us_ia: :us, us_ks: :us, us_nh: :us, us_ok: :us, unitednations: :unitednations, ups: :ups, za: :za, ve: :southamerica, sk: :europe, si: :europe, jp: :jp, vi: :vi, sg: :sg, my: :my, th: :th, ng: :ng }
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ar.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module AR
+    def self.defined_regions: () -> ::Array[:ar]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:ar] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Carnaval Lunes", regions: ::Array[:ar] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Carnaval Martes", regions: ::Array[:ar] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ar] }], 3 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:ar] }], 4 => ::Array[{ mday: 2, name: ::String, regions: ::Array[:ar] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ar] } | { mday: 25, name: ::String, regions: ::Array[:ar] } | { mday: 24, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:ar] }], 6 => ::Array[{ mday: 17, function: "to_nearest_monday(date)", function_arguments: ::Array[:date], name: ::String, regions: ::Array[:ar] } | { mday: 20, name: ::String, regions: ::Array[:ar] }], 7 => ::Array[{ mday: 8, year_ranges: { limited: ::Array[2016] }, name: ::String, regions: ::Array[:ar] } | { mday: 9, name: ::String, regions: ::Array[:ar] }], 8 => ::Array[{ mday: 17, function: "to_nearest_monday(date)", function_arguments: ::Array[:date], name: ::String, regions: ::Array[:ar] }], 10 => ::Array[{ mday: 12, function: "to_nearest_monday(date)", function_arguments: ::Array[:date], name: ::String, regions: ::Array[:ar] } | { mday: 8, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:ar] }], 11 => ::Array[{ mday: 20, name: ::String, regions: ::Array[:ar] } | { mday: 22, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:ar] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:ar] } | { mday: 9, year_ranges: { limited: ::Array[2016] }, name: ::String, regions: ::Array[:ar] } | { mday: 25, name: "Navidad", regions: ::Array[:ar] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/at.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module AT
+    def self.defined_regions: () -> ::Array[:at]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Christi Himmelfahrt", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:at] }], 1 => ::Array[{ mday: 1, name: "Neujahrstag", regions: ::Array[:at] } | { mday: 6, name: ::String, regions: ::Array[:at] }], 5 => ::Array[{ mday: 1, name: "Staatsfeiertag", regions: ::Array[:at] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:at] }], 10 => ::Array[{ mday: 26, name: "Nationalfeiertag", regions: ::Array[:at] }], 11 => ::Array[{ mday: 1, name: "Allerheiligen", regions: ::Array[:at] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:at] } | { mday: 25, name: "1. Weihnachtstag", regions: ::Array[:at] } | { mday: 26, name: "2. Weihnachtstag", regions: ::Array[:at] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/au.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module AU
+    def self.defined_regions: () -> ::Array[:au | :au_nsw | :au_vic | :au_qld | :au_nt | :au_act | :au_sa | :au_wa | :au_tas | :au_tas_south | :au_qld_cairns | :au_qld_brisbane | :au_tas_north | :au_vic_melbourne]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:au] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: "Easter Saturday", regions: ::Array[:au_nsw | :au_vic | :au_qld | :au_nt | :au_act | :au_sa] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Easter Sunday", regions: ::Array[:au_nsw | :au_vic] } | { function: "easter(year)", function_arguments: ::Array[:year], year_ranges: { from: 2017 }, name: "Easter Sunday", regions: ::Array[:au_qld | :au_act] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:au] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:au | :au_nsw | :au_vic | :au_act | :au_sa | :au_wa | :au_nt | :au_qld] } | { mday: 1, function: "to_monday_if_weekend(date)", function_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:au_tas] } | { mday: 26, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Australia Day", regions: ::Array[:au] }], 2 => ::Array[{ wday: 1, week: 2, name: "Royal Hobart Regatta", regions: ::Array[:au_tas_south] }], 3 => ::Array[{ wday: 1, week: 1, name: "Labour Day", regions: ::Array[:au_wa] } | { wday: 1, week: 2, name: "Eight Hours Day", regions: ::Array[:au_tas] } | { wday: 1, week: 2, name: "Labour Day", regions: ::Array[:au_vic] } | { function: "march_pub_hol_sa(year)", function_arguments: ::Array[:year], name: "March Public Holiday", regions: ::Array[:au_sa] } | { wday: 1, week: 2, name: "Canberra Day", regions: ::Array[:au_act] }], 4 => ::Array[{ mday: 25, name: "ANZAC Day", regions: ::Array[:au | :au_vic] } | { mday: 25, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "ANZAC Day", regions: ::Array[:au_nsw | :au_qld | :au_nt | :au_act | :au_sa | :au_tas] } | { mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "ANZAC Day", regions: ::Array[:au_wa] }], 5 => ::Array[{ function: "qld_labour_day_may(year)", function_arguments: ::Array[:year], name: "Labour Day", regions: ::Array[:au_qld] } | { wday: 1, week: 1, name: "May Day", regions: ::Array[:au_nt] } | { function: "may_pub_hol_sa(year)", function_arguments: ::Array[:year], name: "May Public Holiday", regions: ::Array[:au_sa] }], 6 => ::Array[{ wday: 1, week: 1, name: "Western Australia Day", regions: ::Array[:au_wa] } | { wday: 1, week: 2, name: "Queen's Birthday", regions: ::Array[:au_act | :au_nsw | :au_sa | :au_tas | :au_nt | :au_vic] } | { function: "qld_queens_birthday_june(year)", function_arguments: ::Array[:year], name: "Queen's Birthday", regions: ::Array[:au_qld] } | { mday: 6, type: :informal, name: "Queensland Day", regions: ::Array[:au_qld] }], 7 => ::Array[{ wday: 5, week: 3, name: "Cairns Show", regions: ::Array[:au_qld_cairns] }], 8 => ::Array[{ wday: 3, week: -3, name: "Ekka", regions: ::Array[:au_qld_brisbane] }], 9 => ::Array[{ wday: 1, week: -1, name: "Queen's Birthday", regions: ::Array[:au_wa] } | { wday: 1, week: -1, name: "Family & Community Day", regions: ::Array[:au_act] }], 10 => ::Array[{ function: "afl_grand_final(year)", function_arguments: ::Array[:year], name: "Friday before the AFL Grand Final", regions: ::Array[:au_vic] } | { wday: 1, week: 1, name: "Labour Day", regions: ::Array[:au_act | :au_nsw | :au_sa] } | { function: "qld_labour_day_october(year)", function_arguments: ::Array[:year], observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Labour Day", regions: ::Array[:au_qld] } | { function: "qld_queens_bday_october(year)", function_arguments: ::Array[:year], observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Queen's Birthday", regions: ::Array[:au_qld] } | { function: "hobart_show_day(year)", function_arguments: ::Array[:year], name: "Royal Hobart Show", regions: ::Array[:au_tas_south] }], 11 => ::Array[{ function: "g20_day_2014_only(year)", function_arguments: ::Array[:year], name: "G20 Day", regions: ::Array[:au_qld_brisbane] } | { wday: 1, week: 1, name: "Recreation Day", regions: ::Array[:au_tas_north] } | { wday: 2, week: 1, name: "Melbourne Cup Day", regions: ::Array[:au_vic_melbourne] }], 12 => ::Array[{ mday: 25, observed: "to_tuesday_if_sunday_or_monday_if_saturday(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:au_qld | :au_nsw | :au_act | :au_tas | :au_wa | :au_vic | :au_nt] } | { mday: 26, observed: "to_tuesday_if_sunday_or_monday_if_saturday(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:au_nsw | :au_vic | :au_qld | :au_act | :au_wa] } | { function: "to_weekday_if_boxing_weekend_from_year(year)", function_arguments: ::Array[:year], name: "Boxing Day", regions: ::Array[:au_tas | :au_nt] } | { function: "to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)", function_arguments: ::Array[:year], name: "Proclamation Day", regions: ::Array[:au_sa] } | { mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:au_sa] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/be.yaml
+  #
+  # To use the definitions in this file, load it right after you load the
+  # Holiday gem:
+  #
+  #   require 'holidays'
+  #   require 'generated_definitions/be'
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module BE
+    def self.defined_regions: () -> ::Array[:be]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:be] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:be] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Ascension", regions: ::Array[:be] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:be] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:be] }], 1 => ::Array[{ mday: 1, name: "Jour de l'an", regions: ::Array[:be] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:be] }], 7 => ::Array[{ mday: 21, name: ::String, regions: ::Array[:be] }], 8 => ::Array[{ mday: 15, name: "Assomption", regions: ::Array[:be] }], 11 => ::Array[{ mday: 1, name: "Toussaint", regions: ::Array[:be] } | { mday: 11, name: "Armistice 1918", regions: ::Array[:be] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:be] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/be_fr.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module BE_FR
+    def self.defined_regions: () -> ::Array[:be_fr]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Ascension", regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:be_fr] }], 1 => ::Array[{ mday: 1, name: "Jour de l'an", regions: ::Array[:be_fr] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:be_fr] }], 7 => ::Array[{ mday: 21, name: ::String, regions: ::Array[:be_fr] }], 8 => ::Array[{ mday: 15, name: "Assomption", regions: ::Array[:be_fr] }], 11 => ::Array[{ mday: 1, name: "Toussaint", regions: ::Array[:be_fr] } | { mday: 11, name: "Armistice 1918", regions: ::Array[:be_fr] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:be_fr] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/be_nl.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module BE_NL
+    def self.defined_regions: () -> ::Array[:be_nl]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: "Pasen", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Paasmaandag", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "O.H. Hemelvaart", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pinksteren", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pinkstermaandag", regions: ::Array[:be_nl] }], 1 => ::Array[{ mday: 1, name: "Nieuwjaar", regions: ::Array[:be_nl] }], 5 => ::Array[{ mday: 1, name: "Feest van de Arbeid", regions: ::Array[:be_nl] }], 7 => ::Array[{ mday: 21, name: "Nationale Feestdag", regions: ::Array[:be_nl] }], 8 => ::Array[{ mday: 15, name: "O.L.V. Hemelvaart", regions: ::Array[:be_nl] }], 11 => ::Array[{ mday: 1, name: "Allerheiligen", regions: ::Array[:be_nl] } | { mday: 11, name: "Wapenstilstand 1918", regions: ::Array[:be_nl] }], 12 => ::Array[{ mday: 25, name: "Kerstmis", regions: ::Array[:be_nl] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/bg.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module BG
+    def self.defined_regions: () -> ::Array[:bg_en | :bg_bg]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:bg_en] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:bg_bg] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -1, name: "Holy Saturday", regions: ::Array[:bg_en] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:bg_bg] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], name: "Easter Sunday", regions: ::Array[:bg_en] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:bg_bg] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:bg_en] }], 1 => ::Array[{ mday: 1, name: "New Year's Day", regions: ::Array[:bg_en] } | { mday: 1, name: ::String, regions: ::Array[:bg_bg] }], 3 => ::Array[{ mday: 3, name: "Liberation Day", regions: ::Array[:bg_en] } | { mday: 3, name: ::String, regions: ::Array[:bg_bg] }], 5 => ::Array[{ mday: 1, name: "Labour Day", regions: ::Array[:bg_en] } | { mday: 1, name: ::String, regions: ::Array[:bg_bg] } | { mday: 6, name: "St. George's Day", regions: ::Array[:bg_en] } | { mday: 6, name: ::String, regions: ::Array[:bg_bg] } | { mday: 24, name: "Slavic Literacy Day", regions: ::Array[:bg_en] } | { mday: 24, name: ::String, regions: ::Array[:bg_bg] }], 9 => ::Array[{ mday: 6, name: "Unification Day", regions: ::Array[:bg_en] } | { mday: 6, name: ::String, regions: ::Array[:bg_bg] } | { mday: 22, name: "The Independence Day", regions: ::Array[:bg_en] } | { mday: 22, name: ::String, regions: ::Array[:bg_bg] }], 11 => ::Array[{ mday: 1, name: "Revival Leader's Day", regions: ::Array[:bg_en] } | { mday: 1, name: ::String, regions: ::Array[:bg_bg] }], 12 => ::Array[{ mday: 24, name: "Christmas Eve", regions: ::Array[:bg_en] } | { mday: 24, name: ::String, regions: ::Array[:bg_bg] } | { mday: 25, name: "Christmas", regions: ::Array[:bg_en] } | { mday: 25, name: ::String, regions: ::Array[:bg_bg] } | { mday: 26, name: "Christmas", regions: ::Array[:bg_en] } | { mday: 26, name: ::String, regions: ::Array[:bg_bg] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/br.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module BR
+    def self.defined_regions: () -> ::Array[:br]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, type: :informal, name: "Carnaval", regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Sexta-feira Santa", regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Corpus Christi", regions: ::Array[:br] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:br] }], 4 => ::Array[{ mday: 21, name: "Dia de Tiradentes", regions: ::Array[:br] }], 5 => ::Array[{ mday: 1, name: "Dia do Trabalho", regions: ::Array[:br] }], 9 => ::Array[{ mday: 7, name: ::String, regions: ::Array[:br] }], 10 => ::Array[{ mday: 12, name: "Dia de Nossa Senhora Aparecida", regions: ::Array[:br] }], 11 => ::Array[{ mday: 2, name: "Dia de Finados", regions: ::Array[:br] } | { mday: 15, name: ::String, regions: ::Array[:br] }], 12 => ::Array[{ mday: 25, name: "Natal", regions: ::Array[:br] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ca.yaml, definitions/northamericainformal.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module CA
+    def self.defined_regions: () -> ::Array[:ca | :ca_qc | :ca_ab | :ca_sk | :ca_on | :ca_bc | :ca_nb | :ca_mb | :ca_ns | :ca_pe | :ca_nl | :ca_nt | :ca_nu | :ca_yt | :us]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:ca] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Easter Sunday", regions: ::Array[:ca] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, type: :informal, name: "Easter Monday", regions: ::Array[:ca] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:ca] } | { mday: 2, name: "New Year's", regions: ::Array[:ca_qc] }], 2 => ::Array[{ wday: 1, week: 3, year_ranges: { from: 1990 }, name: "Family Day", regions: ::Array[:ca_ab] } | { wday: 1, week: 3, year_ranges: { from: 2007 }, name: "Family Day", regions: ::Array[:ca_sk] } | { wday: 1, week: 3, year_ranges: { from: 2008 }, name: "Family Day", regions: ::Array[:ca_on] } | { wday: 1, week: 2, year_ranges: { between: ::Range[::Integer] }, name: "Family Day", regions: ::Array[:ca_bc] } | { wday: 1, week: 3, year_ranges: { from: 2019 }, name: "Family Day", regions: ::Array[:ca_bc] } | { wday: 1, week: 3, year_ranges: { from: 2018 }, name: "Family Day", regions: ::Array[:ca_nb] } | { wday: 1, week: 3, name: "Louis Riel Day", regions: ::Array[:ca_mb] } | { wday: 1, week: 3, year_ranges: { from: 2015 }, name: "Nova Scotia Heritage Day", regions: ::Array[:ca_ns] } | { wday: 1, week: 3, name: "Islander Day", regions: ::Array[:ca_pe] } | { mday: 2, type: :informal, name: "Groundhog Day", regions: ::Array[:us | :ca] } | { mday: 14, type: :informal, name: "Valentine's Day", regions: ::Array[:us | :ca] }], 3 => ::Array[{ mday: 17, type: :informal, name: "St. Patrick's Day", regions: ::Array[:ca_nl] } | { mday: 23, type: :informal, name: "St. George's Day", regions: ::Array[:ca_nl] } | { mday: 17, type: :informal, name: "St. Patrick's Day", regions: ::Array[:us | :ca] }], 5 => ::Array[{ function: "ca_victoria_day(year)", function_arguments: ::Array[:year], name: "Victoria Day", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nt | :ca_nu | :ca_on | :ca_sk | :ca_yt] } | { function: "ca_victoria_day(year)", function_arguments: ::Array[:year], name: "National Patriotes Day", regions: ::Array[:ca_qc] } | { wday: 0, week: 2, type: :informal, name: "Mother's Day", regions: ::Array[:us | :ca] } | { wday: 6, week: 3, type: :informal, name: "Armed Forces Day", regions: ::Array[:us] }], 6 => ::Array[{ mday: 24, type: :informal, name: "Discovery Day", regions: ::Array[:ca_nl] } | { mday: 24, name: ::String, regions: ::Array[:ca_qc] } | { mday: 21, name: "National Aboriginal Day", regions: ::Array[:ca_nt] } | { mday: 21, year_ranges: { from: 2017 }, name: "National Aboriginal Day", regions: ::Array[:ca_yt] } | { wday: 0, week: 3, type: :informal, name: "Father's Day", regions: ::Array[:us | :ca] }], 7 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Canada Day", regions: ::Array[:ca] } | { mday: 12, type: :informal, name: "Orangemen's Day", regions: ::Array[:ca_nl] } | { mday: 9, year_ranges: { from: 2020 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Nunavut Day", regions: ::Array[:ca_nu] }], 8 => ::Array[{ wday: 1, week: 1, name: "B.C. Day", regions: ::Array[:ca_bc] } | { wday: 1, week: 1, name: "Saskatchewan Day", regions: ::Array[:ca_sk] } | { wday: 1, week: 1, type: :informal, name: "Heritage Day", regions: ::Array[:ca_ab] } | { wday: 1, week: 1, type: :informal, name: "Natal Day", regions: ::Array[:ca_ns] } | { wday: 1, week: 1, name: "Civic Holiday", regions: ::Array[:ca_nt | :ca_nu] } | { wday: 1, week: 1, type: :informal, name: "Civic Holiday", regions: ::Array[:ca_on | :ca_pe] } | { wday: 1, week: 1, name: "New Brunswick Day", regions: ::Array[:ca_nb] } | { wday: 1, week: 1, type: :informal, name: "Terry Fox Day", regions: ::Array[:ca_mb] } | { wday: 1, week: 3, name: "Discovery Day", regions: ::Array[:ca_yt] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labour Day", regions: ::Array[:ca] } | { mday: 30, year_ranges: { from: 2021 }, name: "National Day for Truth and Reconciliation", regions: ::Array[:ca] }], 10 => ::Array[{ wday: 1, week: 2, name: "Thanksgiving", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nt | :ca_nu | :ca_on | :ca_qc | :ca_sk | :ca_yt] } | { mday: 31, type: :informal, name: "Halloween", regions: ::Array[:us | :ca] }], 11 => ::Array[{ mday: 11, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Remembrance Day", regions: ::Array[:ca_ab | :ca_sk | :ca_bc | :ca_pe | :ca_nl | :ca_nt | :ca_nu | :ca_nb | :ca_yt] }], 12 => ::Array[{ mday: 25, year_ranges: { until: 2020 }, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ca_on] } | { mday: 25, year_ranges: { from: 2020 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ca_on] } | { mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nb | :ca_nl | :ca_nt | :ca_ns | :ca_nu | :ca_pe | :ca_qc | :ca_sk | :ca_yt] } | { mday: 26, year_ranges: { until: 2020 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:ca_on] } | { mday: 26, year_ranges: { from: 2020 }, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:ca_on] } | { mday: 26, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], type: :informal, name: "Boxing Day", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nb | :ca_nl | :ca_nt | :ca_ns | :ca_nu | :ca_pe | :ca_qc | :ca_sk | :ca_yt] }], 4 => ::Array[{ mday: 1, type: :informal, name: "April Fool's Day", regions: ::Array[:us | :ca] } | { mday: 22, type: :informal, name: "Earth Day", regions: ::Array[:us | :ca] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ch.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module CH
+    def self.defined_regions: () -> ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_ne | :ch_ge | :ch_ju | :ch_vs | :ch]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Karfreitag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_ne | :ch_ge | :ch_ju] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_vs | :ch_ge | :ch_ju] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Auffahrt", regions: ::Array[:ch] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_vs | :ch_ge | :ch_ju] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_zg | :ch_fr | :ch_so | :ch_ai | :ch_ag | :ch_ti | :ch_vs | :ch_ne | :ch_ju] } | { function: "ch_vd_lundi_du_jeune_federal(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_vd] } | { function: "ch_ge_jeune_genevois(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_ge] }], 1 => ::Array[{ mday: 1, name: "Neujahrstag", regions: ::Array[:ch] } | { mday: 2, name: "Berchtoldstag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_sh | :ch_sg | :ch_ag | :ch_tg | :ch_vd | :ch_vs | :ch_ne | :ch_ju] } | { mday: 6, name: ::String, regions: ::Array[:ch_ur | :ch_sz | :ch_ti] }], 3 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ch_ne] } | { mday: 19, name: "Josephstag", regions: ::Array[:ch_ur | :ch_sz | :ch_nw | :ch_ti | :ch_vs] }], 4 => ::Array[{ function: "ch_gl_naefelser_fahrt(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_gl] }], 5 => ::Array[{ mday: 1, name: "Tag der Arbeit", regions: ::Array[:ch_zh | :ch_bs | :ch_bl | :ch_sh | :ch_ag | :ch_tg | :ch_ti | :ch_ne | :ch_ju] }], 6 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:ch_ju] } | { mday: 29, name: "San Pietro e Paolo", regions: ::Array[:ch_ti] }], 8 => ::Array[{ mday: 1, name: "Bundesfeiertag", regions: ::Array[:ch] } | { mday: 15, name: ::String, regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_zg | :ch_fr | :ch_so | :ch_ai | :ch_ag | :ch_ti | :ch_vs | :ch_ju] }], 9 => ::Array[{ mday: 22, name: "Mauritiustag", regions: ::Array[:ch_ai] } | { mday: 25, name: "Bruderklausenfest", regions: ::Array[:ch_ow] }], 11 => ::Array[{ function: "ch_be_zibelemaerit(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_be] } | { mday: 1, name: "Allerheiligen", regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_ai | :ch_sg | :ch_ag | :ch_ti | :ch_vs | :ch_ju] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_zg | :ch_fr | :ch_ai | :ch_ag | :ch_ti | :ch_vs] } | { mday: 25, name: "Weihnachten", regions: ::Array[:ch] } | { mday: 26, name: "Stefanstag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vs | :ch_ne] } | { mday: 31, name: ::String, regions: ::Array[:ch_ge] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/cl.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module CL
+    def self.defined_regions: () -> ::Array[:cl]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:cl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:cl] } | { function: "st_peter_st_paul_cl(year)", function_arguments: ::Array[:year], year_ranges: { from: 2000 }, name: "San Pedro y San Pablo", regions: ::Array[:cl] } | { function: "other_churches_day_cl(year)", function_arguments: ::Array[:year], year_ranges: { from: 2008 }, name: ::String, regions: ::Array[:cl] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cl] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cl] } | { mday: 21, name: ::String, regions: ::Array[:cl] }], 6 => ::Array[{ mday: 29, year_ranges: { until: 1999 }, name: "San Pedro y San Pablo", regions: ::Array[:cl] }], 7 => ::Array[{ mday: 16, name: ::String, regions: ::Array[:cl] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:cl] }], 9 => ::Array[{ mday: 18, name: "Independencia Nacional", regions: ::Array[:cl] } | { mday: 19, name: ::String, regions: ::Array[:cl] }], 10 => ::Array[{ mday: 12, year_ranges: { until: 1999 }, name: "Encuentro de Dos Mundos", regions: ::Array[:cl] } | { function: "columbus_day_cl(year)", function_arguments: ::Array[:year], year_ranges: { from: 2000 }, name: "Encuentro de Dos Mundos", regions: ::Array[:cl] }], 11 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cl] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:cl] } | { mday: 25, name: "Navidad", regions: ::Array[:cl] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/co.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module CO
+    def self.defined_regions: () -> ::Array[:co]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 43, name: ::String, regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 64, name: "Corpus Christi", regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 71, name: ::String, regions: ::Array[:co] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:co] } | { function: "epiphany(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] }], 3 => ::Array[{ function: "saint_josephs_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:co] }], 6 => ::Array[{ function: "saint_peter_and_saint_paul(year)", function_arguments: ::Array[:year], name: "San Pedro y San Pablo", regions: ::Array[:co] }], 7 => ::Array[{ mday: 20, name: ::String, regions: ::Array[:co] }], 8 => ::Array[{ mday: 7, name: ::String, regions: ::Array[:co] } | { function: "assumption_of_mary(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] }], 10 => ::Array[{ function: "columbus_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] }], 11 => ::Array[{ function: "all_saints_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] } | { function: "independence_of_cartagena(year)", function_arguments: ::Array[:year], name: "Independencia de Cartagena", regions: ::Array[:co] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:co] } | { mday: 25, name: "Navidad", regions: ::Array[:co] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/cr.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module CR
+    def self.defined_regions: () -> ::Array[:cr]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:cr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:cr] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cr] }], 4 => ::Array[{ mday: 11, name: ::String, regions: ::Array[:cr] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cr] }], 7 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:cr] }], 8 => ::Array[{ mday: 2, name: ::String, regions: ::Array[:cr] } | { mday: 15, name: ::String, regions: ::Array[:cr] }], 9 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:cr] }], 10 => ::Array[{ mday: 12, name: ::String, regions: ::Array[:cr] }], 12 => ::Array[{ mday: 25, name: "Navidad", regions: ::Array[:cr] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/cz.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module CZ
+    def self.defined_regions: () -> ::Array[:cz]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:cz] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:cz] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cz] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:cz] } | { mday: 8, name: ::String, regions: ::Array[:cz] }], 7 => ::Array[{ mday: 5, name: ::String, regions: ::Array[:cz] } | { mday: 6, name: ::String, regions: ::Array[:cz] }], 9 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:cz] }], 10 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:cz] }], 11 => ::Array[{ mday: 17, name: "Den boje za svobodu a demokracii", regions: ::Array[:cz] }], 12 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:cz] } | { mday: 25, name: ::String, regions: ::Array[:cz] } | { mday: 26, name: ::String, regions: ::Array[:cz] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/de.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module DE
+    def self.defined_regions: () -> ::Array[:de | :de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn_sorbian | :de_th_cath | :de_sn | :de_st | :de_be | :de_by_cath | :de_by_augsburg | :de_bb | :de_mv | :de_th | :de_hb | :de_hh | :de_ni | :de_sh]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Karfreitag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Ostersonntag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Christi Himmelfahrt", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, type: :informal, name: "Pfingstsonntag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn_sorbian | :de_th_cath] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -52, type: :informal, name: "Weiberfastnacht", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, type: :informal, name: "Rosenmontag", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, type: :informal, name: "Aschermittwoch", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn] }], 1 => ::Array[{ mday: 1, name: "Neujahrstag", regions: ::Array[:de] } | { mday: 6, name: ::String, regions: ::Array[:de_bw | :de_by | :de_st] }], 3 => ::Array[{ mday: 8, year_ranges: { from: 2019 }, name: "Internationaler Frauentag", regions: ::Array[:de_be] }], 5 => ::Array[{ mday: 1, name: "Tag der Arbeit", regions: ::Array[:de] } | { mday: 8, year_ranges: { limited: ::Array[2020] }, name: "Tag der Befreiung", regions: ::Array[:de_be] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:de_by_cath | :de_by_augsburg | :de_sl] } | { mday: 8, name: "Friedensfest", regions: ::Array[:de_by_augsburg] }], 10 => ::Array[{ mday: 3, name: "Tag der Deutschen Einheit", regions: ::Array[:de] } | { mday: 31, name: "Reformationstag", regions: ::Array[:de_bb | :de_mv | :de_sn | :de_st | :de_th] } | { mday: 31, type: :informal, name: "Reformationstag", regions: ::Array[:de_bw] } | { mday: 31, year_ranges: { limited: ::Array[2017] }, name: "Reformationstag", regions: ::Array[:de] } | { mday: 31, year_ranges: { from: 2018 }, name: "Reformationstag", regions: ::Array[:de_hb | :de_hh | :de_ni | :de_sh] }], 11 => ::Array[{ mday: 1, name: "Allerheiligen", regions: ::Array[:de_bw | :de_by | :de_nw | :de_rp | :de_sl] } | { function: "de_buss_und_bettag(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:de_sn] }], 12 => ::Array[{ mday: 24, type: :informal, name: "Heilig Abend", regions: ::Array[:de] } | { mday: 25, name: "1. Weihnachtstag", regions: ::Array[:de] } | { mday: 26, name: "2. Weihnachtstag", regions: ::Array[:de] } | { mday: 31, type: :informal, name: "Silvester", regions: ::Array[:de] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/dk.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module DK
+    def self.defined_regions: () -> ::Array[:dk]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -49, type: :informal, name: "Fastelavn", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, type: :informal, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Langfredag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 26, name: "Store Bededag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Kristi Himmelfartsdag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pinsedag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "2. Pinsedag", regions: ::Array[:dk] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:dk] }], 4 => ::Array[{ mday: 1, type: :informal, name: "1. april", regions: ::Array[:dk] } | { mday: 9, type: :informal, name: ::String, regions: ::Array[:dk] } | { mday: 16, type: :informal, name: ::String, regions: ::Array[:dk] }], 5 => ::Array[{ mday: 1, type: :informal, name: "Arbejdernes kampdag", regions: ::Array[:dk] } | { mday: 5, type: :informal, name: "Danmarks befrielse", regions: ::Array[:dk] }], 6 => ::Array[{ mday: 5, type: :informal, name: "Grundlovsdag", regions: ::Array[:dk] } | { mday: 15, type: :informal, name: "Valdemarsdag og Genforeningsdag", regions: ::Array[:dk] } | { mday: 23, type: :informal, name: "Sankt Hans aften", regions: ::Array[:dk] }], 11 => ::Array[{ mday: 10, type: :informal, name: "Mortensaften", regions: ::Array[:dk] }], 12 => ::Array[{ mday: 13, type: :informal, name: "Sankt Lucia", regions: ::Array[:dk] } | { mday: 24, type: :informal, name: "Juleaftensdag", regions: ::Array[:dk] } | { mday: 25, name: "1. juledag", regions: ::Array[:dk] } | { mday: 26, name: "2. juledag", regions: ::Array[:dk] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ecbtarget.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module ECBTARGET
+    def self.defined_regions: () -> ::Array[:ecbtarget]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:ecbtarget] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:ecbtarget] }], 1 => ::Array[{ mday: 1, name: "New Year's Day", regions: ::Array[:ecbtarget] }], 5 => ::Array[{ mday: 1, name: "Labour Day", regions: ::Array[:ecbtarget] }], 12 => ::Array[{ mday: 25, name: "Christmas Day", regions: ::Array[:ecbtarget] } | { mday: 26, name: "Christmas Holiday", regions: ::Array[:ecbtarget] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ee.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module EE
+    def self.defined_regions: () -> ::Array[:ee]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "suur reede", regions: ::Array[:ee] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ee] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:ee] }], 1 => ::Array[{ mday: 1, name: "uusaasta", regions: ::Array[:ee] }], 2 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:ee] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ee] }], 6 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:ee] } | { mday: 24, name: ::String, regions: ::Array[:ee] }], 8 => ::Array[{ mday: 20, name: ::String, regions: ::Array[:ee] }], 12 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:ee] } | { mday: 25, name: ::String, regions: ::Array[:ee] } | { mday: 26, name: ::String, regions: ::Array[:ee] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/el.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module EL
+    def self.defined_regions: () -> ::Array[:el]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:el] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:el] } | { mday: 6, name: ::String, regions: ::Array[:el] }], 3 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:el] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:el] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:el] }], 10 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:el] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:el] } | { mday: 26, name: ::String, regions: ::Array[:el] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/es.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module ES
+    def self.defined_regions: () -> ::Array[:es_pv | :es_na | :es_an | :es_ib | :es_cm | :es_mu | :es_m | :es_ar | :es_cl | :es_cn | :es_lo | :es_ga | :es_ce | :es_o | :es_ex | :es | :es_ct | :es_v | :es_vc]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:es_pv | :es_na | :es_an | :es_ib | :es_cm | :es_mu | :es_m | :es_ar | :es_cl | :es_cn | :es_lo | :es_ga | :es_ce | :es_o | :es_ex] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:es] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Lunes de Pascua", regions: ::Array[:es_pv | :es_ct | :es_na | :es_v | :es_vc] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Lunes de Pascua Granada", regions: ::Array[:es_ct] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 6, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] }], 2 => ::Array[{ mday: 28, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_an] }], 3 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ib] } | { mday: 19, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_v | :es_vc | :es_cm | :es_mu | :es_m] }], 4 => ::Array[{ mday: 23, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_cl] } | { mday: 23, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ar] }], 5 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 2, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Fiesta de la Comunidad", regions: ::Array[:es_m] } | { mday: 30, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_cn] } | { mday: 31, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_cm] }], 6 => ::Array[{ mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_mu] } | { mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_lo] } | { mday: 24, name: "San Juan", regions: ::Array[:es_ct | :es_vc] }], 7 => ::Array[{ mday: 23, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Santiago Apostol", regions: ::Array[:es_ga] }], 8 => ::Array[{ mday: 15, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] }], 9 => ::Array[{ mday: 2, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ce] } | { mday: 8, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_o] } | { mday: 8, name: ::String, regions: ::Array[:es_ex] } | { mday: 11, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ct] } | { mday: 24, name: ::String, regions: ::Array[:es_ct] }], 10 => ::Array[{ mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_vc | :es_v] } | { mday: 12, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] }], 11 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Todos los Santos", regions: ::Array[:es] }], 12 => ::Array[{ mday: 6, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 8, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 25, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 26, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "San Esteban", regions: ::Array[:es_ib | :es_ct] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/at.yaml, definitions/be_fr.yaml, definitions/be_nl.yaml, definitions/ch.yaml, definitions/cz.yaml, definitions/dk.yaml, definitions/de.yaml, definitions/el.yaml, definitions/es.yaml, definitions/fr.yaml, definitions/gb.yaml, definitions/hr.yaml, definitions/hu.yaml, definitions/ie.yaml, definitions/is.yaml, definitions/it.yaml, definitions/li.yaml, definitions/lt.yaml, definitions/lv.yaml, definitions/nl.yaml, definitions/no.yaml, definitions/pl.yaml, definitions/pt.yaml, definitions/ro.yaml, definitions/sk.yaml, definitions/si.yaml, definitions/bg.yaml, definitions/ua.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module EUROPE
+    def self.defined_regions: () -> ::Array[:at | :be_fr | :be_nl | :ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_ne | :ch_ge | :ch_ju | :ch_vs | :ch | :cz | :dk | :de | :de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn_sorbian | :de_th_cath | :de_sn | :de_st | :de_be | :de_by_cath | :de_by_augsburg | :de_bb | :de_mv | :de_th | :de_hb | :de_hh | :de_ni | :de_sh | :el | :es_pv | :es_na | :es_an | :es_ib | :es_cm | :es_mu | :es_m | :es_ar | :es_cl | :es_cn | :es_lo | :es_ga | :es_ce | :es_o | :es_ex | :es | :es_ct | :es_v | :es_vc | :fr_a | :fr_m | :fr | :gb | :gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy | :gb_sct | :gb_con | :im | :gb_iom | :hr | :hu | :ie | :is | :it | :it_ve | :it_tv | :it_vr | :it_pd | :it_fi | :it_ge | :it_to | :it_rm | :it_vi | :it_bl | :it_ro | :li | :lt | :lv | :nl | :no | :pl | :pt | :pt_li | :pt_po | :ro | :sk | :si | :bg_en | :bg_bg | :ua]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Christi Himmelfahrt", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:at] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Ascension", regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:be_fr] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Pasen", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Paasmaandag", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "O.H. Hemelvaart", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pinksteren", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pinkstermaandag", regions: ::Array[:be_nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Karfreitag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_ne | :ch_ge | :ch_ju] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_vs | :ch_ge | :ch_ju] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Auffahrt", regions: ::Array[:ch] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vd | :ch_vs | :ch_ge | :ch_ju] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_zg | :ch_fr | :ch_so | :ch_ai | :ch_ag | :ch_ti | :ch_vs | :ch_ne | :ch_ju] } | { function: "ch_vd_lundi_du_jeune_federal(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_vd] } | { function: "ch_ge_jeune_genevois(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_ge] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:cz] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:cz] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -49, type: :informal, name: "Fastelavn", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, type: :informal, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Langfredag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 26, name: "Store Bededag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Kristi Himmelfartsdag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pinsedag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "2. Pinsedag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Karfreitag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Ostersonntag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Christi Himmelfahrt", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, type: :informal, name: "Pfingstsonntag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:de] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn_sorbian | :de_th_cath] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -52, type: :informal, name: "Weiberfastnacht", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, type: :informal, name: "Rosenmontag", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, type: :informal, name: "Aschermittwoch", regions: ::Array[:de_bw | :de_by | :de_he | :de_nw | :de_rp | :de_sl | :de_sn] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: ::String, regions: ::Array[:el] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:el] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:es_pv | :es_na | :es_an | :es_ib | :es_cm | :es_mu | :es_m | :es_ar | :es_cl | :es_cn | :es_lo | :es_ga | :es_ce | :es_o | :es_ex] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:es] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Lunes de Pascua", regions: ::Array[:es_pv | :es_ct | :es_na | :es_v | :es_vc] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Lunes de Pascua Granada", regions: ::Array[:es_ct] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Vendredi saint", regions: ::Array[:fr_a | :fr_m] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Ascension", regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, type: :informal, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:gb] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Easter Sunday", regions: ::Array[:gb] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Uskrs", regions: ::Array[:hr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Uskrsni ponedjeljak", regions: ::Array[:hr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Tijelovo", regions: ::Array[:hr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, year_ranges: { from: 2017 }, name: ::String, regions: ::Array[:hu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:hu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:hu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:ie] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Bolludagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Sprengidagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Uppstigningardagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Pasqua", regions: ::Array[:it] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:it] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Fasnachtsdienstag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Karfreitag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Ostern", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Auffahrt", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:lt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:lt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:lv] } | { function: "lv_song_and_dance_festival_end_date(year)", function_arguments: ::Array[:year], year_ranges: { from: 2018 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, type: :informal, name: "Goede Vrijdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Eerste Paasdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Tweede Paasdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Hemelvaartsdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Eerste Pinksterdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Tweede Pinksterdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -49, type: :informal, name: "Fastelavn", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Langfredag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Kristi Himmelfartsdag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "1. pinsedag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "2. pinsedag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -52, type: :informal, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, type: :informal, name: "Ostatki", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, type: :informal, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, type: :informal, name: "Niedziela Palmowa", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, type: :informal, name: "Wielki Czwartek", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, type: :informal, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, type: :informal, name: "Wielka Sobota", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Niedziela Wielkanocna", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, type: :informal, name: "Carnaval", regions: ::Array[:pt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Sexta-feira Santa", regions: ::Array[:pt] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:pt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Corpo de Deus", regions: ::Array[:pt] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, year_ranges: { from: 2018 }, name: ::String, regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Rusaliile - 50", regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Rusaliile - 51", regions: ::Array[:ro] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:sk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:sk] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:si] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:si] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:si] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:bg_en] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:bg_bg] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -1, name: "Holy Saturday", regions: ::Array[:bg_en] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:bg_bg] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], name: "Easter Sunday", regions: ::Array[:bg_en] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:bg_bg] } | { function: "orthodox_easter_julian(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:bg_en] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 49, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 1 => ::Array[{ mday: 1, name: "Neujahrstag", regions: ::Array[:at] } | { mday: 6, name: ::String, regions: ::Array[:at] } | { mday: 1, name: "Jour de l'an", regions: ::Array[:be_fr] } | { mday: 1, name: "Nieuwjaar", regions: ::Array[:be_nl] } | { mday: 1, name: "Neujahrstag", regions: ::Array[:ch] } | { mday: 2, name: "Berchtoldstag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_sh | :ch_sg | :ch_ag | :ch_tg | :ch_vd | :ch_vs | :ch_ne | :ch_ju] } | { mday: 6, name: ::String, regions: ::Array[:ch_ur | :ch_sz | :ch_ti] } | { mday: 1, name: ::String, regions: ::Array[:cz] } | { mday: 1, name: ::String, regions: ::Array[:dk] } | { mday: 1, name: "Neujahrstag", regions: ::Array[:de] } | { mday: 6, name: ::String, regions: ::Array[:de_bw | :de_by | :de_st] } | { mday: 1, name: ::String, regions: ::Array[:el] } | { mday: 6, name: ::String, regions: ::Array[:el] } | { mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 6, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 1, name: "Jour de l'an", regions: ::Array[:fr] } | { mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:gb] } | { mday: 2, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "2nd January", regions: ::Array[:gb_sct] } | { mday: 1, name: "Nova godina", regions: ::Array[:hr] } | { mday: 6, name: "Bogojavljenje ili Sveta tri kralja", regions: ::Array[:hr] } | { mday: 1, name: ::String, regions: ::Array[:hu] } | { mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:ie] } | { mday: 1, name: ::String, regions: ::Array[:is] } | { mday: 6, name: ::String, regions: ::Array[:is] } | { mday: 19, type: :informal, name: ::String, regions: ::Array[:is] } | { mday: 1, name: "Capodanno", regions: ::Array[:it] } | { mday: 6, name: "Epifania", regions: ::Array[:it] } | { mday: 1, name: "Neujahrstag", regions: ::Array[:li] } | { mday: 6, name: ::String, regions: ::Array[:li] } | { mday: 1, name: "Naujieji metai", regions: ::Array[:lt] } | { mday: 1, name: "Jaungada diena", regions: ::Array[:lv] } | { mday: 1, name: "Nieuwjaarsdag", regions: ::Array[:nl] } | { mday: 1, name: ::String, regions: ::Array[:no] } | { mday: 1, name: "Nowy Rok", regions: ::Array[:pl] } | { function: "pl_trzech_kroli(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:pl] } | { function: "pl_trzech_kroli_informal(year)", function_arguments: ::Array[:year], type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 21, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 22, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 1, name: "Ano Novo", regions: ::Array[:pt] } | { mday: 1, name: "Anul nou", regions: ::Array[:ro] } | { mday: 2, name: "Anul nou", regions: ::Array[:ro] } | { mday: 24, year_ranges: { from: 2017 }, name: ::String, regions: ::Array[:ro] } | { mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 6, name: ::String, regions: ::Array[:sk] } | { mday: 1, name: "novo leto", regions: ::Array[:si] } | { mday: 1, name: "New Year's Day", regions: ::Array[:bg_en] } | { mday: 1, name: ::String, regions: ::Array[:bg_bg] } | { mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] } | { mday: 7, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 5 => ::Array[{ mday: 1, name: "Staatsfeiertag", regions: ::Array[:at] } | { mday: 1, name: ::String, regions: ::Array[:be_fr] } | { mday: 1, name: "Feest van de Arbeid", regions: ::Array[:be_nl] } | { mday: 1, name: "Tag der Arbeit", regions: ::Array[:ch_zh | :ch_bs | :ch_bl | :ch_sh | :ch_ag | :ch_tg | :ch_ti | :ch_ne | :ch_ju] } | { mday: 1, name: ::String, regions: ::Array[:cz] } | { mday: 8, name: ::String, regions: ::Array[:cz] } | { mday: 1, type: :informal, name: "Arbejdernes kampdag", regions: ::Array[:dk] } | { mday: 5, type: :informal, name: "Danmarks befrielse", regions: ::Array[:dk] } | { mday: 1, name: "Tag der Arbeit", regions: ::Array[:de] } | { mday: 8, year_ranges: { limited: ::Array[2020] }, name: "Tag der Befreiung", regions: ::Array[:de_be] } | { mday: 1, name: ::String, regions: ::Array[:el] } | { mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 2, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Fiesta de la Comunidad", regions: ::Array[:es_m] } | { mday: 30, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_cn] } | { mday: 31, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_cm] } | { mday: 1, name: ::String, regions: ::Array[:fr] } | { mday: 8, name: "Victoire 1945", regions: ::Array[:fr] } | { wday: 1, week: 1, year_ranges: { until: 2019 }, name: "May Day", regions: ::Array[:gb] } | { mday: 8, year_ranges: { limited: ::Array[2020] }, name: "May Day", regions: ::Array[:gb] } | { wday: 1, week: 1, year_ranges: { from: 2021 }, name: "May Day", regions: ::Array[:gb] } | { mday: 9, name: "Liberation Day", regions: ::Array[:je | :gb_jsy | :gg | :gb_gsy] } | { wday: 1, week: -1, year_ranges: { until: 2021 }, name: "Bank Holiday", regions: ::Array[:gb] } | { wday: 1, week: -1, year_ranges: { from: 2023 }, name: "Bank Holiday", regions: ::Array[:gb] } | { mday: 1, name: "Praznik rada", regions: ::Array[:hr] } | { mday: 30, year_ranges: { from: 2020 }, name: ::String, regions: ::Array[:hr] } | { mday: 1, name: ::String, regions: ::Array[:hu] } | { wday: 1, week: 1, name: "May Day", regions: ::Array[:ie] } | { mday: 1, name: ::String, regions: ::Array[:is] } | { mday: 13, name: ::String, regions: ::Array[:is] } | { mday: 1, name: "Festa dei Lavoratori", regions: ::Array[:it] } | { mday: 21, name: "Festa di San Zeno", regions: ::Array[:it_vr] } | { mday: 1, name: "Tag der Arbeit", regions: ::Array[:li] } | { mday: 1, name: ::String, regions: ::Array[:lt] } | { mday: 1, name: ::String, regions: ::Array[:lv] } | { mday: 4, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:lv] } | { wday: 0, week: 2, name: ::String, regions: ::Array[:lv] } | { mday: 4, type: :informal, name: "Dodenherdenking", regions: ::Array[:nl] } | { mday: 5, name: "Bevrijdingsdag", regions: ::Array[:nl] } | { mday: 1, name: "1. mai", regions: ::Array[:no] } | { mday: 17, name: "17. mai", regions: ::Array[:no] } | { mday: 1, name: ::String, regions: ::Array[:pl] } | { mday: 2, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 3, name: ::String, regions: ::Array[:pl] } | { mday: 1, name: "Dia do Trabalhador", regions: ::Array[:pt] } | { mday: 1, name: "Ziua muncii", regions: ::Array[:ro] } | { mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 8, name: ::String, regions: ::Array[:sk] } | { mday: 1, name: "praznik dela", regions: ::Array[:si] } | { mday: 2, name: "praznik dela", regions: ::Array[:si] } | { mday: 1, name: "Labour Day", regions: ::Array[:bg_en] } | { mday: 1, name: ::String, regions: ::Array[:bg_bg] } | { mday: 6, name: "St. George's Day", regions: ::Array[:bg_en] } | { mday: 6, name: ::String, regions: ::Array[:bg_bg] } | { mday: 24, name: "Slavic Literacy Day", regions: ::Array[:bg_en] } | { mday: 24, name: ::String, regions: ::Array[:bg_bg] } | { mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] } | { mday: 2, year_ranges: { until: 2017 }, name: ::String, regions: ::Array[:ua] } | { mday: 9, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:at] } | { mday: 15, name: "Assomption", regions: ::Array[:be_fr] } | { mday: 15, name: "O.L.V. Hemelvaart", regions: ::Array[:be_nl] } | { mday: 1, name: "Bundesfeiertag", regions: ::Array[:ch] } | { mday: 15, name: ::String, regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_zg | :ch_fr | :ch_so | :ch_ai | :ch_ag | :ch_ti | :ch_vs | :ch_ju] } | { mday: 15, name: ::String, regions: ::Array[:de_by_cath | :de_by_augsburg | :de_sl] } | { mday: 8, name: "Friedensfest", regions: ::Array[:de_by_augsburg] } | { mday: 15, name: ::String, regions: ::Array[:el] } | { mday: 15, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 15, name: "Assomption", regions: ::Array[:fr] } | { wday: 1, week: 1, name: "Bank Holiday", regions: ::Array[:gb_sct] } | { wday: 1, week: -1, name: "Bank Holiday", regions: ::Array[:gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy] } | { mday: 5, name: "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja", regions: ::Array[:hr] } | { mday: 15, name: "Velika Gospa", regions: ::Array[:hr] } | { mday: 20, name: ::String, regions: ::Array[:hu] } | { wday: 1, week: 1, name: "August Bank Holiday", regions: ::Array[:ie] } | { wday: 1, week: 1, name: ::String, regions: ::Array[:is] } | { mday: 15, name: "Assunzione", regions: ::Array[:it] } | { mday: 15, name: "Staatsfeiertag", regions: ::Array[:li] } | { mday: 15, name: ::String, regions: ::Array[:lt] } | { mday: 15, name: ::String, regions: ::Array[:pl] } | { mday: 15, name: ::String, regions: ::Array[:pt] } | { mday: 15, name: "Adormirea Maicii Domnului", regions: ::Array[:ro] } | { mday: 29, name: ::String, regions: ::Array[:sk] } | { mday: 15, name: "Marijino vnebovzetje", regions: ::Array[:si] } | { mday: 24, year_ranges: { from: 1992 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 10 => ::Array[{ mday: 26, name: "Nationalfeiertag", regions: ::Array[:at] } | { mday: 28, name: ::String, regions: ::Array[:cz] } | { mday: 3, name: "Tag der Deutschen Einheit", regions: ::Array[:de] } | { mday: 31, name: "Reformationstag", regions: ::Array[:de_bb | :de_mv | :de_sn | :de_st | :de_th] } | { mday: 31, type: :informal, name: "Reformationstag", regions: ::Array[:de_bw] } | { mday: 31, year_ranges: { limited: ::Array[2017] }, name: "Reformationstag", regions: ::Array[:de] } | { mday: 31, year_ranges: { from: 2018 }, name: "Reformationstag", regions: ::Array[:de_hb | :de_hh | :de_ni | :de_sh] } | { mday: 28, name: ::String, regions: ::Array[:el] } | { mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_vc | :es_v] } | { mday: 12, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 8, year_ranges: { until: 2019 }, name: "Dan neovisnosti", regions: ::Array[:hr] } | { mday: 23, name: ::String, regions: ::Array[:hu] } | { wday: 1, week: -1, name: "October Bank Holiday", regions: ::Array[:ie] } | { mday: 14, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 5, name: ::String, regions: ::Array[:pt] } | { mday: 31, name: "dan reformacije", regions: ::Array[:si] } | { mday: 14, year_ranges: { from: 2015 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 11 => ::Array[{ mday: 1, name: "Allerheiligen", regions: ::Array[:at] } | { mday: 1, name: "Toussaint", regions: ::Array[:be_fr] } | { mday: 11, name: "Armistice 1918", regions: ::Array[:be_fr] } | { mday: 1, name: "Allerheiligen", regions: ::Array[:be_nl] } | { mday: 11, name: "Wapenstilstand 1918", regions: ::Array[:be_nl] } | { function: "ch_be_zibelemaerit(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_be] } | { mday: 1, name: "Allerheiligen", regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_ai | :ch_sg | :ch_ag | :ch_ti | :ch_vs | :ch_ju] } | { mday: 17, name: "Den boje za svobodu a demokracii", regions: ::Array[:cz] } | { mday: 10, type: :informal, name: "Mortensaften", regions: ::Array[:dk] } | { mday: 1, name: "Allerheiligen", regions: ::Array[:de_bw | :de_by | :de_nw | :de_rp | :de_sl] } | { function: "de_buss_und_bettag(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:de_sn] } | { mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Todos los Santos", regions: ::Array[:es] } | { mday: 1, name: "Toussaint", regions: ::Array[:fr] } | { mday: 11, name: "Armistice 1918", regions: ::Array[:fr] } | { mday: 5, type: :informal, name: "Guy Fawkes Day", regions: ::Array[:gb] } | { mday: 30, year_ranges: { until: 2006 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], type: :informal, name: "St. Andrew's Day", regions: ::Array[:gb_sct] } | { mday: 30, year_ranges: { from: 2007 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "St. Andrew's Day", regions: ::Array[:gb_sct] } | { mday: 1, name: "Svi sveti", regions: ::Array[:hr] } | { mday: 18, year_ranges: { from: 2020 }, name: ::String, regions: ::Array[:hr] } | { mday: 1, name: "Mindenszentek", regions: ::Array[:hu] } | { mday: 16, name: ::String, regions: ::Array[:is] } | { mday: 1, name: "Ognissanti", regions: ::Array[:it] } | { mday: 11, name: "Festa di San Martino", regions: ::Array[:it_bl] } | { mday: 26, name: "Festa di San Bellino", regions: ::Array[:it_ro] } | { mday: 1, name: "Allerheiligen", regions: ::Array[:li] } | { mday: 1, name: ::String, regions: ::Array[:lt] } | { mday: 18, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:lv] } | { mday: 1, name: ::String, regions: ::Array[:pl] } | { mday: 2, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 11, name: ::String, regions: ::Array[:pl] } | { mday: 29, type: :informal, name: "Andrzejki", regions: ::Array[:pl] } | { mday: 1, name: "Dia de Todos-os-Santos", regions: ::Array[:pt] } | { mday: 30, name: ::String, regions: ::Array[:ro] } | { mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 17, name: ::String, regions: ::Array[:sk] } | { mday: 1, name: "dan spomina na mrtve", regions: ::Array[:si] } | { mday: 1, name: "Revival Leader's Day", regions: ::Array[:bg_en] } | { mday: 1, name: ::String, regions: ::Array[:bg_bg] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:at] } | { mday: 25, name: "1. Weihnachtstag", regions: ::Array[:at] } | { mday: 26, name: "2. Weihnachtstag", regions: ::Array[:at] } | { mday: 25, name: ::String, regions: ::Array[:be_fr] } | { mday: 25, name: "Kerstmis", regions: ::Array[:be_nl] } | { mday: 8, name: ::String, regions: ::Array[:ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_zg | :ch_fr | :ch_ai | :ch_ag | :ch_ti | :ch_vs] } | { mday: 25, name: "Weihnachten", regions: ::Array[:ch] } | { mday: 26, name: "Stefanstag", regions: ::Array[:ch_zh | :ch_be | :ch_lu | :ch_ur | :ch_sz | :ch_ow | :ch_nw | :ch_gl | :ch_zg | :ch_fr | :ch_so | :ch_bs | :ch_bl | :ch_sh | :ch_ar | :ch_ai | :ch_sg | :ch_gr | :ch_ag | :ch_tg | :ch_ti | :ch_vs | :ch_ne] } | { mday: 31, name: ::String, regions: ::Array[:ch_ge] } | { mday: 24, name: ::String, regions: ::Array[:cz] } | { mday: 25, name: ::String, regions: ::Array[:cz] } | { mday: 26, name: ::String, regions: ::Array[:cz] } | { mday: 13, type: :informal, name: "Sankt Lucia", regions: ::Array[:dk] } | { mday: 24, type: :informal, name: "Juleaftensdag", regions: ::Array[:dk] } | { mday: 25, name: "1. juledag", regions: ::Array[:dk] } | { mday: 26, name: "2. juledag", regions: ::Array[:dk] } | { mday: 24, type: :informal, name: "Heilig Abend", regions: ::Array[:de] } | { mday: 25, name: "1. Weihnachtstag", regions: ::Array[:de] } | { mday: 26, name: "2. Weihnachtstag", regions: ::Array[:de] } | { mday: 31, type: :informal, name: "Silvester", regions: ::Array[:de] } | { mday: 25, name: ::String, regions: ::Array[:el] } | { mday: 26, name: ::String, regions: ::Array[:el] } | { mday: 6, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 8, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 25, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es] } | { mday: 26, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "San Esteban", regions: ::Array[:es_ib | :es_ct] } | { mday: 25, name: ::String, regions: ::Array[:fr] } | { mday: 26, name: ::String, regions: ::Array[:fr_a | :fr_m] } | { mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:gb] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:gb] } | { mday: 25, name: ::String, regions: ::Array[:hr] } | { mday: 26, name: "Sveti Stjepan", regions: ::Array[:hr] } | { mday: 25, name: ::String, regions: ::Array[:hu] } | { mday: 26, name: ::String, regions: ::Array[:hu] } | { mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ie] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "St. Stephen's Day", regions: ::Array[:ie] } | { mday: 24, name: ::String, regions: ::Array[:is] } | { mday: 25, name: ::String, regions: ::Array[:is] } | { mday: 26, name: ::String, regions: ::Array[:is] } | { mday: 31, name: ::String, regions: ::Array[:is] } | { mday: 8, name: "Immacolata Concezione", regions: ::Array[:it] } | { mday: 25, name: "Natale", regions: ::Array[:it] } | { mday: 26, name: "Santo Stefano", regions: ::Array[:it] } | { mday: 8, name: ::String, regions: ::Array[:li] } | { mday: 24, name: "Heilig Abend", regions: ::Array[:li] } | { mday: 25, name: "Weihnachten", regions: ::Array[:li] } | { mday: 26, name: "Stefanstag", regions: ::Array[:li] } | { mday: 31, name: "Silvester", regions: ::Array[:li] } | { mday: 24, name: ::String, regions: ::Array[:lt] } | { mday: 25, name: ::String, regions: ::Array[:lt] } | { mday: 26, name: ::String, regions: ::Array[:lt] } | { mday: 24, name: ::String, regions: ::Array[:lv] } | { mday: 25, name: ::String, regions: ::Array[:lv] } | { mday: 26, name: ::String, regions: ::Array[:lv] } | { mday: 31, name: "Vecgada diena", regions: ::Array[:lv] } | { mday: 5, type: :informal, name: "Sinterklaas", regions: ::Array[:nl] } | { mday: 25, name: "Eerste Kerstdag", regions: ::Array[:nl] } | { mday: 26, name: "Tweede Kerstdag", regions: ::Array[:nl] } | { mday: 24, type: :informal, name: "Julaften", regions: ::Array[:no] } | { mday: 25, name: "1. juledag", regions: ::Array[:no] } | { mday: 26, name: "2. juledag", regions: ::Array[:no] } | { mday: 31, type: :informal, name: ::String, regions: ::Array[:no] } | { mday: 4, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 6, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 24, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 25, name: ::String, regions: ::Array[:pl] } | { mday: 26, name: ::String, regions: ::Array[:pl] } | { mday: 31, type: :informal, name: "Sylwester", regions: ::Array[:pl] } | { mday: 1, name: ::String, regions: ::Array[:pt] } | { mday: 8, name: ::String, regions: ::Array[:pt] } | { mday: 25, name: "Natal", regions: ::Array[:pt] } | { mday: 1, name: ::String, regions: ::Array[:ro] } | { mday: 25, name: ::String, regions: ::Array[:ro] } | { mday: 26, name: ::String, regions: ::Array[:ro] } | { mday: 24, name: ::String, regions: ::Array[:sk] } | { mday: 25, name: ::String, regions: ::Array[:sk] } | { mday: 26, name: ::String, regions: ::Array[:sk] } | { mday: 25, name: ::String, regions: ::Array[:si] } | { mday: 26, name: "dan samostojnosti in enotnosti", regions: ::Array[:si] } | { mday: 24, name: "Christmas Eve", regions: ::Array[:bg_en] } | { mday: 24, name: ::String, regions: ::Array[:bg_bg] } | { mday: 25, name: "Christmas", regions: ::Array[:bg_en] } | { mday: 25, name: ::String, regions: ::Array[:bg_bg] } | { mday: 26, name: "Christmas", regions: ::Array[:bg_en] } | { mday: 26, name: ::String, regions: ::Array[:bg_bg] } | { mday: 25, year_ranges: { from: 2017 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 7 => ::Array[{ mday: 21, name: ::String, regions: ::Array[:be_fr] } | { mday: 21, name: "Nationale Feestdag", regions: ::Array[:be_nl] } | { mday: 5, name: ::String, regions: ::Array[:cz] } | { mday: 6, name: ::String, regions: ::Array[:cz] } | { mday: 23, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Santiago Apostol", regions: ::Array[:es_ga] } | { mday: 14, name: ::String, regions: ::Array[:fr] } | { mday: 5, name: "Tynwald Day", regions: ::Array[:im | :gb_iom] } | { mday: 12, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Battle of the Boyne", regions: ::Array[:gb_nir] } | { mday: 6, name: ::String, regions: ::Array[:lt] } | { mday: 5, name: ::String, regions: ::Array[:sk] } | { mday: 16, year_ranges: { limited: ::Array[1991] }, name: ::String, regions: ::Array[:ua] }], 3 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ch_ne] } | { mday: 19, name: "Josephstag", regions: ::Array[:ch_ur | :ch_sz | :ch_nw | :ch_ti | :ch_vs] } | { mday: 8, year_ranges: { from: 2019 }, name: "Internationaler Frauentag", regions: ::Array[:de_be] } | { mday: 25, name: ::String, regions: ::Array[:el] } | { mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ib] } | { mday: 19, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_v | :es_vc | :es_cm | :es_mu | :es_m] } | { mday: 5, name: "St. Piran's Day", regions: ::Array[:gb_con] } | { mday: 17, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "St. Patrick's Day", regions: ::Array[:gb_nir] } | { mday: 15, name: ::String, regions: ::Array[:hu] } | { mday: 17, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "St. Patrick's Day", regions: ::Array[:ie] } | { mday: 19, name: "St. Josef", regions: ::Array[:li] } | { mday: 11, name: ::String, regions: ::Array[:lt] } | { mday: 8, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 10, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 3, name: "Liberation Day", regions: ::Array[:bg_en] } | { mday: 3, name: ::String, regions: ::Array[:bg_bg] } | { mday: 8, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 4 => ::Array[{ function: "ch_gl_naefelser_fahrt(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ch_gl] } | { mday: 1, type: :informal, name: "1. april", regions: ::Array[:dk] } | { mday: 9, type: :informal, name: ::String, regions: ::Array[:dk] } | { mday: 16, type: :informal, name: ::String, regions: ::Array[:dk] } | { mday: 23, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_cl] } | { mday: 23, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ar] } | { function: "is_sumardagurinn_fyrsti(year)", function_arguments: ::Array[:year], name: "Sumardagurinn fyrsti", regions: ::Array[:is] } | { mday: 25, name: "Festa della Liberazione", regions: ::Array[:it] } | { mday: 25, name: "Festa di San Marco Evangelista", regions: ::Array[:it_ve] } | { mday: 27, name: "Festa di San Liberale", regions: ::Array[:it_tv] } | { mday: 27, name: "Koningsdag", regions: ::Array[:nl] } | { mday: 1, type: :informal, name: "Prima Aprilis", regions: ::Array[:pl] } | { mday: 22, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 25, name: "Dia da Liberdade", regions: ::Array[:pt] } | { mday: 27, name: "dan upora proti okupatorju", regions: ::Array[:si] }], 6 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:ch_ju] } | { mday: 29, name: "San Pietro e Paolo", regions: ::Array[:ch_ti] } | { mday: 5, type: :informal, name: "Grundlovsdag", regions: ::Array[:dk] } | { mday: 15, type: :informal, name: "Valdemarsdag og Genforeningsdag", regions: ::Array[:dk] } | { mday: 23, type: :informal, name: "Sankt Hans aften", regions: ::Array[:dk] } | { mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_mu] } | { mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_lo] } | { mday: 24, name: "San Juan", regions: ::Array[:es_ct | :es_vc] } | { mday: 2, year_ranges: { limited: ::Array[2022] }, name: "Bank Holiday", regions: ::Array[:gb] } | { mday: 3, year_ranges: { limited: ::Array[2022] }, name: "Platinum Jubilee", regions: ::Array[:gb] } | { mday: 22, name: ::String, regions: ::Array[:hr] } | { mday: 25, year_ranges: { until: 2019 }, name: ::String, regions: ::Array[:hr] } | { wday: 1, week: 1, name: "June Bank Holiday", regions: ::Array[:ie] } | { mday: 3, type: :informal, name: ::String, regions: ::Array[:is] } | { mday: 17, name: ::String, regions: ::Array[:is] } | { mday: 2, name: "Festa della Repubblica", regions: ::Array[:it] } | { mday: 13, name: "Festa di Sant'Antonio di Padova", regions: ::Array[:it_pd] } | { mday: 24, name: "Festa di San Giovanni Battista", regions: ::Array[:it_fi | :it_ge | :it_to] } | { mday: 29, name: "Festa di San Pietro e Paolo", regions: ::Array[:it_rm] } | { mday: 24, name: ::String, regions: ::Array[:lt] } | { mday: 23, name: ::String, regions: ::Array[:lv] } | { mday: 24, name: ::String, regions: ::Array[:lv] } | { mday: 23, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 10, name: "Dia de Portugal", regions: ::Array[:pt] } | { mday: 13, name: ::String, regions: ::Array[:pt_li] } | { mday: 24, name: ::String, regions: ::Array[:pt_po] } | { mday: 1, year_ranges: { from: 2017 }, name: "Ziua Copilului", regions: ::Array[:ro] } | { mday: 25, name: ::String, regions: ::Array[:si] } | { mday: 28, year_ranges: { from: 1997 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 9 => ::Array[{ mday: 22, name: "Mauritiustag", regions: ::Array[:ch_ai] } | { mday: 25, name: "Bruderklausenfest", regions: ::Array[:ch_ow] } | { mday: 28, name: ::String, regions: ::Array[:cz] } | { mday: 2, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ce] } | { mday: 8, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_o] } | { mday: 8, name: ::String, regions: ::Array[:es_ex] } | { mday: 11, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_ct] } | { mday: 24, name: ::String, regions: ::Array[:es_ct] } | { mday: 8, name: "Festa della Madonna di Monte Berico", regions: ::Array[:it_vi] } | { mday: 8, name: "Maria Geburt", regions: ::Array[:li] } | { mday: 24, year_ranges: { limited: ::Array[2018] }, name: ::String, regions: ::Array[:lv] } | { mday: 30, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 15, name: ::String, regions: ::Array[:sk] } | { mday: 6, name: "Unification Day", regions: ::Array[:bg_en] } | { mday: 6, name: ::String, regions: ::Array[:bg_bg] } | { mday: 22, name: "The Independence Day", regions: ::Array[:bg_en] } | { mday: 22, name: ::String, regions: ::Array[:bg_bg] }], 2 => ::Array[{ mday: 28, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:es_an] } | { mday: 18, type: :informal, name: "Konudagur", regions: ::Array[:is] } | { mday: 2, name: "Maria Lichtmess", regions: ::Array[:li] } | { mday: 16, name: ::String, regions: ::Array[:lt] } | { mday: 2, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 14, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 8, name: ::String, regions: ::Array[:si] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/federalreserve.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module FEDERALRESERVE
+    def self.defined_regions: () -> ::Array[:federalreserve]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:federalreserve] } | { wday: 1, week: 3, name: "Birthday of Martin Luther King, Jr", regions: ::Array[:federalreserve] }], 2 => ::Array[{ wday: 1, week: 3, name: "Washington's Birthday", regions: ::Array[:federalreserve] }], 5 => ::Array[{ wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:federalreserve] }], 7 => ::Array[{ mday: 4, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:federalreserve] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:federalreserve] }], 10 => ::Array[{ wday: 1, week: 2, name: "Columbus Day", regions: ::Array[:federalreserve] }], 11 => ::Array[{ mday: 11, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Veterans Day", regions: ::Array[:federalreserve] } | { wday: 4, week: 4, name: "Thanksgiving Day", regions: ::Array[:federalreserve] }], 12 => ::Array[{ mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:federalreserve] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/federalreservebanks.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module FEDERALRESERVEBANKS
+    def self.defined_regions: () -> ::Array[:federalreservebanks]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:federalreservebanks] } | { wday: 1, week: 3, name: "Birthday of Martin Luther King, Jr", regions: ::Array[:federalreservebanks] }], 2 => ::Array[{ wday: 1, week: 3, name: "Washington's Birthday", regions: ::Array[:federalreservebanks] }], 5 => ::Array[{ wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:federalreservebanks] }], 6 => ::Array[{ mday: 19, year_ranges: { from: 2021 }, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Juneteenth National Independence Day", regions: ::Array[:federalreservebanks] }], 7 => ::Array[{ mday: 4, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:federalreservebanks] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:federalreservebanks] }], 10 => ::Array[{ wday: 1, week: 2, name: "Columbus Day", regions: ::Array[:federalreservebanks] }], 11 => ::Array[{ mday: 11, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Veterans Day", regions: ::Array[:federalreservebanks] } | { wday: 4, week: 4, name: "Thanksgiving Day", regions: ::Array[:federalreservebanks] }], 12 => ::Array[{ mday: 25, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:federalreservebanks] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/fedex.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module FEDEX
+    def self.defined_regions: () -> ::Array[:fedex]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:fedex] }], 5 => ::Array[{ wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:fedex] }], 7 => ::Array[{ mday: 4, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:fedex] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:fedex] }], 11 => ::Array[{ wday: 4, week: 4, name: "Thanksgiving", regions: ::Array[:fedex] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Day After Thanksgiving", regions: ::Array[:fedex] }], 12 => ::Array[{ mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:fedex] } | { mday: 31, name: "New Year's Eve", regions: ::Array[:fedex] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/fi.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module FI
+    def self.defined_regions: () -> ::Array[:fi]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Helatorstai", regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:fi] } | { function: "fi_pyhainpaiva(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:fi] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:fi] } | { mday: 6, name: "Loppiainen", regions: ::Array[:fi] }], 5 => ::Array[{ mday: 1, name: "Vappu", regions: ::Array[:fi] }], 6 => ::Array[{ function: "fi_juhannusaatto(year)", function_arguments: ::Array[:year], name: "Juhannusaatto", regions: ::Array[:fi] } | { function: "fi_juhannuspaiva(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:fi] }], 12 => ::Array[{ mday: 6, name: ::String, regions: ::Array[:fi] } | { mday: 24, name: "Jouluaatto", regions: ::Array[:fi] } | { mday: 25, name: ::String, regions: ::Array[:fi] } | { mday: 26, name: ::String, regions: ::Array[:fi] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/fr.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module FR
+    def self.defined_regions: () -> ::Array[:fr_a | :fr_m | :fr]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Vendredi saint", regions: ::Array[:fr_a | :fr_m] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Ascension", regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, type: :informal, name: ::String, regions: ::Array[:fr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:fr] }], 1 => ::Array[{ mday: 1, name: "Jour de l'an", regions: ::Array[:fr] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:fr] } | { mday: 8, name: "Victoire 1945", regions: ::Array[:fr] }], 7 => ::Array[{ mday: 14, name: ::String, regions: ::Array[:fr] }], 8 => ::Array[{ mday: 15, name: "Assomption", regions: ::Array[:fr] }], 11 => ::Array[{ mday: 1, name: "Toussaint", regions: ::Array[:fr] } | { mday: 11, name: "Armistice 1918", regions: ::Array[:fr] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:fr] } | { mday: 26, name: ::String, regions: ::Array[:fr_a | :fr_m] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/gb.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module GB
+    def self.defined_regions: () -> ::Array[:gb | :gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy | :gb_sct | :gb_con | :im | :gb_iom]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:gb] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Easter Sunday", regions: ::Array[:gb] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:gb] } | { mday: 2, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "2nd January", regions: ::Array[:gb_sct] }], 3 => ::Array[{ mday: 5, name: "St. Piran's Day", regions: ::Array[:gb_con] } | { mday: 17, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "St. Patrick's Day", regions: ::Array[:gb_nir] }], 5 => ::Array[{ wday: 1, week: 1, year_ranges: { until: 2019 }, name: "May Day", regions: ::Array[:gb] } | { mday: 8, year_ranges: { limited: ::Array[2020] }, name: "May Day", regions: ::Array[:gb] } | { wday: 1, week: 1, year_ranges: { from: 2021 }, name: "May Day", regions: ::Array[:gb] } | { mday: 9, name: "Liberation Day", regions: ::Array[:je | :gb_jsy | :gg | :gb_gsy] } | { wday: 1, week: -1, year_ranges: { until: 2021 }, name: "Bank Holiday", regions: ::Array[:gb] } | { wday: 1, week: -1, year_ranges: { from: 2023 }, name: "Bank Holiday", regions: ::Array[:gb] }], 6 => ::Array[{ mday: 2, year_ranges: { limited: ::Array[2022] }, name: "Bank Holiday", regions: ::Array[:gb] } | { mday: 3, year_ranges: { limited: ::Array[2022] }, name: "Platinum Jubilee", regions: ::Array[:gb] }], 7 => ::Array[{ mday: 5, name: "Tynwald Day", regions: ::Array[:im | :gb_iom] } | { mday: 12, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Battle of the Boyne", regions: ::Array[:gb_nir] }], 8 => ::Array[{ wday: 1, week: 1, name: "Bank Holiday", regions: ::Array[:gb_sct] } | { wday: 1, week: -1, name: "Bank Holiday", regions: ::Array[:gb_eng | :gb_wls | :gb_eaw | :gb_nir | :je | :gb_jsy | :gg | :gb_gsy] }], 11 => ::Array[{ mday: 5, type: :informal, name: "Guy Fawkes Day", regions: ::Array[:gb] } | { mday: 30, year_ranges: { until: 2006 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], type: :informal, name: "St. Andrew's Day", regions: ::Array[:gb_sct] } | { mday: 30, year_ranges: { from: 2007 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "St. Andrew's Day", regions: ::Array[:gb_sct] }], 12 => ::Array[{ mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:gb] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:gb] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ge.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module GE
+    def self.defined_regions: () -> ::Array[:ge]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:ge] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:ge] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ge] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:ge] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ge] } | { mday: 2, name: ::String, regions: ::Array[:ge] } | { mday: 7, name: ::String, regions: ::Array[:ge] } | { mday: 19, name: ::String, regions: ::Array[:ge] }], 3 => ::Array[{ mday: 3, name: ::String, regions: ::Array[:ge] } | { mday: 8, name: ::String, regions: ::Array[:ge] }], 4 => ::Array[{ mday: 9, name: ::String, regions: ::Array[:ge] }], 5 => ::Array[{ mday: 9, name: ::String, regions: ::Array[:ge] } | { mday: 12, name: ::String, regions: ::Array[:ge] } | { mday: 26, name: ::String, regions: ::Array[:ge] }], 8 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:ge] }], 10 => ::Array[{ mday: 14, name: ::String, regions: ::Array[:ge] }], 11 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:ge] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/hk.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module HK
+    def self.defined_regions: () -> ::Array[:hk]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "cn_new_lunar_day(year)", function_arguments: ::Array[:year], observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Lunar New Year's Day", regions: ::Array[:hk] } | { function: "cn_new_lunar_day(year)", function_arguments: ::Array[:year], function_modifier: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "The second day of Lunar New Year", regions: ::Array[:hk] } | { function: "cn_new_lunar_day(year)", function_arguments: ::Array[:year], function_modifier: 2, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "The third day of Lunar New Year", regions: ::Array[:hk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:hk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: "The day following Good Friday", regions: ::Array[:hk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:hk] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:hk] }], 5 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Labour Day", regions: ::Array[:hk] }], 7 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Hong Kong Special Administrative Region Establishment Day", regions: ::Array[:hk] }], 10 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "National Day", regions: ::Array[:hk] }], 12 => ::Array[{ mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:hk] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:hk] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/hr.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module HR
+    def self.defined_regions: () -> ::Array[:hr]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: "Uskrs", regions: ::Array[:hr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Uskrsni ponedjeljak", regions: ::Array[:hr] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Tijelovo", regions: ::Array[:hr] }], 1 => ::Array[{ mday: 1, name: "Nova godina", regions: ::Array[:hr] } | { mday: 6, name: "Bogojavljenje ili Sveta tri kralja", regions: ::Array[:hr] }], 5 => ::Array[{ mday: 1, name: "Praznik rada", regions: ::Array[:hr] } | { mday: 30, year_ranges: { from: 2020 }, name: ::String, regions: ::Array[:hr] }], 6 => ::Array[{ mday: 22, name: ::String, regions: ::Array[:hr] } | { mday: 25, year_ranges: { until: 2019 }, name: ::String, regions: ::Array[:hr] }], 8 => ::Array[{ mday: 5, name: "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja", regions: ::Array[:hr] } | { mday: 15, name: "Velika Gospa", regions: ::Array[:hr] }], 10 => ::Array[{ mday: 8, year_ranges: { until: 2019 }, name: "Dan neovisnosti", regions: ::Array[:hr] }], 11 => ::Array[{ mday: 1, name: "Svi sveti", regions: ::Array[:hr] } | { mday: 18, year_ranges: { from: 2020 }, name: ::String, regions: ::Array[:hr] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:hr] } | { mday: 26, name: "Sveti Stjepan", regions: ::Array[:hr] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/hu.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module HU
+    def self.defined_regions: () -> ::Array[:hu]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, year_ranges: { from: 2017 }, name: ::String, regions: ::Array[:hu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:hu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:hu] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:hu] }], 3 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:hu] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:hu] }], 8 => ::Array[{ mday: 20, name: ::String, regions: ::Array[:hu] }], 10 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:hu] }], 11 => ::Array[{ mday: 1, name: "Mindenszentek", regions: ::Array[:hu] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:hu] } | { mday: 26, name: ::String, regions: ::Array[:hu] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ie.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module IE
+    def self.defined_regions: () -> ::Array[:ie]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:ie] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:ie] }], 3 => ::Array[{ mday: 17, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "St. Patrick's Day", regions: ::Array[:ie] }], 5 => ::Array[{ wday: 1, week: 1, name: "May Day", regions: ::Array[:ie] }], 6 => ::Array[{ wday: 1, week: 1, name: "June Bank Holiday", regions: ::Array[:ie] }], 8 => ::Array[{ wday: 1, week: 1, name: "August Bank Holiday", regions: ::Array[:ie] }], 10 => ::Array[{ wday: 1, week: -1, name: "October Bank Holiday", regions: ::Array[:ie] }], 12 => ::Array[{ mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ie] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "St. Stephen's Day", regions: ::Array[:ie] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/is.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module IS
+    def self.defined_regions: () -> ::Array[:is]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Bolludagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Sprengidagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Uppstigningardagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:is] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:is] } | { mday: 6, name: ::String, regions: ::Array[:is] } | { mday: 19, type: :informal, name: ::String, regions: ::Array[:is] }], 2 => ::Array[{ mday: 18, type: :informal, name: "Konudagur", regions: ::Array[:is] }], 4 => ::Array[{ function: "is_sumardagurinn_fyrsti(year)", function_arguments: ::Array[:year], name: "Sumardagurinn fyrsti", regions: ::Array[:is] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:is] } | { mday: 13, name: ::String, regions: ::Array[:is] }], 6 => ::Array[{ mday: 3, type: :informal, name: ::String, regions: ::Array[:is] } | { mday: 17, name: ::String, regions: ::Array[:is] }], 8 => ::Array[{ wday: 1, week: 1, name: ::String, regions: ::Array[:is] }], 11 => ::Array[{ mday: 16, name: ::String, regions: ::Array[:is] }], 12 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:is] } | { mday: 25, name: ::String, regions: ::Array[:is] } | { mday: 26, name: ::String, regions: ::Array[:is] } | { mday: 31, name: ::String, regions: ::Array[:is] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/it.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module IT
+    def self.defined_regions: () -> ::Array[:it | :it_ve | :it_tv | :it_vr | :it_pd | :it_fi | :it_ge | :it_to | :it_rm | :it_vi | :it_bl | :it_ro]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: "Pasqua", regions: ::Array[:it] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:it] }], 1 => ::Array[{ mday: 1, name: "Capodanno", regions: ::Array[:it] } | { mday: 6, name: "Epifania", regions: ::Array[:it] }], 4 => ::Array[{ mday: 25, name: "Festa della Liberazione", regions: ::Array[:it] } | { mday: 25, name: "Festa di San Marco Evangelista", regions: ::Array[:it_ve] } | { mday: 27, name: "Festa di San Liberale", regions: ::Array[:it_tv] }], 5 => ::Array[{ mday: 1, name: "Festa dei Lavoratori", regions: ::Array[:it] } | { mday: 21, name: "Festa di San Zeno", regions: ::Array[:it_vr] }], 6 => ::Array[{ mday: 2, name: "Festa della Repubblica", regions: ::Array[:it] } | { mday: 13, name: "Festa di Sant'Antonio di Padova", regions: ::Array[:it_pd] } | { mday: 24, name: "Festa di San Giovanni Battista", regions: ::Array[:it_fi | :it_ge | :it_to] } | { mday: 29, name: "Festa di San Pietro e Paolo", regions: ::Array[:it_rm] }], 8 => ::Array[{ mday: 15, name: "Assunzione", regions: ::Array[:it] }], 9 => ::Array[{ mday: 8, name: "Festa della Madonna di Monte Berico", regions: ::Array[:it_vi] }], 11 => ::Array[{ mday: 1, name: "Ognissanti", regions: ::Array[:it] } | { mday: 11, name: "Festa di San Martino", regions: ::Array[:it_bl] } | { mday: 26, name: "Festa di San Bellino", regions: ::Array[:it_ro] }], 12 => ::Array[{ mday: 8, name: "Immacolata Concezione", regions: ::Array[:it] } | { mday: 25, name: "Natale", regions: ::Array[:it] } | { mday: 26, name: "Santo Stefano", regions: ::Array[:it] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/jp.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module JP
+    def self.defined_regions: () -> ::Array[:jp]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:jp] } | { wday: 1, week: 2, name: ::String, regions: ::Array[:jp] } | { mday: 1, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] }], 2 => ::Array[{ mday: 11, name: ::String, regions: ::Array[:jp] } | { mday: 11, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] } | { mday: 23, year_ranges: { from: 2020 }, name: ::String, regions: ::Array[:jp] } | { mday: 23, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], year_ranges: { from: 2020 }, name: ::String, regions: ::Array[:jp] }], 3 => ::Array[{ function: "jp_vernal_equinox_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:jp] } | { function: "jp_vernal_equinox_day_substitute(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:jp] }], 4 => ::Array[{ mday: 29, name: ::String, regions: ::Array[:jp] } | { mday: 29, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] } | { mday: 30, year_ranges: { limited: ::Array[2019] }, name: ::String, regions: ::Array[:jp] }], 5 => ::Array[{ mday: 1, year_ranges: { limited: ::Array[2019] }, name: ::String, regions: ::Array[:jp] } | { mday: 2, year_ranges: { limited: ::Array[2019] }, name: ::String, regions: ::Array[:jp] } | { mday: 3, name: ::String, regions: ::Array[:jp] } | { mday: 4, name: ::String, regions: ::Array[:jp] } | { mday: 5, name: ::String, regions: ::Array[:jp] } | { mday: 3, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] } | { mday: 4, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] } | { mday: 5, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] }], 7 => ::Array[{ mday: 20, year_ranges: { between: ::Range[::Integer] }, name: ::String, regions: ::Array[:jp] } | { wday: 1, week: 3, year_ranges: { between: ::Range[::Integer] }, name: ::String, regions: ::Array[:jp] } | { mday: 23, year_ranges: { limited: ::Array[2020] }, name: ::String, regions: ::Array[:jp] } | { mday: 22, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:jp] } | { wday: 1, week: 3, year_ranges: { from: 2022 }, name: ::String, regions: ::Array[:jp] } | { function: "jp_marine_day_substitute(year)", function_arguments: ::Array[:year], year_ranges: { between: ::Range[::Integer] }, name: ::String, regions: ::Array[:jp] } | { mday: 23, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:jp] } | { mday: 24, year_ranges: { limited: ::Array[2020] }, name: ::String, regions: ::Array[:jp] }], 8 => ::Array[{ function: "jp_mountain_holiday(year)", function_arguments: ::Array[:year], year_ranges: { between: ::Range[::Integer] }, name: ::String, regions: ::Array[:jp] } | { mday: 10, year_ranges: { limited: ::Array[2020] }, name: ::String, regions: ::Array[:jp] } | { mday: 8, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:jp] } | { function: "jp_mountain_holiday(year)", function_arguments: ::Array[:year], year_ranges: { from: 2022 }, name: ::String, regions: ::Array[:jp] } | { function: "jp_mountain_holiday_substitute(year)", function_arguments: ::Array[:year], year_ranges: { between: ::Range[::Integer] }, name: ::String, regions: ::Array[:jp] } | { mday: 9, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:jp] } | { function: "jp_mountain_holiday_substitute(year)", function_arguments: ::Array[:year], year_ranges: { from: 2022 }, name: ::String, regions: ::Array[:jp] }], 9 => ::Array[{ wday: 1, week: 3, name: ::String, regions: ::Array[:jp] } | { function: "jp_respect_for_aged_holiday_substitute(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:jp] } | { function: "jp_citizens_holiday(year)", function_arguments: ::Array[:year], year_ranges: { from: 2003 }, name: ::String, regions: ::Array[:jp] } | { function: "jp_national_culture_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:jp] } | { function: "jp_national_culture_day_substitute(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:jp] }], 10 => ::Array[{ wday: 1, week: 2, year_ranges: { until: 2019 }, name: ::String, regions: ::Array[:jp] } | { wday: 1, week: 2, year_ranges: { from: 2022 }, name: ::String, regions: ::Array[:jp] } | { function: "jp_health_sports_day_substitute(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:jp] } | { mday: 22, year_ranges: { limited: ::Array[2019] }, name: ::String, regions: ::Array[:jp] }], 11 => ::Array[{ mday: 3, name: ::String, regions: ::Array[:jp] } | { mday: 3, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] } | { mday: 23, name: ::String, regions: ::Array[:jp] } | { mday: 23, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], name: ::String, regions: ::Array[:jp] }], 12 => ::Array[{ mday: 23, year_ranges: { until: 2018 }, name: ::String, regions: ::Array[:jp] } | { mday: 23, function: "jp_substitute_holiday(year, month, day)", function_arguments: ::Array[:year | :month | :day], year_ranges: { until: 2018 }, name: ::String, regions: ::Array[:jp] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/kr.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module KR
+    def self.defined_regions: () -> ::Array[:kr]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] } | { mday: 2, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] } | { mday: 1, name: ::String, regions: ::Array[:kr] }], 3 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:kr] }], 4 => ::Array[{ mday: 8, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] }], 5 => ::Array[{ mday: 5, name: ::String, regions: ::Array[:kr] }], 6 => ::Array[{ mday: 6, name: ::String, regions: ::Array[:kr] }], 7 => ::Array[{ mday: 17, type: :informal, name: ::String, regions: ::Array[:kr] }], 8 => ::Array[{ mday: 14, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] } | { mday: 15, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] } | { mday: 16, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] } | { mday: 15, name: ::String, regions: ::Array[:kr] }], 10 => ::Array[{ mday: 3, name: ::String, regions: ::Array[:kr] } | { mday: 9, name: ::String, regions: ::Array[:kr] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:kr] } | { mday: 30, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:kr] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/kz.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module KZ
+    def self.defined_regions: () -> ::Array[:kz]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:kz] } | { mday: 2, name: ::String, regions: ::Array[:kz] }], 3 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:kz] } | { mday: 21, name: ::String, regions: ::Array[:kz] } | { mday: 22, name: ::String, regions: ::Array[:kz] } | { mday: 23, name: ::String, regions: ::Array[:kz] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:kz] } | { mday: 7, name: ::String, regions: ::Array[:kz] } | { mday: 9, name: ::String, regions: ::Array[:kz] }], 7 => ::Array[{ mday: 6, name: ::String, regions: ::Array[:kz] }], 8 => ::Array[{ mday: 30, name: ::String, regions: ::Array[:kz] }], 12 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:kz] } | { mday: 16, name: ::String, regions: ::Array[:kz] } | { mday: 17, name: ::String, regions: ::Array[:kz] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/li.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module LI
+    def self.defined_regions: () -> ::Array[:li]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Fasnachtsdienstag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Karfreitag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Ostern", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Ostermontag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Auffahrt", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Pfingstmontag", regions: ::Array[:li] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Fronleichnam", regions: ::Array[:li] }], 1 => ::Array[{ mday: 1, name: "Neujahrstag", regions: ::Array[:li] } | { mday: 6, name: ::String, regions: ::Array[:li] }], 2 => ::Array[{ mday: 2, name: "Maria Lichtmess", regions: ::Array[:li] }], 3 => ::Array[{ mday: 19, name: "St. Josef", regions: ::Array[:li] }], 5 => ::Array[{ mday: 1, name: "Tag der Arbeit", regions: ::Array[:li] }], 8 => ::Array[{ mday: 15, name: "Staatsfeiertag", regions: ::Array[:li] }], 9 => ::Array[{ mday: 8, name: "Maria Geburt", regions: ::Array[:li] }], 11 => ::Array[{ mday: 1, name: "Allerheiligen", regions: ::Array[:li] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:li] } | { mday: 24, name: "Heilig Abend", regions: ::Array[:li] } | { mday: 25, name: "Weihnachten", regions: ::Array[:li] } | { mday: 26, name: "Stefanstag", regions: ::Array[:li] } | { mday: 31, name: "Silvester", regions: ::Array[:li] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/lt.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module LT
+    def self.defined_regions: () -> ::Array[:lt]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:lt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:lt] }], 1 => ::Array[{ mday: 1, name: "Naujieji metai", regions: ::Array[:lt] }], 2 => ::Array[{ mday: 16, name: ::String, regions: ::Array[:lt] }], 3 => ::Array[{ mday: 11, name: ::String, regions: ::Array[:lt] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:lt] }], 6 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:lt] }], 7 => ::Array[{ mday: 6, name: ::String, regions: ::Array[:lt] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:lt] }], 11 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:lt] }], 12 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:lt] } | { mday: 25, name: ::String, regions: ::Array[:lt] } | { mday: 26, name: ::String, regions: ::Array[:lt] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/lu.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module LU
+    def self.defined_regions: () -> ::Array[:lu]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:lu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Christi Himmelfaart", regions: ::Array[:lu] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:lu] }], 1 => ::Array[{ mday: 1, name: "Neijoerschdag", regions: ::Array[:lu] }], 5 => ::Array[{ mday: 1, name: "Dag vun der Aarbecht", regions: ::Array[:lu] } | { mday: 9, year_ranges: { from: 2019 }, name: "Europadag", regions: ::Array[:lu] }], 6 => ::Array[{ mday: 23, name: "Nationalfeierdag", regions: ::Array[:lu] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:lu] }], 11 => ::Array[{ mday: 1, name: "Allerhellgen", regions: ::Array[:lu] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:lu] } | { mday: 26, name: "Stiefesdag", regions: ::Array[:lu] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/lv.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module LV
+    def self.defined_regions: () -> ::Array[:lv]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:lv] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:lv] } | { function: "lv_song_and_dance_festival_end_date(year)", function_arguments: ::Array[:year], year_ranges: { from: 2018 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:lv] }], 1 => ::Array[{ mday: 1, name: "Jaungada diena", regions: ::Array[:lv] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:lv] } | { mday: 4, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:lv] } | { wday: 0, week: 2, name: ::String, regions: ::Array[:lv] }], 6 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:lv] } | { mday: 24, name: ::String, regions: ::Array[:lv] }], 9 => ::Array[{ mday: 24, year_ranges: { limited: ::Array[2018] }, name: ::String, regions: ::Array[:lv] }], 11 => ::Array[{ mday: 18, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:lv] }], 12 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:lv] } | { mday: 25, name: ::String, regions: ::Array[:lv] } | { mday: 26, name: ::String, regions: ::Array[:lv] } | { mday: 31, name: "Vecgada diena", regions: ::Array[:lv] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ma.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module MA
+    def self.defined_regions: () -> ::Array[:ma]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ma] } | { mday: 11, name: "Takdim watikat al-istiqlal", regions: ::Array[:ma] }], 5 => ::Array[{ mday: 1, name: "Eid Ash-Shughl", regions: ::Array[:ma] }], 7 => ::Array[{ mday: 30, name: ::String, regions: ::Array[:ma] }], 8 => ::Array[{ mday: 14, name: "Zikra Oued Ed-Dahab", regions: ::Array[:ma] } | { mday: 20, name: ::String, regions: ::Array[:ma] } | { mday: 21, name: "Eid Al Milad", regions: ::Array[:ma] }], 11 => ::Array[{ mday: 6, name: "Eid Al Massira Al Khadra", regions: ::Array[:ma] } | { mday: 18, name: "Eid Al Istiqulal", regions: ::Array[:ma] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/mt_en.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module MT_EN
+    def self.defined_regions: () -> ::Array[:mt_en]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:mt_en] }], 1 => ::Array[{ mday: 1, name: "New Year's Day", regions: ::Array[:mt_en] }], 2 => ::Array[{ mday: 10, name: "Feast of Saint Paul's Shipwreck in Malta", regions: ::Array[:mt_en] }], 3 => ::Array[{ mday: 19, name: "Feast of Saint Joseph", regions: ::Array[:mt_en] } | { mday: 31, name: "Freedom Day", regions: ::Array[:mt_en] }], 5 => ::Array[{ mday: 1, name: "Worker's Day", regions: ::Array[:mt_en] }], 6 => ::Array[{ mday: 7, name: "Sette Giugno", regions: ::Array[:mt_en] } | { mday: 29, name: "Feast of Saint Peter & Saint Paul", regions: ::Array[:mt_en] }], 8 => ::Array[{ mday: 15, name: "Feast of the Assumption of Our Lady", regions: ::Array[:mt_en] }], 9 => ::Array[{ mday: 8, name: "Victory Day", regions: ::Array[:mt_en] } | { mday: 21, name: "Independence Day", regions: ::Array[:mt_en] }], 12 => ::Array[{ mday: 8, name: "Feast of the Immaculate Conception", regions: ::Array[:mt_en] } | { mday: 13, name: "Republic Day", regions: ::Array[:mt_en] } | { mday: 25, name: "Christmas Day", regions: ::Array[:mt_en] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/mt_mt.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module MT_MT
+    def self.defined_regions: () -> ::Array[:mt_mt]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:mt_mt] }], 1 => ::Array[{ mday: 1, name: "L-Ewwel tas-Sena", regions: ::Array[:mt_mt] }], 2 => ::Array[{ mday: 10, name: ::String, regions: ::Array[:mt_mt] }], 3 => ::Array[{ mday: 19, name: ::String, regions: ::Array[:mt_mt] } | { mday: 31, name: ::String, regions: ::Array[:mt_mt] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:mt_mt] }], 6 => ::Array[{ mday: 7, name: "Sette Giugno", regions: ::Array[:mt_mt] } | { mday: 29, name: "L-Imnarja", regions: ::Array[:mt_mt] }], 8 => ::Array[{ mday: 15, name: "Santa Marija", regions: ::Array[:mt_mt] }], 9 => ::Array[{ mday: 8, name: "Jum il-Vitorja", regions: ::Array[:mt_mt] } | { mday: 21, name: "Jum l-Indipendenza", regions: ::Array[:mt_mt] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:mt_mt] } | { mday: 13, name: "Jum ir-Repubblika", regions: ::Array[:mt_mt] } | { mday: 25, name: "Il-Milied", regions: ::Array[:mt_mt] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/mx.yaml, definitions/northamericainformal.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module MX
+    def self.defined_regions: () -> ::Array[:mx | :mx_pue | :us | :ca]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:mx] } | { mday: 6, type: :informal, name: "Dia de los Santos Reyes", regions: ::Array[:mx] }], 2 => ::Array[{ wday: 1, week: 1, name: ::String, regions: ::Array[:mx] } | { mday: 2, type: :informal, name: "Groundhog Day", regions: ::Array[:us | :ca] } | { mday: 14, type: :informal, name: "Valentine's Day", regions: ::Array[:us | :ca] }], 3 => ::Array[{ wday: 1, week: 3, name: ::String, regions: ::Array[:mx] } | { mday: 17, type: :informal, name: "St. Patrick's Day", regions: ::Array[:us | :ca] }], 4 => ::Array[{ mday: 30, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 1, type: :informal, name: "April Fool's Day", regions: ::Array[:us | :ca] } | { mday: 22, type: :informal, name: "Earth Day", regions: ::Array[:us | :ca] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:mx] } | { mday: 5, type: :informal, name: "Cinco de Mayo", regions: ::Array[:mx] } | { mday: 5, type: :informal, name: "La Batalla de Puebla", regions: ::Array[:mx_pue] } | { mday: 10, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 15, type: :informal, name: ::String, regions: ::Array[:mx] } | { wday: 0, week: 2, type: :informal, name: "Mother's Day", regions: ::Array[:us | :ca] } | { wday: 6, week: 3, type: :informal, name: "Armed Forces Day", regions: ::Array[:us] }], 6 => ::Array[{ wday: 0, week: 3, type: :informal, name: ::String, regions: ::Array[:mx] } | { wday: 0, week: 3, type: :informal, name: "Father's Day", regions: ::Array[:us | :ca] }], 9 => ::Array[{ mday: 15, name: "Grito de Dolores", regions: ::Array[:mx] } | { mday: 16, name: ::String, regions: ::Array[:mx] }], 10 => ::Array[{ mday: 12, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 31, type: :informal, name: "Halloween", regions: ::Array[:us | :ca] }], 11 => ::Array[{ mday: 1, type: :informal, name: "Todos los Santos", regions: ::Array[:mx] } | { mday: 2, type: :informal, name: "Los Fieles Difuntos", regions: ::Array[:mx] } | { wday: 1, week: 3, name: ::String, regions: ::Array[:mx] }], 12 => ::Array[{ mday: 12, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 24, type: :informal, name: "Nochebuena", regions: ::Array[:mx] } | { mday: 25, name: "Navidad", regions: ::Array[:mx] } | { mday: 28, type: :informal, name: "Los Santos Inocentes", regions: ::Array[:mx] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/my.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module MY
+    def self.defined_regions: () -> ::Array[:my]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:my] }], 5 => ::Array[{ mday: 1, name: "Labour Day", regions: ::Array[:my] }], 6 => ::Array[{ mday: 4, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Agong's Birthday", regions: ::Array[:my] }], 8 => ::Array[{ mday: 31, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:my] }], 9 => ::Array[{ mday: 16, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Malaysia Day", regions: ::Array[:my] }], 12 => ::Array[{ mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:my] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/nerc.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NERC
+    def self.defined_regions: () -> ::Array[:nerc]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:nerc] }], 5 => ::Array[{ wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:nerc] }], 7 => ::Array[{ mday: 4, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:nerc] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:nerc] }], 11 => ::Array[{ wday: 4, week: 4, name: "Thanksgiving", regions: ::Array[:nerc] }], 12 => ::Array[{ mday: 25, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:nerc] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ng.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NG
+    def self.defined_regions: () -> ::Array[:ng]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:ng] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:ng] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:ng] }], 5 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Workers' Day", regions: ::Array[:ng] } | { mday: 27, type: :informal, name: "Children's Day", regions: ::Array[:ng] }], 6 => ::Array[{ mday: 12, year_ranges: { from: 2018 }, name: "Democracy Day", regions: ::Array[:ng] }], 10 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:ng] }], 12 => ::Array[{ mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ng] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:ng] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/nl.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NL
+    def self.defined_regions: () -> ::Array[:nl]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, type: :informal, name: "Goede Vrijdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Eerste Paasdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Tweede Paasdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Hemelvaartsdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Eerste Pinksterdag", regions: ::Array[:nl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Tweede Pinksterdag", regions: ::Array[:nl] }], 1 => ::Array[{ mday: 1, name: "Nieuwjaarsdag", regions: ::Array[:nl] }], 4 => ::Array[{ mday: 27, name: "Koningsdag", regions: ::Array[:nl] }], 5 => ::Array[{ mday: 4, type: :informal, name: "Dodenherdenking", regions: ::Array[:nl] } | { mday: 5, name: "Bevrijdingsdag", regions: ::Array[:nl] }], 12 => ::Array[{ mday: 5, type: :informal, name: "Sinterklaas", regions: ::Array[:nl] } | { mday: 25, name: "Eerste Kerstdag", regions: ::Array[:nl] } | { mday: 26, name: "Tweede Kerstdag", regions: ::Array[:nl] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/no.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NO
+    def self.defined_regions: () -> ::Array[:no]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -49, type: :informal, name: "Fastelavn", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Langfredag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Kristi Himmelfartsdag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "1. pinsedag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "2. pinsedag", regions: ::Array[:no] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:no] }], 5 => ::Array[{ mday: 1, name: "1. mai", regions: ::Array[:no] } | { mday: 17, name: "17. mai", regions: ::Array[:no] }], 12 => ::Array[{ mday: 24, type: :informal, name: "Julaften", regions: ::Array[:no] } | { mday: 25, name: "1. juledag", regions: ::Array[:no] } | { mday: 26, name: "2. juledag", regions: ::Array[:no] } | { mday: 31, type: :informal, name: ::String, regions: ::Array[:no] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ca.yaml, definitions/mx.yaml, definitions/us.yaml, definitions/northamericainformal.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NORTHAMERICA
+    def self.defined_regions: () -> ::Array[:ca | :ca_qc | :ca_ab | :ca_sk | :ca_on | :ca_bc | :ca_nb | :ca_mb | :ca_ns | :ca_pe | :ca_nl | :ca_nt | :ca_nu | :ca_yt | :mx | :mx_pue | :us_fl | :us_la | :us | :us_ct | :us_de | :us_gu | :us_hi | :us_in | :us_ky | :us_nj | :us_nc | :us_nd | :us_pr | :us_tn | :us_ms | :us_id | :us_ar | :us_tx | :us_dc | :us_md | :us_va | :us_vt | :us_ak | :us_ca | :us_me | :us_ma | :us_al | :us_ga | :us_ne | :us_mo | :us_sc | :us_wv | :us_vi | :us_ut | :us_ri | :us_az | :us_co | :us_il | :us_mt | :us_nm | :us_ny | :us_oh | :us_pa | :us_mi | :us_mn | :us_nv | :us_or | :us_sd | :us_wa | :us_wi | :us_wy | :us_ia | :us_ks | :us_nh | :us_ok]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:ca] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Easter Sunday", regions: ::Array[:ca] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, type: :informal, name: "Easter Monday", regions: ::Array[:ca] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Shrove Tuesday", regions: ::Array[:us_fl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Mardi Gras Day", regions: ::Array[:us_la] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, type: :informal, name: "Good Friday", regions: ::Array[:us] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:us_ct | :us_de | :us_gu | :us_hi | :us_in | :us_ky | :us_la | :us_nj | :us_nc | :us_nd | :us_pr | :us_tn] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Easter Sunday", regions: ::Array[:us] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:ca] } | { mday: 2, name: "New Year's", regions: ::Array[:ca_qc] } | { mday: 1, name: ::String, regions: ::Array[:mx] } | { mday: 6, type: :informal, name: "Dia de los Santos Reyes", regions: ::Array[:mx] } | { mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:us] } | { wday: 1, week: 3, name: "Martin Luther King's and Robert E. Lee's Birthdays", regions: ::Array[:us_ms] } | { wday: 1, week: 3, name: "Idaho Human Rights Day", regions: ::Array[:us_id] } | { wday: 1, week: 3, name: "Civil Rights Day", regions: ::Array[:us_ar] } | { wday: 1, week: 3, name: "Martin Luther King, Jr. Day", regions: ::Array[:us] } | { function: "us_inauguration_day(year)", function_arguments: ::Array[:year], name: "Inauguration Day", regions: ::Array[:us_tx | :us_dc | :us_la | :us_md | :us_va] } | { function: "lee_jackson_day(year, month)", function_arguments: ::Array[:year | :month], name: "Lee-Jackson Day", regions: ::Array[:us_va] } | { mday: 19, name: "Confederate Heroes Day", regions: ::Array[:us_tx] }], 2 => ::Array[{ wday: 1, week: 3, year_ranges: { from: 1990 }, name: "Family Day", regions: ::Array[:ca_ab] } | { wday: 1, week: 3, year_ranges: { from: 2007 }, name: "Family Day", regions: ::Array[:ca_sk] } | { wday: 1, week: 3, year_ranges: { from: 2008 }, name: "Family Day", regions: ::Array[:ca_on] } | { wday: 1, week: 2, year_ranges: { between: ::Range[::Integer] }, name: "Family Day", regions: ::Array[:ca_bc] } | { wday: 1, week: 3, year_ranges: { from: 2019 }, name: "Family Day", regions: ::Array[:ca_bc] } | { wday: 1, week: 3, year_ranges: { from: 2018 }, name: "Family Day", regions: ::Array[:ca_nb] } | { wday: 1, week: 3, name: "Louis Riel Day", regions: ::Array[:ca_mb] } | { wday: 1, week: 3, year_ranges: { from: 2015 }, name: "Nova Scotia Heritage Day", regions: ::Array[:ca_ns] } | { wday: 1, week: 3, name: "Islander Day", regions: ::Array[:ca_pe] } | { wday: 1, week: 1, name: ::String, regions: ::Array[:mx] } | { wday: 1, week: 3, name: "Presidents' Day", regions: ::Array[:us] } | { mday: 2, type: :informal, name: "Groundhog Day", regions: ::Array[:us | :ca] } | { mday: 14, type: :informal, name: "Valentine's Day", regions: ::Array[:us | :ca] }], 3 => ::Array[{ mday: 17, type: :informal, name: "St. Patrick's Day", regions: ::Array[:ca_nl] } | { mday: 23, type: :informal, name: "St. George's Day", regions: ::Array[:ca_nl] } | { wday: 1, week: 3, name: ::String, regions: ::Array[:mx] } | { wday: 2, week: 1, name: "Town Meeting Day", regions: ::Array[:us_vt] } | { mday: 2, name: "Texas Independence Day", regions: ::Array[:us_tx] } | { mday: 26, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Prince Jonah Kuhio Kalanianaole Day", regions: ::Array[:us_hi] } | { wday: 1, week: -1, name: "Seward's Day", regions: ::Array[:us_ak] } | { mday: 31, name: ::String, regions: ::Array[:us_ca] } | { mday: 17, type: :informal, name: "St. Patrick's Day", regions: ::Array[:us | :ca] }], 5 => ::Array[{ function: "ca_victoria_day(year)", function_arguments: ::Array[:year], name: "Victoria Day", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nt | :ca_nu | :ca_on | :ca_sk | :ca_yt] } | { function: "ca_victoria_day(year)", function_arguments: ::Array[:year], name: "National Patriotes Day", regions: ::Array[:ca_qc] } | { mday: 1, name: ::String, regions: ::Array[:mx] } | { mday: 5, type: :informal, name: "Cinco de Mayo", regions: ::Array[:mx] } | { mday: 5, type: :informal, name: "La Batalla de Puebla", regions: ::Array[:mx_pue] } | { mday: 10, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 15, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 8, name: "Truman Day", regions: ::Array[:us_mo] } | { mday: 10, name: "Confederate Memorial Day", regions: ::Array[:us_sc] } | { wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:us] } | { wday: 0, week: 2, type: :informal, name: "Mother's Day", regions: ::Array[:us | :ca] } | { wday: 6, week: 3, type: :informal, name: "Armed Forces Day", regions: ::Array[:us] }], 6 => ::Array[{ mday: 24, type: :informal, name: "Discovery Day", regions: ::Array[:ca_nl] } | { mday: 24, name: ::String, regions: ::Array[:ca_qc] } | { mday: 21, name: "National Aboriginal Day", regions: ::Array[:ca_nt] } | { mday: 21, year_ranges: { from: 2017 }, name: "National Aboriginal Day", regions: ::Array[:ca_yt] } | { wday: 0, week: 3, type: :informal, name: ::String, regions: ::Array[:mx] } | { wday: 1, week: 1, name: "Jefferson Davis' Birthday", regions: ::Array[:us_al] } | { mday: 3, name: "Birthday of Jefferson Davis", regions: ::Array[:us_fl] } | { mday: 11, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "King Kamehameha I Day", regions: ::Array[:us_hi] } | { mday: 19, year_ranges: { from: 2021 }, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Juneteenth National Independence Day", regions: ::Array[:us] } | { mday: 19, name: "Emancipation Day in Texas", regions: ::Array[:us_tx] } | { mday: 20, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "West Virginia Day", regions: ::Array[:us_wv] } | { wday: 0, week: 3, type: :informal, name: "Father's Day", regions: ::Array[:us | :ca] }], 7 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Canada Day", regions: ::Array[:ca] } | { mday: 12, type: :informal, name: "Orangemen's Day", regions: ::Array[:ca_nl] } | { mday: 9, year_ranges: { from: 2020 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Nunavut Day", regions: ::Array[:ca_nu] } | { mday: 3, name: "Emancipation Day", regions: ::Array[:us_vi] } | { mday: 4, name: "Independence Day", regions: ::Array[:us] } | { mday: 4, function: "to_weekday_if_weekend(date)", function_arguments: ::Array[:date], name: "Independence Day (Holiday)", regions: ::Array[:us_va] } | { mday: 24, name: "Pioneer Day", regions: ::Array[:us_ut] }], 8 => ::Array[{ wday: 1, week: 1, name: "B.C. Day", regions: ::Array[:ca_bc] } | { wday: 1, week: 1, name: "Saskatchewan Day", regions: ::Array[:ca_sk] } | { wday: 1, week: 1, type: :informal, name: "Heritage Day", regions: ::Array[:ca_ab] } | { wday: 1, week: 1, type: :informal, name: "Natal Day", regions: ::Array[:ca_ns] } | { wday: 1, week: 1, name: "Civic Holiday", regions: ::Array[:ca_nt | :ca_nu] } | { wday: 1, week: 1, type: :informal, name: "Civic Holiday", regions: ::Array[:ca_on | :ca_pe] } | { wday: 1, week: 1, name: "New Brunswick Day", regions: ::Array[:ca_nb] } | { wday: 1, week: 1, type: :informal, name: "Terry Fox Day", regions: ::Array[:ca_mb] } | { wday: 1, week: 3, name: "Discovery Day", regions: ::Array[:ca_yt] } | { wday: 1, week: 2, name: "Victory Day", regions: ::Array[:us_ri] } | { mday: 16, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Bennington Battle Day", regions: ::Array[:us_vt] } | { wday: 5, week: 3, name: "Statehood Day", regions: ::Array[:us_hi] } | { mday: 27, name: "Lyndon Baines Johnson Day", regions: ::Array[:us_tx] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labour Day", regions: ::Array[:ca] } | { mday: 30, year_ranges: { from: 2021 }, name: "National Day for Truth and Reconciliation", regions: ::Array[:ca] } | { mday: 15, name: "Grito de Dolores", regions: ::Array[:mx] } | { mday: 16, name: ::String, regions: ::Array[:mx] } | { wday: 1, week: 1, name: "Labor Day", regions: ::Array[:us] } | { function: "rosh_hashanah(year)", function_arguments: ::Array[:year], name: "Rosh Hashanah", regions: ::Array[:us_tx] } | { function: "yom_kippur(year)", function_arguments: ::Array[:year], name: "Yom Kippur", regions: ::Array[:us_tx] }], 10 => ::Array[{ wday: 1, week: 2, name: "Thanksgiving", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nt | :ca_nu | :ca_on | :ca_qc | :ca_sk | :ca_yt] } | { mday: 12, type: :informal, name: ::String, regions: ::Array[:mx] } | { wday: 1, week: 2, name: "Columbus Day", regions: ::Array[:us_al | :us_az | :us_co | :us_ct | :us_dc | :us_ga | :us_id | :us_il | :us_in | :us_ma | :us_md | :us_me | :us_mo | :us_mt | :us_ne | :us_nj | :us_nm | :us_ny | :us_oh | :us_pa | :us_ri | :us_ut | :us_va | :us_wv] } | { wday: 1, week: 2, type: :informal, name: "Columbus Day", regions: ::Array[:us_ak | :us_ar | :us_ca | :us_de | :us_fl | :us_hi | :us_mi | :us_mn | :us_nd | :us_nv | :us_or | :us_sd | :us_tx | :us_vt | :us_wa | :us_wi | :us_wy] } | { mday: 18, name: "Alaska Day", regions: ::Array[:us_ak] } | { wday: 5, week: -1, name: "Nevada Day", regions: ::Array[:us_nv] } | { mday: 31, type: :informal, name: "Halloween", regions: ::Array[:us | :ca] }], 11 => ::Array[{ mday: 11, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Remembrance Day", regions: ::Array[:ca_ab | :ca_sk | :ca_bc | :ca_pe | :ca_nl | :ca_nt | :ca_nu | :ca_nb | :ca_yt] } | { mday: 1, type: :informal, name: "Todos los Santos", regions: ::Array[:mx] } | { mday: 2, type: :informal, name: "Los Fieles Difuntos", regions: ::Array[:mx] } | { wday: 1, week: 3, name: ::String, regions: ::Array[:mx] } | { function: "election_day(year)", function_arguments: ::Array[:year], name: "Election Day", regions: ::Array[:us_de | :us_hi | :us_in | :us_mt | :us_nj | :us_ny | :us_pa | :us_ri] } | { mday: 11, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Veterans Day", regions: ::Array[:us] } | { wday: 4, week: 4, name: "Thanksgiving", regions: ::Array[:us] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Family Day", regions: ::Array[:us_nv] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "State Holiday", regions: ::Array[:us_ga] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Presidents' Day", regions: ::Array[:us_nm] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Lincoln's Birthday", regions: ::Array[:us_in] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "American Indian Heritage Day", regions: ::Array[:us_md] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Day after Thanksgiving (Black Friday)", regions: ::Array[:us_ca | :us_de | :us_fl | :us_ia | :us_il | :us_ks | :us_ky | :us_me | :us_mi | :us_mn | :us_ms | :us_ne | :us_nh | :us_nc | :us_pa | :us_sc | :us_ok | :us_tn | :us_tx | :us_va | :us_wa | :us_wv] }], 12 => ::Array[{ mday: 25, year_ranges: { until: 2020 }, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ca_on] } | { mday: 25, year_ranges: { from: 2020 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ca_on] } | { mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nb | :ca_nl | :ca_nt | :ca_ns | :ca_nu | :ca_pe | :ca_qc | :ca_sk | :ca_yt] } | { mday: 26, year_ranges: { until: 2020 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:ca_on] } | { mday: 26, year_ranges: { from: 2020 }, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:ca_on] } | { mday: 26, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], type: :informal, name: "Boxing Day", regions: ::Array[:ca_ab | :ca_bc | :ca_mb | :ca_nb | :ca_nl | :ca_nt | :ca_ns | :ca_nu | :ca_pe | :ca_qc | :ca_sk | :ca_yt] } | { mday: 12, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 24, type: :informal, name: "Nochebuena", regions: ::Array[:mx] } | { mday: 25, name: "Navidad", regions: ::Array[:mx] } | { mday: 28, type: :informal, name: "Los Santos Inocentes", regions: ::Array[:mx] } | { mday: 24, name: "Christmas Eve", regions: ::Array[:us_ar | :us_mi | :us_nc | :us_sc | :us_tx | :us_wi] } | { mday: 24, function: "christmas_eve_holiday(date)", function_arguments: ::Array[:date], name: "Christmas Eve (Holiday)", regions: ::Array[:us_mi | :us_sc | :us_va] } | { mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:us] } | { mday: 26, name: "Day after Christmas", regions: ::Array[:us_ar | :us_nc | :us_ok | :us_sc | :us_tn | :us_tx] } | { mday: 31, name: "New Year's Eve", regions: ::Array[:us_mi | :us_wi] }], 4 => ::Array[{ mday: 30, type: :informal, name: ::String, regions: ::Array[:mx] } | { mday: 16, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Emancipation Day", regions: ::Array[:us_dc] } | { wday: 1, week: 3, name: "Patriots' Day", regions: ::Array[:us_me | :us_ma] } | { mday: 21, name: "San Jacinto Day", regions: ::Array[:us_tx] } | { wday: 1, week: -1, name: "Confederate Memorial Day", regions: ::Array[:us_al | :us_ms] } | { mday: 26, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Confederate Memorial Day", regions: ::Array[:us_fl] } | { function: "georgia_state_holiday(year, month)", function_arguments: ::Array[:year | :month], name: "State Holiday", regions: ::Array[:us_ga] } | { mday: 28, name: "Arbor Day", regions: ::Array[:us_ne] } | { mday: 1, type: :informal, name: "April Fool's Day", regions: ::Array[:us | :ca] } | { mday: 22, type: :informal, name: "Earth Day", regions: ::Array[:us | :ca] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/nyse.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NYSE
+    def self.defined_regions: () -> ::Array[:nyse]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:nyse] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:nyse] } | { wday: 1, week: 3, name: "Martin Luther King, Jr. Day", regions: ::Array[:nyse] }], 2 => ::Array[{ wday: 1, week: 3, name: "Presidents' Day", regions: ::Array[:nyse] }], 5 => ::Array[{ wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:nyse] }], 7 => ::Array[{ mday: 4, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:nyse] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:nyse] }], 11 => ::Array[{ wday: 4, week: 4, name: "Thanksgiving", regions: ::Array[:nyse] }], 12 => ::Array[{ mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:nyse] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/nz.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module NZ
+    def self.defined_regions: () -> ::Array[:nz | :nz_sl | :nz_we | :nz_ak | :nz_nl | :nz_ne | :nz_ot | :nz_ta | :nz_sc | :nz_hb | :nz_mb | :nz_ca | :nz_ch | :nz_wl]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:nz] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Easter Monday", regions: ::Array[:nz] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:nz] } | { mday: 2, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Day after New Year's Day", regions: ::Array[:nz] } | { mday: 17, name: "Southland Anniversary Day", regions: ::Array[:nz_sl] } | { mday: 22, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Wellington Anniversary Day", regions: ::Array[:nz_we] } | { mday: 29, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Auckland Anniversary Day", regions: ::Array[:nz_ak] } | { mday: 29, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Northland Anniversary Day", regions: ::Array[:nz_nl] }], 2 => ::Array[{ mday: 1, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Nelson Anniversary Day", regions: ::Array[:nz_ne] } | { mday: 6, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Waitangi Day", regions: ::Array[:nz] }], 3 => ::Array[{ mday: 23, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Otago Anniversary Day", regions: ::Array[:nz_ot] } | { wday: 1, week: 2, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Taranaki Anniversary Day", regions: ::Array[:nz_ta] }], 4 => ::Array[{ mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "ANZAC Day", regions: ::Array[:nz] }], 6 => ::Array[{ wday: 1, week: 1, name: "Queen's Birthday", regions: ::Array[:nz] }], 9 => ::Array[{ wday: 1, week: 4, name: "Dominion Day", regions: ::Array[:nz_sc] }], 10 => ::Array[{ wday: 1, week: 1, observed: "previous_friday(date)", observed_arguments: ::Array[:date], name: "Hawke's bay Anniversary Day", regions: ::Array[:nz_hb] } | { wday: 1, week: 4, name: "Labour Day", regions: ::Array[:nz] } | { wday: 1, week: 4, observed: "next_week(date)", observed_arguments: ::Array[:date], name: "Marlborough Anniversary Day", regions: ::Array[:nz_mb] }], 11 => ::Array[{ wday: 5, week: 2, name: "Canterbury Anniversary Day", regions: ::Array[:nz_ca] } | { mday: 30, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Chatham Island Anniversary Day", regions: ::Array[:nz_ch] }], 12 => ::Array[{ mday: 1, observed: "closest_monday(date)", observed_arguments: ::Array[:date], name: "Westland Anniversary Day", regions: ::Array[:nz_wl] } | { mday: 25, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:nz] } | { mday: 26, observed: "to_weekday_if_boxing_weekend(date)", observed_arguments: ::Array[:date], name: "Boxing Day", regions: ::Array[:nz] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/pe.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module PE
+    def self.defined_regions: () -> ::Array[:pe]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:pe] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:pe] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Pascua", regions: ::Array[:pe] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:pe] } | { mday: 6, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:pe] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:pe] } | { wday: 0, week: 2, type: :informal, name: ::String, regions: ::Array[:pe] }], 6 => ::Array[{ mday: 7, type: :informal, name: ::String, regions: ::Array[:pe] } | { wday: 0, week: 3, type: :informal, name: ::String, regions: ::Array[:pe] } | { mday: 24, type: :informal, name: "Inti Raymi", regions: ::Array[:pe] } | { mday: 29, name: "San Pablo y San Pedro", regions: ::Array[:pe] }], 7 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:pe] } | { mday: 29, name: ::String, regions: ::Array[:pe] }], 8 => ::Array[{ mday: 30, name: "Santa Rosa de Lima", regions: ::Array[:pe] }], 9 => ::Array[{ mday: 24, type: :informal, name: ::String, regions: ::Array[:pe] }], 10 => ::Array[{ mday: 8, name: "Batalla de Angamos", regions: ::Array[:pe] }], 11 => ::Array[{ mday: 1, name: "Todos los Santos", regions: ::Array[:pe] }], 12 => ::Array[{ mday: 8, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:pe] } | { mday: 25, name: ::String, regions: ::Array[:pe] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ph.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module PH
+    def self.defined_regions: () -> ::Array[:ph]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Maundy Thursday", regions: ::Array[:ph] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:ph] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: "Holy Saturday", regions: ::Array[:ph] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Easter Sunday", regions: ::Array[:ph] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ph] }], 2 => ::Array[{ mday: 25, type: :informal, name: "People Power Anniversary", regions: ::Array[:ph] }], 4 => ::Array[{ mday: 9, name: "The Day of Valor", regions: ::Array[:ph] }], 5 => ::Array[{ mday: 1, name: "Labor Day", regions: ::Array[:ph] }], 6 => ::Array[{ mday: 12, name: "Independence Day", regions: ::Array[:ph] }], 8 => ::Array[{ mday: 21, name: "Ninoy Aquino Day", regions: ::Array[:ph] } | { function: "ph_heroes_day(year)", function_arguments: ::Array[:year], name: "National Heroes Day", regions: ::Array[:ph] }], 11 => ::Array[{ mday: 1, type: :informal, name: "All Saints Day", regions: ::Array[:ph] } | { mday: 30, name: "Bonifacio Day", regions: ::Array[:ph] }], 12 => ::Array[{ mday: 25, name: "Christmas Day", regions: ::Array[:ph] } | { mday: 30, name: "Rizal Day", regions: ::Array[:ph] } | { mday: 31, name: "New Year's Eve", regions: ::Array[:ph] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/pl.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module PL
+    def self.defined_regions: () -> ::Array[:pl]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -52, type: :informal, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, type: :informal, name: "Ostatki", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, type: :informal, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, type: :informal, name: "Niedziela Palmowa", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, type: :informal, name: "Wielki Czwartek", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, type: :informal, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, type: :informal, name: "Wielka Sobota", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Niedziela Wielkanocna", regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:pl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: ::String, regions: ::Array[:pl] }], 1 => ::Array[{ mday: 1, name: "Nowy Rok", regions: ::Array[:pl] } | { function: "pl_trzech_kroli(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:pl] } | { function: "pl_trzech_kroli_informal(year)", function_arguments: ::Array[:year], type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 21, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 22, type: :informal, name: ::String, regions: ::Array[:pl] }], 2 => ::Array[{ mday: 2, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 14, type: :informal, name: ::String, regions: ::Array[:pl] }], 3 => ::Array[{ mday: 8, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 10, type: :informal, name: ::String, regions: ::Array[:pl] }], 4 => ::Array[{ mday: 1, type: :informal, name: "Prima Aprilis", regions: ::Array[:pl] } | { mday: 22, type: :informal, name: ::String, regions: ::Array[:pl] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:pl] } | { mday: 2, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 3, name: ::String, regions: ::Array[:pl] }], 6 => ::Array[{ mday: 23, type: :informal, name: ::String, regions: ::Array[:pl] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:pl] }], 9 => ::Array[{ mday: 30, type: :informal, name: ::String, regions: ::Array[:pl] }], 10 => ::Array[{ mday: 14, type: :informal, name: ::String, regions: ::Array[:pl] }], 11 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:pl] } | { mday: 2, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 11, name: ::String, regions: ::Array[:pl] } | { mday: 29, type: :informal, name: "Andrzejki", regions: ::Array[:pl] }], 12 => ::Array[{ mday: 4, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 6, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 24, type: :informal, name: ::String, regions: ::Array[:pl] } | { mday: 25, name: ::String, regions: ::Array[:pl] } | { mday: 26, name: ::String, regions: ::Array[:pl] } | { mday: 31, type: :informal, name: "Sylwester", regions: ::Array[:pl] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/pt.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module PT
+    def self.defined_regions: () -> ::Array[:pt | :pt_li | :pt_po]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, type: :informal, name: "Carnaval", regions: ::Array[:pt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Sexta-feira Santa", regions: ::Array[:pt] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:pt] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Corpo de Deus", regions: ::Array[:pt] }], 1 => ::Array[{ mday: 1, name: "Ano Novo", regions: ::Array[:pt] }], 4 => ::Array[{ mday: 25, name: "Dia da Liberdade", regions: ::Array[:pt] }], 5 => ::Array[{ mday: 1, name: "Dia do Trabalhador", regions: ::Array[:pt] }], 6 => ::Array[{ mday: 10, name: "Dia de Portugal", regions: ::Array[:pt] } | { mday: 13, name: ::String, regions: ::Array[:pt_li] } | { mday: 24, name: ::String, regions: ::Array[:pt_po] }], 8 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:pt] }], 10 => ::Array[{ mday: 5, name: ::String, regions: ::Array[:pt] }], 11 => ::Array[{ mday: 1, name: "Dia de Todos-os-Santos", regions: ::Array[:pt] }], 12 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:pt] } | { mday: 8, name: ::String, regions: ::Array[:pt] } | { mday: 25, name: "Natal", regions: ::Array[:pt] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ro.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module RO
+    def self.defined_regions: () -> ::Array[:ro]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, year_ranges: { from: 2018 }, name: ::String, regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Rusaliile - 50", regions: ::Array[:ro] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "Rusaliile - 51", regions: ::Array[:ro] }], 1 => ::Array[{ mday: 1, name: "Anul nou", regions: ::Array[:ro] } | { mday: 2, name: "Anul nou", regions: ::Array[:ro] } | { mday: 24, year_ranges: { from: 2017 }, name: ::String, regions: ::Array[:ro] }], 5 => ::Array[{ mday: 1, name: "Ziua muncii", regions: ::Array[:ro] }], 6 => ::Array[{ mday: 1, year_ranges: { from: 2017 }, name: "Ziua Copilului", regions: ::Array[:ro] }], 8 => ::Array[{ mday: 15, name: "Adormirea Maicii Domnului", regions: ::Array[:ro] }], 11 => ::Array[{ mday: 30, name: ::String, regions: ::Array[:ro] }], 12 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ro] } | { mday: 25, name: ::String, regions: ::Array[:ro] } | { mday: 26, name: ::String, regions: ::Array[:ro] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/rs_cyrl.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module RS_CYRL
+    def self.defined_regions: () -> ::Array[:rs_cyrl]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:rs_cyrl] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:rs_cyrl] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:rs_cyrl] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:rs_cyrl] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:rs_cyrl] } | { mday: 2, name: ::String, regions: ::Array[:rs_cyrl] } | { mday: 7, name: ::String, regions: ::Array[:rs_cyrl] } | { mday: 27, name: ::String, regions: ::Array[:rs_cyrl] }], 2 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:rs_cyrl] } | { mday: 16, name: ::String, regions: ::Array[:rs_cyrl] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:rs_cyrl] } | { mday: 2, name: ::String, regions: ::Array[:rs_cyrl] } | { mday: 9, name: ::String, regions: ::Array[:rs_cyrl] }], 6 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:rs_cyrl] }], 11 => ::Array[{ mday: 11, name: ::String, regions: ::Array[:rs_cyrl] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/rs_la.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module RS_LA
+    def self.defined_regions: () -> ::Array[:rs_la]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Veliki Petak", regions: ::Array[:rs_la] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: "Velika Subota", regions: ::Array[:rs_la] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], name: "Uskrs", regions: ::Array[:rs_la] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Vaskrsni ponedeljak", regions: ::Array[:rs_la] }], 1 => ::Array[{ mday: 1, name: "Nova Godina", regions: ::Array[:rs_la] } | { mday: 2, name: "Nova Godina", regions: ::Array[:rs_la] } | { mday: 7, name: ::String, regions: ::Array[:rs_la] } | { mday: 27, name: "Dan Svetog Save", regions: ::Array[:rs_la] }], 2 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:rs_la] } | { mday: 16, name: ::String, regions: ::Array[:rs_la] }], 5 => ::Array[{ mday: 1, name: "Praznik rada", regions: ::Array[:rs_la] } | { mday: 2, name: "Praznik rada", regions: ::Array[:rs_la] } | { mday: 9, name: "Dan pobede", regions: ::Array[:rs_la] }], 6 => ::Array[{ mday: 28, name: "Vidovdan", regions: ::Array[:rs_la] }], 11 => ::Array[{ mday: 11, name: "Dan primirja", regions: ::Array[:rs_la] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ru.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module RU
+    def self.defined_regions: () -> ::Array[:ru]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ru] } | { mday: 2, name: ::String, regions: ::Array[:ru] } | { mday: 3, name: ::String, regions: ::Array[:ru] } | { mday: 4, name: ::String, regions: ::Array[:ru] } | { mday: 5, name: ::String, regions: ::Array[:ru] } | { mday: 7, name: ::String, regions: ::Array[:ru] }], 2 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:ru] }], 3 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:ru] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ru] } | { mday: 9, name: ::String, regions: ::Array[:ru] }], 6 => ::Array[{ mday: 12, name: ::String, regions: ::Array[:ru] }], 8 => ::Array[{ mday: 22, name: ::String, regions: ::Array[:ru] }], 11 => ::Array[{ mday: 4, name: ::String, regions: ::Array[:ru] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/dk.yaml, definitions/is.yaml, definitions/no.yaml, definitions/se.yaml, definitions/fi.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module SCANDINAVIA
+    def self.defined_regions: () -> ::Array[:dk | :is | :no | :se | :fi]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -49, type: :informal, name: "Fastelavn", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, type: :informal, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Langfredag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 26, name: "Store Bededag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Kristi Himmelfartsdag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pinsedag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "2. Pinsedag", regions: ::Array[:dk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Bolludagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Sprengidagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -46, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Uppstigningardagur", regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: ::String, regions: ::Array[:is] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -49, type: :informal, name: "Fastelavn", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -7, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Langfredag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Kristi Himmelfartsdag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "1. pinsedag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 50, name: "2. pinsedag", regions: ::Array[:no] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, type: :informal, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pingstdagen", regions: ::Array[:se] } | { function: "se_alla_helgons_dag(year)", function_arguments: ::Array[:year], name: "Alla helgons dag", regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: "Helatorstai", regions: ::Array[:fi] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:fi] } | { function: "fi_pyhainpaiva(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:fi] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:dk] } | { mday: 1, name: ::String, regions: ::Array[:is] } | { mday: 6, name: ::String, regions: ::Array[:is] } | { mday: 19, type: :informal, name: ::String, regions: ::Array[:is] } | { mday: 1, name: ::String, regions: ::Array[:no] } | { mday: 1, name: ::String, regions: ::Array[:se] } | { mday: 6, name: "Trettondedag jul", regions: ::Array[:se] } | { mday: 1, name: ::String, regions: ::Array[:fi] } | { mday: 6, name: "Loppiainen", regions: ::Array[:fi] }], 4 => ::Array[{ mday: 1, type: :informal, name: "1. april", regions: ::Array[:dk] } | { mday: 9, type: :informal, name: ::String, regions: ::Array[:dk] } | { mday: 16, type: :informal, name: ::String, regions: ::Array[:dk] } | { function: "is_sumardagurinn_fyrsti(year)", function_arguments: ::Array[:year], name: "Sumardagurinn fyrsti", regions: ::Array[:is] }], 5 => ::Array[{ mday: 1, type: :informal, name: "Arbejdernes kampdag", regions: ::Array[:dk] } | { mday: 5, type: :informal, name: "Danmarks befrielse", regions: ::Array[:dk] } | { mday: 1, name: ::String, regions: ::Array[:is] } | { mday: 13, name: ::String, regions: ::Array[:is] } | { mday: 1, name: "1. mai", regions: ::Array[:no] } | { mday: 17, name: "17. mai", regions: ::Array[:no] } | { mday: 1, name: ::String, regions: ::Array[:se] } | { mday: 1, name: "Vappu", regions: ::Array[:fi] }], 6 => ::Array[{ mday: 5, type: :informal, name: "Grundlovsdag", regions: ::Array[:dk] } | { mday: 15, type: :informal, name: "Valdemarsdag og Genforeningsdag", regions: ::Array[:dk] } | { mday: 23, type: :informal, name: "Sankt Hans aften", regions: ::Array[:dk] } | { mday: 3, type: :informal, name: ::String, regions: ::Array[:is] } | { mday: 17, name: ::String, regions: ::Array[:is] } | { mday: 6, name: "Nationaldagen", regions: ::Array[:se] } | { function: "se_midsommardagen(year)", function_arguments: ::Array[:year], name: "Midsommardagen", regions: ::Array[:se] } | { function: "se_midsommardagen(year)", function_arguments: ::Array[:year], function_modifier: -1, type: :informal, name: "Midsommarafton", regions: ::Array[:se] } | { function: "fi_juhannusaatto(year)", function_arguments: ::Array[:year], name: "Juhannusaatto", regions: ::Array[:fi] } | { function: "fi_juhannuspaiva(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:fi] }], 11 => ::Array[{ mday: 10, type: :informal, name: "Mortensaften", regions: ::Array[:dk] } | { mday: 16, name: ::String, regions: ::Array[:is] }], 12 => ::Array[{ mday: 13, type: :informal, name: "Sankt Lucia", regions: ::Array[:dk] } | { mday: 24, type: :informal, name: "Juleaftensdag", regions: ::Array[:dk] } | { mday: 25, name: "1. juledag", regions: ::Array[:dk] } | { mday: 26, name: "2. juledag", regions: ::Array[:dk] } | { mday: 24, name: ::String, regions: ::Array[:is] } | { mday: 25, name: ::String, regions: ::Array[:is] } | { mday: 26, name: ::String, regions: ::Array[:is] } | { mday: 31, name: ::String, regions: ::Array[:is] } | { mday: 24, type: :informal, name: "Julaften", regions: ::Array[:no] } | { mday: 25, name: "1. juledag", regions: ::Array[:no] } | { mday: 26, name: "2. juledag", regions: ::Array[:no] } | { mday: 31, type: :informal, name: ::String, regions: ::Array[:no] } | { mday: 24, type: :informal, name: "Julafton", regions: ::Array[:se] } | { mday: 25, name: "Juldagen", regions: ::Array[:se] } | { mday: 26, name: "Annandag jul", regions: ::Array[:se] } | { mday: 31, type: :informal, name: ::String, regions: ::Array[:se] } | { mday: 6, name: ::String, regions: ::Array[:fi] } | { mday: 24, name: "Jouluaatto", regions: ::Array[:fi] } | { mday: 25, name: ::String, regions: ::Array[:fi] } | { mday: 26, name: ::String, regions: ::Array[:fi] }], 2 => ::Array[{ mday: 18, type: :informal, name: "Konudagur", regions: ::Array[:is] }], 8 => ::Array[{ wday: 1, week: 1, name: ::String, regions: ::Array[:is] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/se.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module SE
+    def self.defined_regions: () -> ::Array[:se]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, type: :informal, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 39, name: ::String, regions: ::Array[:se] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: "Pingstdagen", regions: ::Array[:se] } | { function: "se_alla_helgons_dag(year)", function_arguments: ::Array[:year], name: "Alla helgons dag", regions: ::Array[:se] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:se] } | { mday: 6, name: "Trettondedag jul", regions: ::Array[:se] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:se] }], 6 => ::Array[{ mday: 6, name: "Nationaldagen", regions: ::Array[:se] } | { function: "se_midsommardagen(year)", function_arguments: ::Array[:year], name: "Midsommardagen", regions: ::Array[:se] } | { function: "se_midsommardagen(year)", function_arguments: ::Array[:year], function_modifier: -1, type: :informal, name: "Midsommarafton", regions: ::Array[:se] }], 12 => ::Array[{ mday: 24, type: :informal, name: "Julafton", regions: ::Array[:se] } | { mday: 25, name: "Juldagen", regions: ::Array[:se] } | { mday: 26, name: "Annandag jul", regions: ::Array[:se] } | { mday: 31, type: :informal, name: ::String, regions: ::Array[:se] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/sg.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module SG
+    def self.defined_regions: () -> ::Array[:sg]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:sg] }], 1 => ::Array[{ mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:sg] }], 2 => ::Array[{ mday: 14, type: :informal, name: "Valentine's Day", regions: ::Array[:sg] } | { mday: 15, type: :informal, name: "Total Defence Day", regions: ::Array[:sg] }], 5 => ::Array[{ mday: 1, name: "Labour Day", regions: ::Array[:sg] }], 8 => ::Array[{ mday: 9, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "National Day", regions: ::Array[:sg] }], 12 => ::Array[{ mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:sg] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/si.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module SI
+    def self.defined_regions: () -> ::Array[:si]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:si] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:si] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 49, name: ::String, regions: ::Array[:si] }], 1 => ::Array[{ mday: 1, name: "novo leto", regions: ::Array[:si] }], 2 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:si] }], 4 => ::Array[{ mday: 27, name: "dan upora proti okupatorju", regions: ::Array[:si] }], 5 => ::Array[{ mday: 1, name: "praznik dela", regions: ::Array[:si] } | { mday: 2, name: "praznik dela", regions: ::Array[:si] }], 6 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:si] }], 8 => ::Array[{ mday: 15, name: "Marijino vnebovzetje", regions: ::Array[:si] }], 10 => ::Array[{ mday: 31, name: "dan reformacije", regions: ::Array[:si] }], 11 => ::Array[{ mday: 1, name: "dan spomina na mrtve", regions: ::Array[:si] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:si] } | { mday: 26, name: "dan samostojnosti in enotnosti", regions: ::Array[:si] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/sk.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module SK
+    def self.defined_regions: () -> ::Array[:sk]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:sk] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: ::String, regions: ::Array[:sk] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 6, name: ::String, regions: ::Array[:sk] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 8, name: ::String, regions: ::Array[:sk] }], 7 => ::Array[{ mday: 5, name: ::String, regions: ::Array[:sk] }], 8 => ::Array[{ mday: 29, name: ::String, regions: ::Array[:sk] }], 9 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 15, name: ::String, regions: ::Array[:sk] }], 11 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:sk] } | { mday: 17, name: ::String, regions: ::Array[:sk] }], 12 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:sk] } | { mday: 25, name: ::String, regions: ::Array[:sk] } | { mday: 26, name: ::String, regions: ::Array[:sk] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ar.yaml, definitions/br.yaml, definitions/cl.yaml, definitions/co.yaml, definitions/pe.yaml, definitions/ve.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module SOUTHAMERICA
+    def self.defined_regions: () -> ::Array[:ar | :br | :cl | :co | :pe | :ve]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:ar] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Carnaval Lunes", regions: ::Array[:ar] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Carnaval Martes", regions: ::Array[:ar] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, type: :informal, name: "Carnaval", regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Sexta-feira Santa", regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 60, name: "Corpus Christi", regions: ::Array[:br] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:cl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -1, name: ::String, regions: ::Array[:cl] } | { function: "st_peter_st_paul_cl(year)", function_arguments: ::Array[:year], year_ranges: { from: 2000 }, name: "San Pedro y San Pablo", regions: ::Array[:cl] } | { function: "other_churches_day_cl(year)", function_arguments: ::Array[:year], year_ranges: { from: 2008 }, name: ::String, regions: ::Array[:cl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 43, name: ::String, regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 64, name: "Corpus Christi", regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 71, name: ::String, regions: ::Array[:co] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:pe] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:pe] } | { function: "easter(year)", function_arguments: ::Array[:year], name: "Pascua", regions: ::Array[:pe] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Lunes Carnaval", regions: ::Array[:ve] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Martes Carnaval", regions: ::Array[:ve] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:ve] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:ve] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ar] } | { mday: 1, name: ::String, regions: ::Array[:br] } | { mday: 1, name: ::String, regions: ::Array[:cl] } | { mday: 1, name: ::String, regions: ::Array[:co] } | { function: "epiphany(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] } | { mday: 1, name: ::String, regions: ::Array[:pe] } | { mday: 6, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:pe] } | { mday: 1, name: ::String, regions: ::Array[:ve] }], 3 => ::Array[{ mday: 24, name: ::String, regions: ::Array[:ar] } | { function: "saint_josephs_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] }], 4 => ::Array[{ mday: 2, name: ::String, regions: ::Array[:ar] } | { mday: 21, name: "Dia de Tiradentes", regions: ::Array[:br] } | { mday: 19, name: ::String, regions: ::Array[:ve] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ar] } | { mday: 25, name: ::String, regions: ::Array[:ar] } | { mday: 24, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:ar] } | { mday: 1, name: "Dia do Trabalho", regions: ::Array[:br] } | { mday: 1, name: ::String, regions: ::Array[:cl] } | { mday: 21, name: ::String, regions: ::Array[:cl] } | { mday: 1, name: ::String, regions: ::Array[:co] } | { mday: 1, name: ::String, regions: ::Array[:pe] } | { wday: 0, week: 2, type: :informal, name: ::String, regions: ::Array[:pe] } | { mday: 1, name: ::String, regions: ::Array[:ve] }], 6 => ::Array[{ mday: 17, function: "to_nearest_monday(date)", function_arguments: ::Array[:date], name: ::String, regions: ::Array[:ar] } | { mday: 20, name: ::String, regions: ::Array[:ar] } | { mday: 29, year_ranges: { until: 1999 }, name: "San Pedro y San Pablo", regions: ::Array[:cl] } | { function: "saint_peter_and_saint_paul(year)", function_arguments: ::Array[:year], name: "San Pedro y San Pablo", regions: ::Array[:co] } | { mday: 7, type: :informal, name: ::String, regions: ::Array[:pe] } | { wday: 0, week: 3, type: :informal, name: ::String, regions: ::Array[:pe] } | { mday: 24, type: :informal, name: "Inti Raymi", regions: ::Array[:pe] } | { mday: 29, name: "San Pablo y San Pedro", regions: ::Array[:pe] } | { mday: 24, name: "Aniversario Batalla de Carabobo", regions: ::Array[:ve] }], 7 => ::Array[{ mday: 8, year_ranges: { limited: ::Array[2016] }, name: ::String, regions: ::Array[:ar] } | { mday: 9, name: ::String, regions: ::Array[:ar] } | { mday: 16, name: ::String, regions: ::Array[:cl] } | { mday: 20, name: ::String, regions: ::Array[:co] } | { mday: 28, name: ::String, regions: ::Array[:pe] } | { mday: 29, name: ::String, regions: ::Array[:pe] } | { mday: 5, name: ::String, regions: ::Array[:ve] } | { mday: 24, name: ::String, regions: ::Array[:ve] }], 8 => ::Array[{ mday: 17, function: "to_nearest_monday(date)", function_arguments: ::Array[:date], name: ::String, regions: ::Array[:ar] } | { mday: 15, name: ::String, regions: ::Array[:cl] } | { mday: 7, name: ::String, regions: ::Array[:co] } | { function: "assumption_of_mary(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] } | { mday: 30, name: "Santa Rosa de Lima", regions: ::Array[:pe] }], 10 => ::Array[{ mday: 12, function: "to_nearest_monday(date)", function_arguments: ::Array[:date], name: ::String, regions: ::Array[:ar] } | { mday: 8, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:ar] } | { mday: 12, name: "Dia de Nossa Senhora Aparecida", regions: ::Array[:br] } | { mday: 12, year_ranges: { until: 1999 }, name: "Encuentro de Dos Mundos", regions: ::Array[:cl] } | { function: "columbus_day_cl(year)", function_arguments: ::Array[:year], year_ranges: { from: 2000 }, name: "Encuentro de Dos Mundos", regions: ::Array[:cl] } | { function: "columbus_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] } | { mday: 8, name: "Batalla de Angamos", regions: ::Array[:pe] } | { mday: 12, name: ::String, regions: ::Array[:ve] }], 11 => ::Array[{ mday: 20, name: ::String, regions: ::Array[:ar] } | { mday: 22, year_ranges: { limited: ::Array[2021] }, name: ::String, regions: ::Array[:ar] } | { mday: 2, name: "Dia de Finados", regions: ::Array[:br] } | { mday: 15, name: ::String, regions: ::Array[:br] } | { mday: 1, name: ::String, regions: ::Array[:cl] } | { function: "all_saints_day(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:co] } | { function: "independence_of_cartagena(year)", function_arguments: ::Array[:year], name: "Independencia de Cartagena", regions: ::Array[:co] } | { mday: 1, name: "Todos los Santos", regions: ::Array[:pe] }], 12 => ::Array[{ mday: 8, name: ::String, regions: ::Array[:ar] } | { mday: 9, year_ranges: { limited: ::Array[2016] }, name: ::String, regions: ::Array[:ar] } | { mday: 25, name: "Navidad", regions: ::Array[:ar] } | { mday: 25, name: "Natal", regions: ::Array[:br] } | { mday: 8, name: ::String, regions: ::Array[:cl] } | { mday: 25, name: "Navidad", regions: ::Array[:cl] } | { mday: 8, name: ::String, regions: ::Array[:co] } | { mday: 25, name: "Navidad", regions: ::Array[:co] } | { mday: 8, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:pe] } | { mday: 25, name: ::String, regions: ::Array[:pe] } | { mday: 25, name: ::String, regions: ::Array[:ve] }], 9 => ::Array[{ mday: 7, name: ::String, regions: ::Array[:br] } | { mday: 18, name: "Independencia Nacional", regions: ::Array[:cl] } | { mday: 19, name: ::String, regions: ::Array[:cl] } | { mday: 24, type: :informal, name: ::String, regions: ::Array[:pe] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/th.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module TH
+    def self.defined_regions: () -> ::Array[:th]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:th] }], 4 => ::Array[{ mday: 6, name: ::String, regions: ::Array[:th] } | { mday: 13, name: ::String, regions: ::Array[:th] } | { mday: 14, name: ::String, regions: ::Array[:th] } | { mday: 15, name: ::String, regions: ::Array[:th] }], 7 => ::Array[{ mday: 28, name: ::String, regions: ::Array[:th] }], 8 => ::Array[{ mday: 12, name: ::String, regions: ::Array[:th] }], 10 => ::Array[{ mday: 13, name: ::String, regions: ::Array[:th] } | { mday: 23, name: ::String, regions: ::Array[:th] }], 12 => ::Array[{ mday: 5, name: ::String, regions: ::Array[:th] } | { mday: 10, name: ::String, regions: ::Array[:th] } | { mday: 31, name: ::String, regions: ::Array[:th] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/tn.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module TN
+    def self.defined_regions: () -> ::Array[:tn]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: "Jour de l'an", regions: ::Array[:tn] } | { mday: 14, name: ::String, regions: ::Array[:tn] }], 3 => ::Array[{ mday: 20, name: ::String, regions: ::Array[:tn] }], 4 => ::Array[{ mday: 9, name: ::String, regions: ::Array[:tn] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:tn] }], 7 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:tn] }], 8 => ::Array[{ mday: 13, name: ::String, regions: ::Array[:tn] }], 10 => ::Array[{ mday: 15, name: ::String, regions: ::Array[:tn] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/tr.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module TR
+    def self.defined_regions: () -> ::Array[:tr]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "ramadan_feast(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:tr] } | { function: "ramadan_feast(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:tr] } | { function: "ramadan_feast(year)", function_arguments: ::Array[:year], function_modifier: 2, name: ::String, regions: ::Array[:tr] } | { function: "sacrifice_feast(year)", function_arguments: ::Array[:year], name: ::String, regions: ::Array[:tr] } | { function: "sacrifice_feast(year)", function_arguments: ::Array[:year], function_modifier: 1, name: ::String, regions: ::Array[:tr] } | { function: "sacrifice_feast(year)", function_arguments: ::Array[:year], function_modifier: 2, name: ::String, regions: ::Array[:tr] } | { function: "sacrifice_feast(year)", function_arguments: ::Array[:year], function_modifier: 3, name: ::String, regions: ::Array[:tr] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:tr] }], 4 => ::Array[{ mday: 23, name: ::String, regions: ::Array[:tr] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:tr] } | { mday: 19, name: ::String, regions: ::Array[:tr] }], 7 => ::Array[{ mday: 15, year_ranges: { from: 2016 }, name: ::String, regions: ::Array[:tr] }], 8 => ::Array[{ mday: 30, name: ::String, regions: ::Array[:tr] }], 10 => ::Array[{ mday: 29, name: ::String, regions: ::Array[:tr] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ua.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module UA
+    def self.defined_regions: () -> ::Array[:ua]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "orthodox_easter(year)", function_arguments: ::Array[:year], observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] } | { function: "orthodox_easter(year)", function_arguments: ::Array[:year], function_modifier: 49, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] } | { mday: 7, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 3 => ::Array[{ mday: 8, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 5 => ::Array[{ mday: 1, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] } | { mday: 2, year_ranges: { until: 2017 }, name: ::String, regions: ::Array[:ua] } | { mday: 9, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 6 => ::Array[{ mday: 28, year_ranges: { from: 1997 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 7 => ::Array[{ mday: 16, year_ranges: { limited: ::Array[1991] }, name: ::String, regions: ::Array[:ua] }], 8 => ::Array[{ mday: 24, year_ranges: { from: 1992 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 10 => ::Array[{ mday: 14, year_ranges: { from: 2015 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }], 12 => ::Array[{ mday: 25, year_ranges: { from: 2017 }, observed: "to_monday_if_weekend(date)", observed_arguments: ::Array[:date], name: ::String, regions: ::Array[:ua] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/unitednations.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module UNITEDNATIONS
+    def self.defined_regions: () -> ::Array[:unitednations]
+
+    def self.holidays_by_month: () -> { 2 => ::Array[{ mday: 2, name: "International Mother Language Day", regions: ::Array[:unitednations] }], 3 => ::Array[{ mday: 8, name: "United Nations Day for Women's Rights and International Peace", regions: ::Array[:unitednations] } | { mday: 21, name: "International Day for the Elimination of Racial Discrimination", regions: ::Array[:unitednations] } | { mday: 21, name: "Beginning of the Week of Solidarity with the Peoples Struggling against Racism and Racial Discrimination", regions: ::Array[:unitednations] } | { mday: 22, name: "World Day for Water", regions: ::Array[:unitednations] } | { mday: 23, name: "World Meteorological Day", regions: ::Array[:unitednations] }], 4 => ::Array[{ mday: 7, name: "World Health Day", regions: ::Array[:unitednations] } | { mday: 23, name: "World Book and Copyright Day", regions: ::Array[:unitednations] }], 5 => ::Array[{ mday: 3, name: "World Press Freedom Day", regions: ::Array[:unitednations] } | { mday: 15, name: "International Day of Families", regions: ::Array[:unitednations] } | { mday: 17, name: "World Telecommunication Day", regions: ::Array[:unitednations] } | { mday: 21, name: "World Day for Cultural Diversity for Dialogue and Development", regions: ::Array[:unitednations] } | { mday: 22, name: "International Day for Biological Diversity", regions: ::Array[:unitednations] } | { mday: 25, name: "Beginning of the Week of Solidarity with the Peoples of Non-Self-Governing Territories", regions: ::Array[:unitednations] } | { mday: 29, name: "International Day of United Nations Peacekeepers", regions: ::Array[:unitednations] } | { mday: 31, name: "World No-Tobacco Day", regions: ::Array[:unitednations] }], 6 => ::Array[{ mday: 4, name: "International Day of Innocent Children Victims of Aggression", regions: ::Array[:unitednations] } | { mday: 5, name: "World Environment Day", regions: ::Array[:unitednations] } | { mday: 17, name: "World Day to Combat Desertification and Drought", regions: ::Array[:unitednations] } | { mday: 20, name: "World Refugee Day", regions: ::Array[:unitednations] } | { mday: 23, name: "United Nations Public Service Day", regions: ::Array[:unitednations] } | { mday: 26, name: "International Day against Drug Abuse and Illicit Trafficking", regions: ::Array[:unitednations] } | { mday: 26, name: "International Day in Support of Victims of Torture", regions: ::Array[:unitednations] }], 7 => ::Array[{ wday: 6, week: 1, name: "International Day of Cooperatives", regions: ::Array[:unitednations] } | { mday: 11, name: "World Population Day", regions: ::Array[:unitednations] }], 8 => ::Array[{ mday: 9, name: "International Day of the World's Indigenous People", regions: ::Array[:unitednations] } | { mday: 12, name: "International Youth Day", regions: ::Array[:unitednations] } | { mday: 23, name: "International Day for the Remembrance of the Slave Trade and Its Abolition", regions: ::Array[:unitednations] }], 9 => ::Array[{ mday: 8, name: "International Literacy Day", regions: ::Array[:unitednations] } | { mday: 16, name: "International Day for the Preservation of the Ozone Layer", regions: ::Array[:unitednations] } | { mday: 21, name: "International Day of Peace", regions: ::Array[:unitednations] } | { mday: 1, name: "International Day of Older Persons", regions: ::Array[:unitednations] }], 10 => ::Array[{ mday: 4, name: "World Space Week", regions: ::Array[:unitednations] } | { mday: 5, name: "World Teachers' Day", regions: ::Array[:unitednations] } | { wday: 1, week: 1, name: "World Habitat Day", regions: ::Array[:unitednations] } | { wday: 3, week: 2, name: "International Day for Natural Disaster Reduction", regions: ::Array[:unitednations] } | { mday: 9, name: "World Post Day", regions: ::Array[:unitednations] } | { mday: 10, name: "World Mental Health Day", regions: ::Array[:unitednations] } | { mday: 16, name: "World Food Day", regions: ::Array[:unitednations] } | { mday: 17, name: "International Day for the Eradication of Poverty", regions: ::Array[:unitednations] } | { mday: 24, name: "United Nations Day", regions: ::Array[:unitednations] } | { mday: 24, name: "World Development Information Day", regions: ::Array[:unitednations] } | { mday: 24, name: "Disarmament Week", regions: ::Array[:unitednations] }], 11 => ::Array[{ mday: 6, name: "International Day for Preventing the Exploitation of the Environment in War and Armed Conflict", regions: ::Array[:unitednations] } | { mday: 16, name: "International Day for Tolerance", regions: ::Array[:unitednations] } | { mday: 20, name: "Africa Industrialization Day", regions: ::Array[:unitednations] } | { mday: 20, name: "Universal Children's Day", regions: ::Array[:unitednations] } | { mday: 21, name: "World Television Day", regions: ::Array[:unitednations] } | { mday: 25, name: "International Day for the Elimination of Violence against Women", regions: ::Array[:unitednations] } | { mday: 29, name: "International Day of Solidarity with the Palestinian People", regions: ::Array[:unitednations] }], 12 => ::Array[{ mday: 1, name: "World AIDS Day", regions: ::Array[:unitednations] } | { mday: 2, name: "International Day for the Abolition of Slavery", regions: ::Array[:unitednations] } | { mday: 3, name: "International Day of Disabled Persons", regions: ::Array[:unitednations] } | { mday: 5, name: "International Volunteer Day for Economic and Social Development", regions: ::Array[:unitednations] } | { mday: 7, name: "International Civil Aviation Day", regions: ::Array[:unitednations] } | { mday: 10, name: "Human Rights Day", regions: ::Array[:unitednations] } | { mday: 18, name: "International Migrants Day", regions: ::Array[:unitednations] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ups.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module UPS
+    def self.defined_regions: () -> ::Array[:ups]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:ups] }], 5 => ::Array[{ wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:ups] }], 7 => ::Array[{ mday: 4, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Independence Day", regions: ::Array[:ups] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:ups] }], 11 => ::Array[{ wday: 4, week: 4, name: "Thanksgiving", regions: ::Array[:ups] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Day After Thanksgiving", regions: ::Array[:ups] }], 12 => ::Array[{ mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:ups] } | { mday: 31, name: "New Year's Eve", regions: ::Array[:ups] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/us.yaml, definitions/northamericainformal.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module US
+    def self.defined_regions: () -> ::Array[:us_fl | :us_la | :us | :us_ct | :us_de | :us_gu | :us_hi | :us_in | :us_ky | :us_nj | :us_nc | :us_nd | :us_pr | :us_tn | :us_ms | :us_id | :us_ar | :us_tx | :us_dc | :us_md | :us_va | :us_vt | :us_ak | :us_ca | :us_me | :us_ma | :us_al | :us_ga | :us_ne | :us_mo | :us_sc | :us_wv | :us_vi | :us_ut | :us_ri | :us_az | :us_co | :us_il | :us_mt | :us_nm | :us_ny | :us_oh | :us_pa | :us_mi | :us_mn | :us_nv | :us_or | :us_sd | :us_wa | :us_wi | :us_wy | :us_ia | :us_ks | :us_nh | :us_ok | :ca]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Shrove Tuesday", regions: ::Array[:us_fl] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Mardi Gras Day", regions: ::Array[:us_la] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, type: :informal, name: "Good Friday", regions: ::Array[:us] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:us_ct | :us_de | :us_gu | :us_hi | :us_in | :us_ky | :us_la | :us_nj | :us_nc | :us_nd | :us_pr | :us_tn] } | { function: "easter(year)", function_arguments: ::Array[:year], type: :informal, name: "Easter Sunday", regions: ::Array[:us] }], 1 => ::Array[{ mday: 1, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:us] } | { wday: 1, week: 3, name: "Martin Luther King's and Robert E. Lee's Birthdays", regions: ::Array[:us_ms] } | { wday: 1, week: 3, name: "Idaho Human Rights Day", regions: ::Array[:us_id] } | { wday: 1, week: 3, name: "Civil Rights Day", regions: ::Array[:us_ar] } | { wday: 1, week: 3, name: "Martin Luther King, Jr. Day", regions: ::Array[:us] } | { function: "us_inauguration_day(year)", function_arguments: ::Array[:year], name: "Inauguration Day", regions: ::Array[:us_tx | :us_dc | :us_la | :us_md | :us_va] } | { function: "lee_jackson_day(year, month)", function_arguments: ::Array[:year | :month], name: "Lee-Jackson Day", regions: ::Array[:us_va] } | { mday: 19, name: "Confederate Heroes Day", regions: ::Array[:us_tx] }], 2 => ::Array[{ wday: 1, week: 3, name: "Presidents' Day", regions: ::Array[:us] } | { mday: 2, type: :informal, name: "Groundhog Day", regions: ::Array[:us | :ca] } | { mday: 14, type: :informal, name: "Valentine's Day", regions: ::Array[:us | :ca] }], 3 => ::Array[{ wday: 2, week: 1, name: "Town Meeting Day", regions: ::Array[:us_vt] } | { mday: 2, name: "Texas Independence Day", regions: ::Array[:us_tx] } | { mday: 26, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Prince Jonah Kuhio Kalanianaole Day", regions: ::Array[:us_hi] } | { wday: 1, week: -1, name: "Seward's Day", regions: ::Array[:us_ak] } | { mday: 31, name: ::String, regions: ::Array[:us_ca] } | { mday: 17, type: :informal, name: "St. Patrick's Day", regions: ::Array[:us | :ca] }], 4 => ::Array[{ mday: 16, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Emancipation Day", regions: ::Array[:us_dc] } | { wday: 1, week: 3, name: "Patriots' Day", regions: ::Array[:us_me | :us_ma] } | { mday: 21, name: "San Jacinto Day", regions: ::Array[:us_tx] } | { wday: 1, week: -1, name: "Confederate Memorial Day", regions: ::Array[:us_al | :us_ms] } | { mday: 26, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Confederate Memorial Day", regions: ::Array[:us_fl] } | { function: "georgia_state_holiday(year, month)", function_arguments: ::Array[:year | :month], name: "State Holiday", regions: ::Array[:us_ga] } | { mday: 28, name: "Arbor Day", regions: ::Array[:us_ne] } | { mday: 1, type: :informal, name: "April Fool's Day", regions: ::Array[:us | :ca] } | { mday: 22, type: :informal, name: "Earth Day", regions: ::Array[:us | :ca] }], 5 => ::Array[{ mday: 8, name: "Truman Day", regions: ::Array[:us_mo] } | { mday: 10, name: "Confederate Memorial Day", regions: ::Array[:us_sc] } | { wday: 1, week: -1, name: "Memorial Day", regions: ::Array[:us] } | { wday: 0, week: 2, type: :informal, name: "Mother's Day", regions: ::Array[:us | :ca] } | { wday: 6, week: 3, type: :informal, name: "Armed Forces Day", regions: ::Array[:us] }], 6 => ::Array[{ wday: 1, week: 1, name: "Jefferson Davis' Birthday", regions: ::Array[:us_al] } | { mday: 3, name: "Birthday of Jefferson Davis", regions: ::Array[:us_fl] } | { mday: 11, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "King Kamehameha I Day", regions: ::Array[:us_hi] } | { mday: 19, year_ranges: { from: 2021 }, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Juneteenth National Independence Day", regions: ::Array[:us] } | { mday: 19, name: "Emancipation Day in Texas", regions: ::Array[:us_tx] } | { mday: 20, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "West Virginia Day", regions: ::Array[:us_wv] } | { wday: 0, week: 3, type: :informal, name: "Father's Day", regions: ::Array[:us | :ca] }], 7 => ::Array[{ mday: 3, name: "Emancipation Day", regions: ::Array[:us_vi] } | { mday: 4, name: "Independence Day", regions: ::Array[:us] } | { mday: 4, function: "to_weekday_if_weekend(date)", function_arguments: ::Array[:date], name: "Independence Day (Holiday)", regions: ::Array[:us_va] } | { mday: 24, name: "Pioneer Day", regions: ::Array[:us_ut] }], 8 => ::Array[{ wday: 1, week: 2, name: "Victory Day", regions: ::Array[:us_ri] } | { mday: 16, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Bennington Battle Day", regions: ::Array[:us_vt] } | { wday: 5, week: 3, name: "Statehood Day", regions: ::Array[:us_hi] } | { mday: 27, name: "Lyndon Baines Johnson Day", regions: ::Array[:us_tx] }], 9 => ::Array[{ wday: 1, week: 1, name: "Labor Day", regions: ::Array[:us] } | { function: "rosh_hashanah(year)", function_arguments: ::Array[:year], name: "Rosh Hashanah", regions: ::Array[:us_tx] } | { function: "yom_kippur(year)", function_arguments: ::Array[:year], name: "Yom Kippur", regions: ::Array[:us_tx] }], 10 => ::Array[{ wday: 1, week: 2, name: "Columbus Day", regions: ::Array[:us_al | :us_az | :us_co | :us_ct | :us_dc | :us_ga | :us_id | :us_il | :us_in | :us_ma | :us_md | :us_me | :us_mo | :us_mt | :us_ne | :us_nj | :us_nm | :us_ny | :us_oh | :us_pa | :us_ri | :us_ut | :us_va | :us_wv] } | { wday: 1, week: 2, type: :informal, name: "Columbus Day", regions: ::Array[:us_ak | :us_ar | :us_ca | :us_de | :us_fl | :us_hi | :us_mi | :us_mn | :us_nd | :us_nv | :us_or | :us_sd | :us_tx | :us_vt | :us_wa | :us_wi | :us_wy] } | { mday: 18, name: "Alaska Day", regions: ::Array[:us_ak] } | { wday: 5, week: -1, name: "Nevada Day", regions: ::Array[:us_nv] } | { mday: 31, type: :informal, name: "Halloween", regions: ::Array[:us | :ca] }], 11 => ::Array[{ function: "election_day(year)", function_arguments: ::Array[:year], name: "Election Day", regions: ::Array[:us_de | :us_hi | :us_in | :us_mt | :us_nj | :us_ny | :us_pa | :us_ri] } | { mday: 11, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Veterans Day", regions: ::Array[:us] } | { wday: 4, week: 4, name: "Thanksgiving", regions: ::Array[:us] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Family Day", regions: ::Array[:us_nv] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "State Holiday", regions: ::Array[:us_ga] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Presidents' Day", regions: ::Array[:us_nm] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Lincoln's Birthday", regions: ::Array[:us_in] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "American Indian Heritage Day", regions: ::Array[:us_md] } | { function: "day_after_thanksgiving(year)", function_arguments: ::Array[:year], name: "Day after Thanksgiving (Black Friday)", regions: ::Array[:us_ca | :us_de | :us_fl | :us_ia | :us_il | :us_ks | :us_ky | :us_me | :us_mi | :us_mn | :us_ms | :us_ne | :us_nh | :us_nc | :us_pa | :us_sc | :us_ok | :us_tn | :us_tx | :us_va | :us_wa | :us_wv] }], 12 => ::Array[{ mday: 24, name: "Christmas Eve", regions: ::Array[:us_ar | :us_mi | :us_nc | :us_sc | :us_tx | :us_wi] } | { mday: 24, function: "christmas_eve_holiday(date)", function_arguments: ::Array[:date], name: "Christmas Eve (Holiday)", regions: ::Array[:us_mi | :us_sc | :us_va] } | { mday: 25, observed: "to_weekday_if_weekend(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:us] } | { mday: 26, name: "Day after Christmas", regions: ::Array[:us_ar | :us_nc | :us_ok | :us_sc | :us_tn | :us_tx] } | { mday: 31, name: "New Year's Eve", regions: ::Array[:us_mi | :us_wi] }] }
+
+    def self.custom_methods: () -> ::Hash[::String, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/ve.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module VE
+    def self.defined_regions: () -> ::Array[:ve]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -48, name: "Lunes Carnaval", regions: ::Array[:ve] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -47, name: "Martes Carnaval", regions: ::Array[:ve] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -3, name: "Jueves Santo", regions: ::Array[:ve] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Viernes Santo", regions: ::Array[:ve] }], 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ve] }], 4 => ::Array[{ mday: 19, name: ::String, regions: ::Array[:ve] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:ve] }], 6 => ::Array[{ mday: 24, name: "Aniversario Batalla de Carabobo", regions: ::Array[:ve] }], 7 => ::Array[{ mday: 5, name: ::String, regions: ::Array[:ve] } | { mday: 24, name: ::String, regions: ::Array[:ve] }], 10 => ::Array[{ mday: 12, name: ::String, regions: ::Array[:ve] }], 12 => ::Array[{ mday: 25, name: ::String, regions: ::Array[:ve] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/vi.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module VI
+    def self.defined_regions: () -> ::Array[:vi]
+
+    def self.holidays_by_month: () -> { 1 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:vi] }], 3 => ::Array[{ mday: 10, function: "lunar_to_solar(year, month, day, region)", function_arguments: ::Array[:year | :month | :day | :region], name: ::String, regions: ::Array[:vi] }], 4 => ::Array[{ mday: 30, name: ::String, regions: ::Array[:vi] }], 5 => ::Array[{ mday: 1, name: ::String, regions: ::Array[:vi] }], 9 => ::Array[{ mday: 2, name: ::String, regions: ::Array[:vi] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+# encoding: utf-8
+module Holidays
+  # This file is generated by the Ruby Holidays gem.
+  #
+  # Definitions loaded: definitions/za.yaml
+  #
+  # All the definitions are available at https://github.com/holidays/holidays
+  module ZA
+    def self.defined_regions: () -> ::Array[:za]
+
+    def self.holidays_by_month: () -> { 0 => ::Array[{ function: "easter(year)", function_arguments: ::Array[:year], function_modifier: -2, name: "Good Friday", regions: ::Array[:za] } | { function: "easter(year)", function_arguments: ::Array[:year], function_modifier: 1, name: "Family Day", regions: ::Array[:za] }], 1 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "New Year's Day", regions: ::Array[:za] }], 3 => ::Array[{ mday: 21, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Human Rights Day", regions: ::Array[:za] }], 4 => ::Array[{ mday: 27, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Freedom Day", regions: ::Array[:za] }], 5 => ::Array[{ mday: 1, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Workers Day", regions: ::Array[:za] }], 6 => ::Array[{ mday: 16, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Youth Day", regions: ::Array[:za] }], 8 => ::Array[{ mday: 9, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "National Women's Day", regions: ::Array[:za] }], 9 => ::Array[{ mday: 24, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Heritage Day", regions: ::Array[:za] }], 12 => ::Array[{ mday: 16, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Day of Reconciliation", regions: ::Array[:za] } | { mday: 25, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Christmas Day", regions: ::Array[:za] } | { mday: 26, observed: "to_monday_if_sunday(date)", observed_arguments: ::Array[:date], name: "Day of Goodwill", regions: ::Array[:za] }] }
+
+    def self.custom_methods: () -> ::Hash[untyped, untyped]
+  end
+end
+
+module Holidays
+  WEEKS: { first: 1, second: 2, third: 3, fourth: 4, fifth: 5, last: -1, second_last: -2, third_last: -3 }
+
+  MONTH_LENGTHS: ::Array[31 | 28 | 30]
+
+  DAY_SYMBOLS: untyped
+
+  DEFINITIONS_PATH: "generated_definitions"
+
+  FULL_DEFINITIONS_PATH: untyped
+
+  def self.any_holidays_during_work_week?: (untyped date, *untyped options) -> untyped
+
+  def self.on: (untyped date, *untyped options) -> untyped
+
+  def self.between: (untyped start_date, untyped end_date, *untyped options) -> untyped
+
+  # IXME All other methods start with a date and require a date. For the next
+  #      major version bump we should take the opportunity to change this
+  #      signature to match, e.g. next_holidays(from_date, count, options)
+  def self.next_holidays: (untyped holidays_count, untyped options, ?untyped from_date) -> untyped
+
+  # IXME All other methods start with a date and require a date. For the next
+  #      major version bump we should take the opportunity to change this
+  #      signature to match, e.g. year_holidays(from_date, options)
+  def self.year_holidays: (untyped options, ?untyped from_date) -> untyped
+
+  def self.cache_between: (untyped start_date, untyped end_date, *untyped options) -> untyped
+
+  def self.available_regions: () -> untyped
+
+  def self.load_custom: (*untyped files) -> untyped
+
+  def self.load_all: () -> untyped
+
+  private
+
+  def self.get_date: (untyped date) -> untyped
+end
+
+module Holidays
+  module CoreExtensions
+    module Date
+      def self.included: (untyped base) -> untyped
+
+      # Get holidays on the current date.
+      #
+      # Returns an array of hashes or nil. See Holidays#between for options
+      # and the output format.
+      #
+      #   Date.civil('2008-01-01').holidays(:ca_)
+      #   => [{:name => 'New Year\'s Day',...}]
+      #
+      # Also available via Holidays#on.
+      def holidays: (*untyped options) -> untyped
+
+      # Check if the current date is a holiday.
+      #
+      # Returns true or false.
+      #
+      #   Date.civil('2008-01-01').holiday?(:ca)
+      #   => true
+      def holiday?: (*untyped options) -> untyped
+
+      # Returns a new Date where one or more of the elements have been changed according to the +options+ parameter.
+      # The +options+ parameter is a hash with a combination of these keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>.
+      #
+      #   Date.new(2007, 5, 12).change(day: 1)               # => Date.new(2007, 5, 1)
+      #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
+      def change: (untyped options) -> untyped
+
+      def end_of_month: () -> untyped
+
+      module ClassMethods
+        def calculate_mday: (untyped year, untyped month, untyped week, untyped wday) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module CoreExtensions
+    module Time
+      def self.included: (untyped base) -> untyped
+
+      module ClassMethods
+        COMMON_YEAR_DAYS_IN_MONTH: ::Array[nil | 31 | 28 | 30]
+
+        # Returns the number of days in the given month.
+        # If no year is specified, it will use the current year.
+        def days_in_month: (untyped month, ?untyped year) -> (29 | untyped)
+      end
+    end
+  end
+end
+
+module Holidays
+  module DateCalculator
+    # Calculate day of the month based on the week number and the day of the
+    # week.
+    #
+    # ==== Parameters
+    # [<tt>year</tt>]  Integer.
+    # [<tt>month</tt>] Integer from 1-12.
+    # [<tt>week</tt>]  One of <tt>:first</tt>, <tt>:second</tt>, <tt>:third</tt>,
+    #                  <tt>:fourth</tt>, <tt>:fifth</tt> or <tt>:last</tt>.
+    # [<tt>wday</tt>]  Day of the week as an integer from 0 (Sunday) to 6
+    #                  (Saturday) or as a symbol (e.g. <tt>:monday</tt>).
+    #
+    # Returns an integer.
+    #
+    # ===== Examples
+    # First Monday of January, 2008:
+    #   Holidays::Factory::DateCalculator.day_of_month_calculator.call(2008, 1, :first, :monday)
+    #   => 7
+    #
+    # Third Thursday of December, 2008:
+    #   Holidays::Factory::DateCalculator.day_of_month_calculator.call(2008, 12, :third, :thursday)
+    #   => 18
+    #
+    # Last Monday of January, 2008:
+    #   Holidays::Factory::DateCalculator.day_of_month_calculator.call(2008, 1, :last, 1)
+    #   => 28
+    # -
+    # see http://www.irt.org/articles/js050/index.htm
+    class DayOfMonth
+      def call: (untyped year, untyped month, untyped week, untyped wday) -> untyped
+
+      private
+
+      def weeks: () -> untyped
+
+      def day_symbols: () -> untyped
+
+      def month_lengths: () -> untyped
+    end
+  end
+end
+
+module Holidays
+  module DateCalculator
+    module Easter
+      class Gregorian
+        def calculate_easter_for: (untyped year) -> untyped
+
+        def calculate_orthodox_easter_for: (untyped year) -> untyped
+      end
+
+      class Julian
+        # Copied from https://github.com/Loyolny/when_easter
+        # Graciously allowed by Michał Nierebiński (https://github.com/Loyolny)
+        def calculate_easter_for: (untyped year) -> untyped
+
+        def calculate_orthodox_easter_for: (untyped year) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module DateCalculator
+    # Copied from https://github.com/sunsidew/ruby_lunardate
+    # Graciously allowed by JeeWoong Yang (https://github.com/sunsidew)
+    class LunarDate
+      attr_accessor year: untyped
+
+      attr_accessor month: untyped
+
+      attr_accessor day: untyped
+
+      def to_solar: (untyped year, untyped month, untyped day, untyped region) -> untyped
+
+      def lunardays_for_type: (untyped month_type) -> untyped
+
+      def to_s: () -> untyped
+
+      private
+
+      VIETNAMESE_LUNAR_YEAR_INFO: ::Array[::Array[384 | 1 | 2 | 4] | ::Array[354 | 1 | 2] | ::Array[355 | 2 | 1] | ::Array[383 | 1 | 2 | 3] | ::Array[354 | 2 | 1] | ::Array[384 | 1 | 2 | 5] | ::Array[384 | 1 | 4 | 2] | ::Array[384 | 2 | 1 | 4] | ::Array[384 | 2 | 3 | 1] | ::Array[384 | 2 | 1 | 3] | ::Array[385 | 2 | 1 | 4] | ::Array[383 | 1 | 2 | 4] | ::Array[384 | 1 | 2 | 6] | ::Array[355 | 1 | 2] | ::Array[384 | 2 | 1 | 5] | ::Array[384 | 2 | 4 | 1] | ::Array[384 | 2 | 1 | 6]]
+
+      KOREAN_LUNAR_YEAR_INFO: ::Array[::Array[384 | 1 | 2 | 4] | ::Array[354 | 1 | 2] | ::Array[355 | 2 | 1] | ::Array[383 | 1 | 2 | 3] | ::Array[354 | 2 | 1] | ::Array[384 | 1 | 2 | 5] | ::Array[384 | 1 | 4 | 2] | ::Array[384 | 2 | 1 | 4] | ::Array[384 | 2 | 3 | 1] | ::Array[384 | 2 | 1 | 3] | ::Array[385 | 2 | 1 | 4] | ::Array[383 | 1 | 2 | 4] | ::Array[384 | 1 | 2 | 6] | ::Array[355 | 1 | 2] | ::Array[384 | 2 | 1 | 5] | ::Array[384 | 2 | 4 | 1] | ::Array[384 | 2 | 1 | 6] | ::Array[384 | 1 | 2 | 3]]
+
+      MAX_YEAR_NUMBER: 150
+
+      # Given the region, CALENDAR_YEAR_INFO_MAP looks up the date 
+      # table and uses it in the calculation
+      CALENDAR_YEAR_INFO_MAP: { kr: untyped, vi: untyped }
+
+      # Provides number of days per lunar month type.  Lunar months 
+      # can be either 29 or 30 days long (29.5 days, rounded up or down). 
+      # Keys 3 - 6 provide data for intercalary (leap month) occurrences. 
+      # Format: [TOTAL, NORMAL, LEAP]
+      LUNARDAYS_FOR_MONTHTYPE: { 1 => ::Array[29 | 0], 2 => ::Array[30 | 0], 3 => ::Array[58 | 29], 4 => ::Array[59 | 30 | 29], 5 => ::Array[59 | 29 | 30], 6 => ::Array[60 | 30] }
+
+      # Provides the reference point for the Gregorian calendar and is
+      # used in all calculations
+      SOLAR_START_DATE: untyped
+    end
+  end
+end
+
+module Holidays
+  module DateCalculator
+    class WeekendModifier
+      # Move date to Monday if it occurs on a Saturday on Sunday.
+      # Does not modify date if it is not a weekend.
+      # Used as a callback function.
+      def to_monday_if_weekend: (untyped date) -> untyped
+
+      # Move date to Monday if it occurs on a Sunday.
+      # Does not modify the date if it is not a Sunday.
+      # Used as a callback function.
+      def to_monday_if_sunday: (untyped date) -> untyped
+
+      # Move Boxing Day if it falls on a weekend, leaving room for Christmas.
+      # Used as a callback function.
+      def to_weekday_if_boxing_weekend: (untyped date) -> untyped
+
+      # if Christmas falls on a Saturday, move it to the next Monday (Boxing Day will be Sunday and potentially Tuesday)
+      # if Christmas falls on a Sunday, move it to the next Tuesday (Boxing Day will go on Monday)
+      #
+      # if Boxing Day falls on a Saturday, move it to the next Monday (Christmas will go on Friday)
+      # if Boxing Day falls on a Sunday, move it to the next Tuesday (Christmas will go on Saturday & Monday)
+      def to_tuesday_if_sunday_or_monday_if_saturday: (untyped date) -> untyped
+
+      # Call to_weekday_if_boxing_weekend but first get date based on year
+      # Used as a callback function.
+      def to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday: (untyped year) -> untyped
+
+      # Call to_weekday_if_boxing_weekend but first get date based on year
+      # Used as a callback function.
+      def to_weekday_if_boxing_weekend_from_year: (untyped year) -> untyped
+
+      # Move date to Monday if it occurs on a Sunday or to Friday if it occurs on a
+      # Saturday.
+      # Used as a callback function.
+      def to_weekday_if_weekend: (untyped date) -> untyped
+
+      # Finds the next weekday. For example, if a 'Friday' date is received
+      # it will return the following Monday. If Sunday then return Monday,
+      # if Saturday return Monday, if Tuesday return Wednesday, etc.
+      def to_next_weekday: (untyped date) -> untyped
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Context
+      class FunctionProcessor
+        def initialize: (untyped custom_methods_repo, untyped proc_result_cache_repo) -> void
+
+        def call: (untyped input, untyped func_id, untyped desired_func_args, ?untyped? func_modifier) -> untyped
+
+        private
+
+        VALID_ARGUMENTS: ::Array[:year | :month | :day | :date | :region]
+
+        def validate!: (untyped input, untyped func_id, untyped desired_func_args) -> untyped
+
+        def parse_arguments: (untyped input, untyped target_args) -> untyped
+
+        def calculate: (untyped input, untyped id, untyped args, untyped modifier) -> untyped
+      end
+    end
+  end
+end
+
+# IXME This whole file is my next refactor target. We do wayyyyy too much by
+#      convention here. We need hard and fast rules and explicit errors when you
+#      try to parse something that isn't allowed. So if you are a dev recognize
+#      that a lot of the guard statements in here are to codify existing legacy
+#      logic. The fact is that we already require these guards, we just don't
+#      enforce it explicitly. Now we will. And by doing so things will begin
+#      to look very, very messy.
+module Holidays
+  module Definition
+    module Context
+      class Generator
+        def initialize: (untyped custom_method_parser, untyped custom_method_source_decorator, untyped custom_methods_repository, untyped test_parser, untyped test_source_generator, untyped module_source_generator) -> void
+
+        def parse_definition_files: (untyped files) -> ::Array[untyped]
+
+        def generate_definition_source: (untyped module_name, untyped files, untyped regions, untyped rules_by_month, untyped custom_methods, untyped tests) -> untyped
+
+        private
+
+        # IXME This should be a 'month_definitions_parser' like the above parser
+        def parse_month_definitions: (untyped month_definitions, untyped parsed_custom_methods) -> ::Array[untyped]
+
+        # IXME This should really be split out and tested with its own unit tests.
+        def generate_month_definition_strings: (untyped rules_by_month, untyped parsed_custom_methods) -> untyped
+
+        # This method sucks. The issue here is that the custom methods repo has the 'general' methods (like easter)
+        # but the 'parsed_custom_methods' have the recently parsed stuff. We don't load those until they are needed later.
+        # This entire file is a refactor target so I am adding some tech debt to get me over the hump.
+        # What we should do is ensure that all custom methods are loaded into the repo as soon as they are parsed
+        # so we only have one place to look.
+        def get_function_arguments: (untyped function_id, untyped parsed_custom_methods) -> (untyped | untyped | nil)
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Context
+      class Load
+        def initialize: (untyped definition_merger, untyped full_definitions_path) -> void
+
+        def call: (untyped region) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Context
+      # Merge a new set of definitions into the Holidays module.
+      class Merger
+        def initialize: (untyped holidays_by_month_repo, untyped regions_repo, untyped custom_methods_repo) -> void
+
+        def call: (untyped target_regions, untyped target_holidays, untyped target_custom_methods) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Decorator
+      class CustomMethodProc
+        def call: (untyped proc) -> untyped
+
+        private
+
+        def validate!: (untyped proc) -> untyped
+
+        def parse_arguments: (untyped args) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Decorator
+      class CustomMethodSource
+        def call: (untyped proc) -> ::String
+
+        private
+
+        def validate!: (untyped proc) -> untyped
+
+        def args_string: (untyped args) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Decorator
+      class Test
+        def call: (untyped t) -> untyped
+
+        private
+
+        def decorate_options: (untyped options) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Entity
+      CustomMethod: untyped
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Entity
+      Test: untyped
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Generator
+      class Module
+        def call: (untyped module_name, untyped files, untyped regions, untyped month_strings, untyped custom_methods) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Generator
+      class Regions
+        # The "ca", "mx", and "us" holiday definitions include the "northamericainformal"
+        # holiday definitions, but that does not make these countries subregions of one another.
+        NORTH_AMERICA_REGIONS: ::Array[:ca | :mx | :us]
+
+        def call: (untyped regions) -> ::String
+
+        private
+
+        def validate!: (untyped regions) -> untyped
+
+        def to_array: (untyped regions) -> untyped
+
+        def generate_parent_lookup: (untyped regions) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Generator
+      class Test
+        def initialize: (untyped decorator) -> void
+
+        def call: (untyped module_name, untyped file_names, untyped tests) -> untyped
+
+        private
+
+        def validate!: (untyped module_name, untyped file_names, untyped tests) -> untyped
+
+        def decorate: (untyped tests) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Parser
+      class CustomMethod
+        def initialize: (untyped validator) -> void
+
+        def call: (untyped methods) -> (::Hash[untyped, untyped] | untyped)
+
+        private
+
+        def validate!: (untyped methods) -> (untyped | nil)
+
+        def parse_arguments!: (untyped arguments) -> untyped
+
+        def method_key: (untyped name, untyped args) -> ::String
+
+        def args_string: (untyped args) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Parser
+      class Test
+        def initialize: (untyped validator) -> void
+
+        def call: (untyped tests) -> (::Array[untyped] | untyped)
+
+        private
+
+        def validate!: (untyped tests) -> (untyped | nil)
+
+        def parse_dates: (untyped dates) -> untyped
+
+        def parse_regions: (untyped regions) -> untyped
+
+        def parse_options: (untyped options) -> (untyped | ::Array[untyped] | nil)
+
+        # If flag is not present then default to 'true'
+        def is_holiday?: (untyped flag) -> (true | untyped)
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Repository
+      class Cache
+        def initialize: () -> void
+
+        def cache_between: (untyped start_date, untyped end_date, untyped cache_data, untyped options) -> untyped
+
+        def find: (untyped start_date, untyped end_date, untyped options) -> (nil | untyped)
+
+        def reset!: () -> untyped
+
+        private
+
+        def in_cache_range?: (untyped start_date, untyped end_date, untyped options) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Repository
+      class CustomMethods
+        def initialize: () -> void
+
+        # This performs a merge that overwrites any conflicts.
+        # While this is not ideal I'm leaving it as-is since I have no
+        # evidence of any current definitions that will cause an issue.
+        #
+        # FIXME: this should probably return an error if a method with the
+        # same ID already exists.
+        def add: (untyped new_custom_methods) -> untyped
+
+        def find: (untyped method_id) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Repository
+      class HolidaysByMonth
+        def initialize: () -> void
+
+        def all: () -> untyped
+
+        def find_by_month: (untyped month) -> untyped
+
+        def add: (untyped new_holidays) -> untyped
+
+        private
+
+        def definition_exists?: (untyped existing_def, untyped target_def) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Repository
+      # ==== Benchmarks
+      #
+      # Lookup Easter Sunday, with caching, by number of iterations:
+      #
+      #       user     system      total        real
+      # 0001  0.000000   0.000000   0.000000 (  0.000000)
+      # 0010  0.000000   0.000000   0.000000 (  0.000000)
+      # 0100  0.078000   0.000000   0.078000 (  0.078000)
+      # 1000  0.641000   0.000000   0.641000 (  0.641000)
+      # 5000  3.172000   0.015000   3.187000 (  3.219000)
+      #
+      # Lookup Easter Sunday, without caching, by number of iterations:
+      #
+      #       user     system      total        real
+      # 0001  0.000000   0.000000   0.000000 (  0.000000)
+      # 0010  0.016000   0.000000   0.016000 (  0.016000)
+      # 0100  0.125000   0.000000   0.125000 (  0.125000)
+      # 1000  1.234000   0.000000   1.234000 (  1.234000)
+      # 5000  6.094000   0.031000   6.125000 (  6.141000)
+      class ProcResultCache
+        def initialize: () -> void
+
+        def lookup: (untyped function, *untyped function_arguments) -> untyped
+
+        private
+
+        def validate!: (untyped function, untyped function_arguments) -> untyped
+
+        def build_proc_key: (untyped function, untyped function_arguments) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Repository
+      class Regions
+        def initialize: (untyped all_generated_regions, untyped parent_region_lookup) -> void
+
+        def all_generated: () -> untyped
+
+        def parent_region_lookup: (untyped r) -> untyped
+
+        def all_loaded: () -> untyped
+
+        def loaded?: (untyped region) -> untyped
+
+        def add: (untyped regions) -> untyped
+
+        def search: (untyped prefix) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Validator
+      class CustomMethod
+        VALID_ARGUMENTS: ::Array["date" | "year" | "month" | "day" | "region"]
+
+        def valid?: (untyped m) -> untyped
+
+        private
+
+        def valid_name?: (untyped name) -> untyped
+
+        def valid_arguments?: (untyped arguments) -> untyped
+
+        def valid_source?: (untyped source) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Validator
+      class Region
+        def initialize: (untyped regions_repo) -> void
+
+        def valid?: (untyped r) -> (false | untyped)
+
+        private
+
+        # Ex: :gb_ transformed to :gb
+        def find_wildcard_base: (untyped region) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Definition
+    module Validator
+      class Test
+        def valid?: (untyped t) -> untyped
+
+        private
+
+        def valid_dates?: (untyped dates) -> (false | untyped)
+
+        def valid_regions?: (untyped regions) -> (false | untyped)
+
+        # Can be missing
+        def valid_name?: (untyped n) -> (true | untyped)
+
+        # Can be missing
+        def valid_holiday?: (untyped h) -> (true | untyped)
+
+        # Okay to be missing and can be either string or array of strings
+        def valid_options?: (untyped options) -> (true | untyped)
+
+        def required_fields?: (untyped t) -> (false | true)
+      end
+    end
+  end
+end
+
+module Holidays
+  class Error < StandardError
+  end
+
+  class FunctionNotFound < Error
+  end
+
+  class InvalidFunctionResponse < Error
+  end
+
+  class UnknownRegionError < Error
+  end
+
+  class InvalidRegion < Error
+  end
+
+  class DefinitionTestError < Error
+  end
+end
+
+module Holidays
+  module Factory
+    module DateCalculator
+      module Easter
+        module Gregorian
+          def self.easter_calculator: () -> untyped
+        end
+
+        module Julian
+          def self.easter_calculator: () -> untyped
+        end
+      end
+
+      def self.lunar_date: () -> untyped
+
+      def self.weekend_modifier: () -> untyped
+
+      def self.day_of_month_calculator: () -> untyped
+    end
+  end
+end
+
+module Holidays
+  module Factory
+    module Definition
+      def self.file_parser: () -> untyped
+
+      def self.source_generator: () -> untyped
+
+      def self.function_processor: () -> untyped
+
+      def self.merger: () -> untyped
+
+      def self.custom_method_parser: () -> untyped
+
+      def self.custom_method_proc_decorator: () -> untyped
+
+      def self.custom_method_source_decorator: () -> untyped
+
+      def self.region_validator: () -> untyped
+
+      def self.custom_method_validator: () -> untyped
+
+      def self.holidays_by_month_repository: () -> untyped
+
+      def self.regions_repository: () -> untyped
+
+      def self.cache_repository: () -> untyped
+
+      def self.proc_result_cache_repository: () -> untyped
+
+      def self.custom_methods_repository: () -> untyped
+
+      def self.regions_generator: () -> untyped
+
+      def self.loader: () -> untyped
+
+      def self.module_generator: () -> untyped
+
+      def self.test_generator: () -> untyped
+
+      def self.test_decorator: () -> untyped
+
+      def self.test_parser: () -> untyped
+    end
+  end
+end
+
+module Holidays
+  module Factory
+    module Finder
+      def self.search: () -> untyped
+
+      def self.between: () -> untyped
+
+      def self.next_holiday: () -> untyped
+
+      def self.year_holiday: () -> untyped
+
+      def self.parse_options: () -> untyped
+
+      private
+
+      def self.dates_driver_builder: () -> untyped
+
+      def self.rules: () -> { in_region: untyped, year_range: untyped }
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Context
+      class Between
+        def initialize: (untyped definition_search, untyped dates_driver_builder, untyped options_parser) -> void
+
+        def call: (untyped start_date, untyped end_date, untyped options) -> untyped
+
+        private
+
+        def validate!: (untyped start_date, untyped end_date) -> untyped
+
+        def gather_options: (untyped observed, untyped informal) -> untyped
+      end
+    end
+  end
+end
+
+# This context builds a hash that contains {:year => [<array of months>]}. The idea is that
+# we will iterate over each year and then over each month internally and check to see if the
+# supplied dates match any holidays for the region and date. So if we supply start_date of 2015/1/1
+# and end_date of 2015/6/1 then we will return a date driver of {:2015 => [0, 1, 2, 5, 6, 7]}.
+# In the logic in the various other 'finder' contexts we will iterate over this and compare dates
+# in these months to the supplied range to determine whether they should be returned to the user.
+module Holidays
+  module Finder
+    module Context
+      class DatesDriverBuilder
+        def call: (untyped start_date, untyped end_date) -> untyped
+
+        private
+
+        # As part of https://github.com/holidays/holidays/issues/146 I am returning
+        # additional months in an attempt to catch month-spanning date situations (i.e.
+        # dates falling on 2/1 but being observed on 1/31). By including the additional months
+        # we are increasing runtimes slightly but improving accuracy, which is more important
+        # to me at this stage.
+        def add_border_months: (untyped current_date, untyped dates_driver) -> untyped
+
+        def clean: (untyped dates_driver) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Context
+      class NextHoliday
+        def initialize: (untyped definition_search, untyped dates_driver_builder, untyped options_parser) -> void
+
+        def call: (untyped holidays_count, untyped from_date, untyped options) -> untyped
+
+        private
+
+        def validate!: (untyped holidays_count, untyped from_date) -> untyped
+
+        def gather_options: (untyped observed, untyped informal) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Context
+      class ParseOptions
+        def initialize: (untyped regions_repo, untyped region_validator, untyped definition_loader) -> void
+
+        # Returns [(arr)regions, (bool)observed, (bool)informal]
+        def call: (*untyped options) -> untyped
+
+        private
+
+        # Check regions against list of supported regions and return an array of
+        # symbols.
+        #
+        # If a wildcard region is found (e.g. :ca_) it is expanded into all
+        # of its available sub regions.
+        def parse_regions!: (untyped regions) -> untyped
+
+        def validate!: (untyped regions) -> untyped
+
+        def is_wildcard?: (untyped r) -> untyped
+
+        def load_wildcard_parent!: (untyped wildcard_region) -> untyped
+
+        def load_region!: (untyped r) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Context
+      class Search
+        def initialize: (untyped holidays_by_month_repo, untyped custom_method_processor, untyped day_of_month_calculator, untyped rules) -> void
+
+        def call: (untyped dates_driver, untyped regions, untyped options) -> untyped
+
+        private
+
+        def validate!: (untyped dates_driver) -> untyped
+
+        def informal_type?: (untyped `type`) -> untyped
+
+        def informal_set?: (untyped options) -> untyped
+
+        def observed_set?: (untyped options) -> untyped
+
+        def build_date: (untyped year, untyped month, untyped h) -> untyped
+
+        def custom_holiday: (untyped year, untyped month, untyped h) -> untyped
+
+        def build_custom_method_input: (untyped year, untyped month, untyped day, untyped regions) -> { year: untyped, month: untyped, day: untyped, region: untyped }
+
+        def build_observed_date: (untyped date, untyped regions, untyped h) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Context
+      class YearHoliday
+        def initialize: (untyped definition_search, untyped dates_driver_builder, untyped options_parser) -> void
+
+        def call: (untyped from_date, untyped options) -> untyped
+
+        private
+
+        def validate!: (untyped from_date) -> (untyped | nil)
+
+        def gather_options: (untyped observed, untyped informal) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Rules
+      class InRegion
+        def self.call: (untyped requested, untyped available) -> (true | untyped)
+      end
+    end
+  end
+end
+
+module Holidays
+  module Finder
+    module Rules
+      class YearRange
+        UNTIL: :until
+
+        FROM: :from
+
+        LIMITED: :limited
+
+        BETWEEN: :between
+
+        def self.call: (untyped target_year, untyped year_range_defs) -> untyped
+
+        private
+
+        def self.validate!: (untyped target_year, untyped year_ranges) -> untyped
+      end
+    end
+  end
+end
+
+module Holidays
+  # ODO This file should be renamed. It's no longer about definitions, really.
+  class LoadAllDefinitions
+    def self.call: () -> untyped
+
+    private
+
+    def self.gregorian_easter: () -> untyped
+
+    def self.julian_easter: () -> untyped
+
+    def self.weekend_modifier: () -> untyped
+
+    def self.day_of_month_calculator: () -> untyped
+
+    def self.lunar_date: () -> untyped
+  end
+end
+
+module Holidays
+  VERSION: "8.5.0"
+end


### PR DESCRIPTION
Add type definitions for https://github.com/holidays/holidays 8.4

The type definitions are generated by `rbs prototype rb` command as below.

```sh
$ rbs prototype rb gems/holidays/8.4/_src/lib/**/*.rb > gems/holidays/8.4/holidays-generated.rbs
```

Sorry for the few tests. I use two methods in my project. 