### PR TITLE
Change block to optional for `ActiveRecord::Relation#find_or_initialize_by`

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -19702,7 +19702,7 @@ module ActiveRecord
 
     # Like #find_or_create_by, but calls {new}[rdoc-ref:Core#new]
     # instead of {create}[rdoc-ref:Persistence::ClassMethods#create].
-    def find_or_initialize_by: (untyped attributes) { () -> untyped } -> untyped
+    def find_or_initialize_by: (untyped attributes) ?{ () -> untyped } -> untyped
 
     # Runs EXPLAIN on the query or queries triggered by this relation and
     # returns the result as a string. The string is formatted imitating the


### PR DESCRIPTION
`ActiveRecord::Relation#find_or_initialize_by` type definition requires a block.
If we try to run without blocks, we will get the following error:

```
[error] The method cannot be called without a block
│ Diagnostic ID: Ruby::RequiredBlockMissing
│
└     admin_user = User.find_or_initialize_by(role: admin)
```

However, if we look at the method definitions, we will see that they can accept blocks.

```ruby
def find_or_initialize_by(attributes, &block)
  find_by(attributes) || new(attributes, &block)
end
```
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L231-L233

So this PR change to make the block optional.