### PR TITLE
Add RBS for kaminari-activerecord

### DIFF
--- a/gems/kaminari-activerecord/1.2/_scripts/test
+++ b/gems/kaminari-activerecord/1.2/_scripts/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r kaminari-activerecord:1.2 -r kaminari-core:1.2 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/kaminari-activerecord/1.2/_test/Steepfile
+++ b/gems/kaminari-activerecord/1.2/_test/Steepfile
@@ -1,0 +1,23 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "kaminari-activerecord"
+
+  library "kaminari-core:1.2"
+  library "activerecord:6.0"
+  library "activesupport:6.0"
+  library "activemodel:6.0"
+
+  library "singleton"
+  library "logger"
+  library "mutex_m"
+  library "monitor"
+  library "time"
+  library "date"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/kaminari-activerecord/1.2/_test/test.rb
+++ b/gems/kaminari-activerecord/1.2/_test/test.rb
@@ -1,0 +1,15 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "kaminari-activerecord"
+
+class User < ActiveRecord::Base
+  paginates_per 10
+  max_paginates_per 100
+  max_pages 1000
+end
+
+User.page(1)
+User.default_per_page
+User.max_per_page
+User.max_pages

--- a/gems/kaminari-activerecord/1.2/_test/test.rbs
+++ b/gems/kaminari-activerecord/1.2/_test/test.rbs
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+  include Kaminari::ActiveRecordModelExtension
+  extend Kaminari::ActiveRecordModelExtension::ClassMethods
+end

--- a/gems/kaminari-activerecord/1.2/kaminari-activerecord.rbs
+++ b/gems/kaminari-activerecord/1.2/kaminari-activerecord.rbs
@@ -1,0 +1,29 @@
+module Kaminari
+  module ActiveRecordModelExtension
+    module ClassMethods
+      include Kaminari::ConfigurationMethods::ClassMethods
+
+      def page: (?Integer num) -> self
+    end
+  end
+
+  module ActiveRecordRelationMethods
+  end
+
+  module ActiveRecordExtension
+    module ClassMethods
+    end
+  end
+end
+
+module ActiveRecord
+  class Base
+    include Kaminari::ActiveRecordExtension
+    extend Kaminari::ActiveRecordExtension::ClassMethods
+  end
+
+  class Relation
+    include Kaminari::ActiveRecordRelationMethods
+    include Kaminari::PageScopeMethods
+  end
+end

--- a/gems/kaminari-core/1.2/_test/test.rb
+++ b/gems/kaminari-core/1.2/_test/test.rb
@@ -56,3 +56,15 @@ model.prev_page
 model.first_page?
 model.last_page?
 model.out_of_range?
+
+class Model
+  extend Kaminari::ConfigurationMethods::ClassMethods
+
+  paginates_per 10
+  max_paginates_per 100
+  max_pages 1000
+end
+
+Model.default_per_page
+Model.max_per_page
+Model.max_pages

--- a/gems/kaminari-core/1.2/_test/test.rbs
+++ b/gems/kaminari-core/1.2/_test/test.rbs
@@ -4,3 +4,7 @@ class ModelRelation
   def limit: (Integer num) -> self
   def offset: (Integer num) -> self
 end
+
+class Model
+  extend Kaminari::ConfigurationMethods::ClassMethods
+end

--- a/gems/kaminari-core/1.2/kaminari-core.rbs
+++ b/gems/kaminari-core/1.2/kaminari-core.rbs
@@ -29,6 +29,16 @@ module Kaminari
     def out_of_range?: () -> bool
   end
 
+  module ConfigurationMethods
+    module ClassMethods
+      def paginates_per: (Integer val) -> void
+      def default_per_page: () -> Integer
+      def max_paginates_per: (Integer val) -> void
+      def max_per_page: () -> Integer?
+      def max_pages: (?Integer | Symbol val) -> (Integer? | void)
+    end
+  end
+
   interface _Model_Relation
     def limit: (Integer) -> self
     def offset: (Integer) -> self

--- a/gems/kaminari-core/1.2/kaminari-core.rbs
+++ b/gems/kaminari-core/1.2/kaminari-core.rbs
@@ -35,7 +35,8 @@ module Kaminari
       def default_per_page: () -> Integer
       def max_paginates_per: (Integer val) -> void
       def max_per_page: () -> Integer?
-      def max_pages: (?Integer | Symbol val) -> (Integer? | void)
+      def max_pages: (Integer) -> void
+                   | () -> Integer
     end
   end
 


### PR DESCRIPTION
This PR added RBS files and tests for a `self.page` method and so on in `kaminari-activerecord` .
Besides, I added types for Kaminari::ConfigurationMethods module in `kaminari-core` because the method is used in kaminari-activerecord.

Please check them.
[kaminari-activerecord](https://github.com/kaminari/kaminari/tree/master/kaminari-activerecord)