### PR TITLE
Add some type definitions to Faraday

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -3,6 +3,8 @@
 
 require "faraday"
 
+Faraday.default_adapter
+
 conn = Faraday.new(
   url: 'http://example.com/test1',
 )

--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -12,21 +12,25 @@ response = conn.get('/get', { param: '1' }, { 'Content-Type' => 'application/jso
 response.status
 response.headers
 response.body
+response.success?
 
 response = conn.head('/head')
 response.status
 response.headers
 response.body
+response.success?
 
 response = conn.delete('/delete')
 response.status
 response.headers
 response.body
+response.success?
 
 response = conn.trace('/trace')
 response.status
 response.headers
 response.body
+response.success?
 
 conn = Faraday.new(
   url: 'http://example.com/test2',
@@ -38,6 +42,7 @@ end
 response.status
 response.headers
 response.body
+response.success?
 
 response = conn.put('/put') do |req|
   req.body = "{ query: 'chunky bacon' }"
@@ -45,6 +50,7 @@ end
 response.status
 response.headers
 response.body
+response.success?
 
 response = conn.patch('/patch') do |req|
   req.body = "{ query: 'chunky bacon' }"
@@ -52,3 +58,4 @@ end
 response.status
 response.headers
 response.body
+response.success?

--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -8,6 +8,7 @@ Faraday.default_adapter
 conn = Faraday.new(
   url: 'http://example.com/test1',
 )
+conn.headers
 response = conn.get('/get', { param: '1' }, { 'Content-Type' => 'application/json' })
 response.status
 response.headers

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -1,4 +1,6 @@
 module Faraday
+  attr_reader self.default_adapter: Symbol
+
   def self.new: (?untyped url, ?untyped options) ?{ (?untyped) -> void } -> Faraday::Connection
 
   class Connection

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -4,6 +4,8 @@ module Faraday
   def self.new: (?untyped url, ?untyped options) ?{ (?untyped) -> void } -> Faraday::Connection
 
   class Connection
+    attr_reader headers: Hash[String, String]
+
     def get: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def head: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def delete: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -18,6 +18,7 @@ module Faraday
     def status: () -> Integer
     def headers: () -> untyped
     def body: () -> String
+    def success?: () -> bool
   end
 
   class Request


### PR DESCRIPTION
Add some type definitions to [Faraday](https://github.com/lostisland/faraday).
Since I am still new to writing RBS, I only added methods that I currently use and do not have a type definition.

* `Faraday.default_adopter`
* `Faraday::Response#success?`
* `Faraday::Response#header`

Could you please check this PR?