### PR TITLE
Increase fetch-depth to 100 to fetch more commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 2
+        fetch-depth: 100
     - name: 'Install dependencies'
       run: 'bundle install --frozen'
     - name: Get changed files


### PR DESCRIPTION
`fetch-depth: 2` causes an error when a PR has many commits (more than two I guess). So we need to remove the limit by setting `0` as `fetch-depth` or increasing this value. I guess `100` commits is enough for 99% use case.