### PR TITLE
Tweak message in init_new_gem to recommend to focus on main feature

### DIFF
--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -147,6 +147,6 @@ end
 puts
 puts <<~MESSAGE
   The boilerplate for #{gem_name} gem has been generated.
-  Start writing the RBS! We recommend to use `rbs prototype` or `typeprof` command.
+  Start writing the RBS! We recommend to focus on the main API of #{gem_name}.
   See the CONTRIBUTING.md for more information.
 MESSAGE


### PR DESCRIPTION
This PR tweaks a message in init_new_gem to recommend focusing on the main feature when writing RBS.

Previously I recommend using `rbs prototype` to generate RBS, but now I don't. The generator is useful, but the output can be unusable.
I think writing RBS only for the main feature is better than generating RBS. The hand written RBS is smaller than generated one, but it well describes the feature.

So I'd like to remove the recommendation from the message.

It does not mean that we should not use generators. Generators are powerful, but I think hand written RBS is more valuable in many cases.