### PR TITLE
Remove `#url=` and add `#url` on Faraday

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -10,6 +10,10 @@ conn.headers
 response = conn.get('/get', { param: '1' }, { 'Content-Type' => 'application/json' }) do |req|
   req.path = "/new_get"
   req.path = URI("https://example.com/new_get?abc=m")
+  req.url("/new_url")
+  req.url("/new_url", { x_foo: "OK" })
+  req.url(URI("https://example.com/new_url?abc=foo"))
+  req.url(URI("https://example.com/new_url?abc=bar"), { x_bar: "OK" })
 end
 response.status
 response.headers

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -30,7 +30,7 @@ module Faraday
     def headers=: (untyped) -> void
     def body=: (untyped) -> void
     def options=: (untyped) -> void
-    def url=: (untyped path, untyped hash) -> void
+    def url: (String | URI path, ?::Hash[untyped, untyped] params) -> void
     def []: (untyped key) -> void
     def []=: (untyped key, untyped value) -> void
   end


### PR DESCRIPTION
As far as I see, Faraday doesn't seem to have `#url=`. Instead, `#url` exists in `Faraday::Request`.

https://github.com/lostisland/faraday/blob/4024f4d4029e090e533c68c3f933c7509280592d/lib/faraday/request.rb#L71-L85

Besides, the second positional argument seems to require an instance of `Hash` or `nil`, which can also be omitted, so I updated it as well.