### PR TITLE
add_version_type_definition_to_zengin_code

### DIFF
--- a/gems/zengin_code/1.0/_test/test.rb
+++ b/gems/zengin_code/1.0/_test/test.rb
@@ -22,3 +22,5 @@ puts branch.roma
 puts branch.bank
 
 ZenginCode::Bank["0000"] # => nil
+
+ZenginCode.version # => "1.0.1-p20221002"

--- a/gems/zengin_code/1.0/zengin_code.rbs
+++ b/gems/zengin_code/1.0/zengin_code.rbs
@@ -20,4 +20,6 @@ module ZenginCode
     attr_reader hira: String
     attr_reader roma: String
   end
+
+  def self.version: () -> String
 end


### PR DESCRIPTION
Add `ZenginCode.version` type definition to [zengin-code](https://github.com/zengin-code/zengin-rb).

Could you please check this PR?