### PR TITLE
Support URI on HTTP verb methods of Faraday

### DIFF
--- a/gems/faraday/2.5/_scripts/test
+++ b/gems/faraday/2.5/_scripts/test
@@ -13,7 +13,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r faraday:2.5 validate --silent
+bundle exec rbs --repo $REPO_DIR -r faraday:2.5 -r uri:0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/faraday/2.5/_test/Steepfile
+++ b/gems/faraday/2.5/_test/Steepfile
@@ -6,6 +6,7 @@ target :test do
 
   repo_path "../../../"
   library "faraday"
+  library "uri"
 
   configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -5,28 +5,32 @@ require "faraday"
 
 Faraday.default_adapter
 
-conn = Faraday.new(
-  url: 'http://example.com/test1',
-)
+conn = Faraday.new('http://example.com/test1')
 conn.headers
-response = conn.get('/get', { param: '1' }, { 'Content-Type' => 'application/json' })
+response = conn.get('/get', { param: '1' }, { 'Content-Type' => 'application/json' }) do |req|
+  req.path = "/new_get"
+  req.path = URI("https://example.com/new_get?abc=m")
+end
 response.status
 response.headers
 response.body
 response.success?
 
+conn.head(URI("https://example.com/head")) { |req| req[:x_csrf_token] }
 response = conn.head('/head')
 response.status
 response.headers
 response.body
 response.success?
 
+conn.delete(URI("https://example.com/delete")) { |req| req[:authorization] }
 response = conn.delete('/delete')
 response.status
 response.headers
 response.body
 response.success?
 
+conn.trace(URI("https://example.com/trace")) { |req| req[:content_type] }
 response = conn.trace('/trace')
 response.status
 response.headers
@@ -37,6 +41,7 @@ conn = Faraday.new(
   url: 'http://example.com/test2',
   headers: { 'Content-Type' => 'application/json' }
 )
+conn.post(URI("http://example.com/post"))
 response = conn.post('/post') do |req|
   req.body = "{ query: 'chunky bacon' }"
 end
@@ -45,6 +50,7 @@ response.headers
 response.body
 response.success?
 
+conn.put(URI("http://example.com/put"))
 response = conn.put('/put') do |req|
   req.body = "{ query: 'chunky bacon' }"
 end
@@ -53,6 +59,7 @@ response.headers
 response.body
 response.success?
 
+conn.patch(URI("https://example.com/patch"))
 response = conn.patch('/patch') do |req|
   req.body = "{ query: 'chunky bacon' }"
 end

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -6,14 +6,14 @@ module Faraday
   class Connection
     attr_reader headers: Hash[String, String]
 
-    def get: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
-    def head: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
-    def delete: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
-    def trace: (?String url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def get: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def head: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def delete: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def trace: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
 
-    def post: (?String url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
-    def put: (?String url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
-    def patch: (?String url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def post: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def put: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+    def patch: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
   end
 
   class Response
@@ -25,7 +25,7 @@ module Faraday
 
   class Request
     def http_method=: (untyped) -> void
-    def path=: (untyped) -> void
+    def path=: (String | URI) -> void
     def params=: (untyped) -> void
     def headers=: (untyped) -> void
     def body=: (untyped) -> void

--- a/gems/faraday/2.5/manifest.yaml
+++ b/gems/faraday/2.5/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: uri


### PR DESCRIPTION
Faraday's methods which are the namesake of HTTP verbs also receive an instance of `URI` for the first positional argument. In addition to them, `Request#path=` support `URI`, too.

These changes follow the upstream behavior and make `gems/faraday/2.5` load `uri`. Also, they update `test.rb` to test Faraday signatures more comprehensively, such as calling a block on `get`.

By the way, I read [Write manifest.yaml](https://github.com/ruby/gem_rbs_collection/blob/79fdb8770f7073f0fd07d3440d53eae66bbe4e99/docs/CONTRIBUTING.md#write-manifestyaml), and I thought `manifest.yaml` should be added in this PR too because `uri` is not explicitly included in the [gemspec](https://github.com/lostisland/faraday/blob/fe6e71bbe0d03134f79fad3a2a095799265da6dd/faraday.gemspec) (Should I open a PR on Faraday to add it to the file?).

Anyway, thank you for maintaining such a great repository.