### PR TITLE
Load `timeout` when checking httparty

### DIFF
--- a/gems/httparty/0.18/_scripts/test
+++ b/gems/httparty/0.18/_scripts/test
@@ -12,7 +12,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r httparty:0.18 -r uri:0 -r net-http:0 validate --silent
+bundle exec rbs --repo $REPO_DIR -r httparty:0.18 -r uri:0 -r timeout:0 -r net-http:0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/httparty/0.18/_test/Steepfile
+++ b/gems/httparty/0.18/_test/Steepfile
@@ -7,6 +7,7 @@ target :test do
   library "httparty:0.18"
   library "uri"
   library "net-http"
+  library "timeout"
   signature "."
 
   configure_code_diagnostics(D::Ruby.all_error)


### PR DESCRIPTION
I stumbled across an issue with httparty when running a test like this:

```console
❯ ./bin/setup
...
❯ ./bin/test gems/httparty/0.18
Detected test script: gems/httparty/0.18/_scripts/test

# Set RBS_DIR variable to change directory to execute type checks using `steep check`
RBS_DIR=$(cd $(dirname $0)/..; pwd)
cd $(dirname $0)/..; pwd
dirname $0
# Set REPO_DIR variable to validate RBS files added to the corresponding folder
REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
cd $(dirname $0)/../../..; pwd
dirname $0
# Validate RBS files, using the bundler environment present
bundle exec rbs --repo $REPO_DIR -r httparty:0.18 -r uri:0 -r net-http:0 validate --silent
/Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/errors.rb:149:in `check!': /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/stdlib/net-http/0/net-http.rbs:40:2...41:5: Could not find super class: Timeout::Error (RBS::NoSuperclassFoundError)
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/definition_builder/ancestor_builder.rb:211:in `one_instance_ancestors'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/definition_builder/ancestor_builder.rb:399:in `instance_ancestors'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/definition_builder.rb:142:in `block in build_instance'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/definition_builder.rb:798:in `try_cache'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/definition_builder.rb:136:in `build_instance'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/cli.rb:435:in `block in run_validate'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/cli.rb:433:in `each'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/cli.rb:433:in `run_validate'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/lib/rbs/cli.rb:125:in `run'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.6.0/exe/rbs:7:in `<top (required)>'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/bin/rbs:25:in `load'
	from /Users/yutaka.kamei/.rbenv/versions/3.1.2/bin/rbs:25:in `<main>'
 => Failure 🚨
```

As far as I see, net-http seems to depend on timeout, so it could be resolved by making rbs to load timeout as well as adding `library "timeout"` in `Steepfile`.

On my local machine, I could get succeeded with this patch 🎉 

<details>
<summary>The result after patching the changes</summary>

```console
❯ ./bin/test gems/httparty/0.18
Detected test script: gems/httparty/0.18/_scripts/test

# Set RBS_DIR variable to change directory to execute type checks using `steep check`
RBS_DIR=$(cd $(dirname $0)/..; pwd)
cd $(dirname $0)/..; pwd
dirname $0
# Set REPO_DIR variable to validate RBS files added to the corresponding folder
REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
cd $(dirname $0)/../../..; pwd
dirname $0
# Validate RBS files, using the bundler environment present
bundle exec rbs --repo $REPO_DIR -r httparty:0.18 -r uri:0 -r timeout:0 -r net-http:0 validate --silent

cd ${RBS_DIR}/_test
# Run type checks
bundle exec steep check
 => Success 💪
```

</details>

I followed [line-bot-api/1.25](https://github.com/ruby/gem_rbs_collection/tree/8e2fd75fc0e2bcbda9023e8c936fe5ba654b1436/gems/line-bot-api/1.25) because it configures something like this patch. What do you think?