### PR TITLE
Fix block definition of `ActionController::Base#rescue_from` and `ActionController::Base#rescue_from`

### DIFF
--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -5,7 +5,8 @@ module ActionController
   end
 
   interface _API_and_Base_singletion
-    def rescue_from: (*Class, ?with: Symbol | Proc) { (Exception) -> void } -> void
+    def rescue_from: (*Class, ?with: Symbol | Proc) -> void
+                   | (*Class) { (Exception) -> void } -> void
   end
 
   class Base < Metal


### PR DESCRIPTION
This PR changes block for `rescue_from` in `actionpack` to be optional.
When `with:` parameter is given, block is not needed.

I checked behavior via Steep.

Before:
<img width="531" alt="image" src="https://user-images.githubusercontent.com/7571111/194712990-5872b9f1-1fcf-4f87-8004-1229d25d1ba5.png">

After:
<img width="552" alt="image" src="https://user-images.githubusercontent.com/7571111/194713048-4f764217-fa8d-4e1f-ac46-f0d3a2d17655.png">
