### PR TITLE
Make returned value of `initialize` void for line-bot-sdk-ruby gem

### DIFF
--- a/gems/line-bot-api/1.25/line-bot-api.rbs
+++ b/gems/line-bot-api/1.25/line-bot-api.rbs
@@ -73,7 +73,7 @@ module Line
       attr_accessor endpoint: String
       attr_accessor blob_endpoint: String
 
-      def initialize: (?Hash[String, String] options) ?{ (instance) -> void } -> instance
+      def initialize: (?Hash[String, String] options) ?{ (instance) -> void } -> void
       def oauth_endpoint: () -> String
       def liff_endpoint: () -> String
 


### PR DESCRIPTION
Follow up #206 

In general, `initialize` method returns anything and it is ignored by `Class#new` method. So the returned type should be void usually.