### PR TITLE
Fix backslash escaping for the boilerplate

### DIFF
--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -91,7 +91,7 @@ put base / '_scripts/test', <<~BASH
   # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
   set -eou pipefail
   # Internal Field Separator - Linux shell variable
-  IFS=$'\n\t'
+  IFS=$'\\n\\t'
   # Print shell input lines
   set -v
 

--- a/gems/active_decorator/1.4/_scripts/test
+++ b/gems/active_decorator/1.4/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/aws-sdk-core/3/_scripts/test
+++ b/gems/aws-sdk-core/3/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/aws-sdk-ec2/1/_scripts/test
+++ b/gems/aws-sdk-ec2/1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/aws-sdk-kms/1/_scripts/test
+++ b/gems/aws-sdk-kms/1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/aws-sdk-s3/1/_scripts/test
+++ b/gems/aws-sdk-s3/1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/aws-sdk-sqs/1/_scripts/test
+++ b/gems/aws-sdk-sqs/1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/aws-sdk-ssm/1/_scripts/test
+++ b/gems/aws-sdk-ssm/1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/bcrypt/3.1/_scripts/test
+++ b/gems/bcrypt/3.1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/delayed_job_active_record/4.1/_scripts/test
+++ b/gems/delayed_job_active_record/4.1/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/enumerize/2.5/_scripts/test
+++ b/gems/enumerize/2.5/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/faraday/2.5/_scripts/test
+++ b/gems/faraday/2.5/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/holidays/8.4/_scripts/test
+++ b/gems/holidays/8.4/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/i18n/1.10/_scripts/test
+++ b/gems/i18n/1.10/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/kaminari-core/1.2/_scripts/test
+++ b/gems/kaminari-core/1.2/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/line-bot-api/1.25/_scripts/test
+++ b/gems/line-bot-api/1.25/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/paranoia/2.5/_scripts/test
+++ b/gems/paranoia/2.5/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/rolify/6.0/_scripts/test
+++ b/gems/rolify/6.0/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/sentry-ruby/5.2/_scripts/test
+++ b/gems/sentry-ruby/5.2/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 

--- a/gems/sorcery/0.16/_scripts/test
+++ b/gems/sorcery/0.16/_scripts/test
@@ -3,8 +3,7 @@
 # Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
 set -eou pipefail
 # Internal Field Separator - Linux shell variable
-IFS=$'
-	'
+IFS=$'\n\t'
 # Print shell input lines
 set -v
 


### PR DESCRIPTION
The `$IFS` should be escaped `\n\t`, but it was actually raw `\n\t` accidently. This PR fixes the boilerplate and existing `_scripts/test` scripts.