### PR TITLE
Fixed to allow omission of blocks in`ActiveModel::Validations::ClassMethods#validate`

### DIFF
--- a/gems/activemodel/6.0/activemodel-generated.rbs
+++ b/gems/activemodel/6.0/activemodel-generated.rbs
@@ -3924,7 +3924,7 @@ module ActiveModel
       #
       # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.
       #
-      def validate: (*untyped args) ?{ () -> untyped } -> untyped
+      def validate: (*untyped args) ?{ (untyped) -> untyped } -> untyped
 
       # List all validators that are being used to validate the model using
       # +validates_with+ method.

--- a/gems/activemodel/6.0/activemodel-generated.rbs
+++ b/gems/activemodel/6.0/activemodel-generated.rbs
@@ -3924,7 +3924,7 @@ module ActiveModel
       #
       # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.
       #
-      def validate: (*untyped args) { () -> untyped } -> untyped
+      def validate: (*untyped args) ?{ () -> untyped } -> untyped
 
       # List all validators that are being used to validate the model using
       # +validates_with+ method.


### PR DESCRIPTION
**Background**

When calling `ActiveModel::Validations.validate` as described below., the block could not be omitted.

```
class Comment
  include ActiveModel::Validations

  validate :must_be_friends

  def must_be_friends
    errors.add(:base, 'Must be friends to leave a comment') unless commenter.friend_of?(commentee)
  end
 end
```

**Solution**

Fixed to allow omission of blocks in`ActiveModel::Validations::ClassMethods#validate`