### PR TITLE
Update boilerplate and CONTRIBUTING.md to clarify `manifest.yaml`

### DIFF
--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -111,7 +111,7 @@ put base / 'manifest.yaml', <<~'YAML'
   # manifest.yaml describes dependencies which do not appear in the gemspec.
   # If this gem includes such dependencies, comment-out the following lines and
   # declare the dependencies.
-  # If all dependencies appear in the gemspec, you can remove this file.
+  # If all dependencies appear in the gemspec, you should remove this file.
   #
   # dependencies:
   #   - name: pathname
@@ -148,5 +148,5 @@ puts
 puts <<~MESSAGE
   The boilerplate for #{gem_name} gem has been generated.
   Start writing the RBS! We recommend to use `rbs prototype` or `typeprof` command.
-  See the README.md for more information.
+  See the CONTRIBUTING.md for more information.
 MESSAGE

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -85,6 +85,12 @@ Then you can run `steep check` to type check the test scripts.
 
 See existing gems for examples, like [redis/4.2](https://github.com/ruby/gem_rbs_collection/tree/main/gems/redis/4.2/_test) or [listen/3.2](https://github.com/ruby/gem_rbs_collection/tree/main/gems/listen/3.2/_test).
 
+### Write manifest.yaml
+
+`manifest.yaml` describes dependencies which do not appear in the gemspec.
+If this gem includes such dependencies, comment-out the following lines and declare the dependencies.
+If all dependencies appear in the gemspec, you should remove this file.
+See [the documentation](https://github.com/ruby/rbs/blob/master/docs/collection.md) for more information.
 
 ## Code Owners
 


### PR DESCRIPTION
No one removes `manifest.yaml` even if it's unnecessary, so we need to clarify the contributing process.