### PR TITLE
Add RequestStore type definition

### DIFF
--- a/gems/request_store/1.5/_scripts/test
+++ b/gems/request_store/1.5/_scripts/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r request_store:1.5 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/request_store/1.5/_test/Steepfile
+++ b/gems/request_store/1.5/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "request_store"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/request_store/1.5/_test/test.rb
+++ b/gems/request_store/1.5/_test/test.rb
@@ -1,0 +1,8 @@
+require "request_store"
+
+RequestStore.store[:a] = 1
+RequestStore.store
+RequestStore.store[:a]
+RequestStore.fetch(:block_test) do
+  "some stored strings"
+end

--- a/gems/request_store/1.5/manifest.yaml
+++ b/gems/request_store/1.5/manifest.yaml
@@ -1,7 +1,0 @@
-# manifest.yaml describes dependencies which do not appear in the gemspec.
-# If this gem includes such dependencies, comment-out the following lines and
-# declare the dependencies.
-# If all dependencies appear in the gemspec, you should remove this file.
-#
-# dependencies:
-#   - name: pathname

--- a/gems/request_store/1.5/manifest.yaml
+++ b/gems/request_store/1.5/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname

--- a/gems/request_store/1.5/request_store.rbs
+++ b/gems/request_store/1.5/request_store.rbs
@@ -1,0 +1,6 @@
+module RequestStore
+  def self.store: () -> Hash[untyped, untyped]
+  def self.[]: (untyped) -> untyped
+  def self.[]=: (untyped) -> void
+  def self.fetch: (untyped) { () -> void } -> untyped
+end


### PR DESCRIPTION
Add type definitions for [request_store](https://github.com/steveklabnik/request_store) gem.

I added only some methods written in [RequestStore's README](https://github.com/steveklabnik/request_store/blob/master/README.md).
This is the firest PR, and I'll add other method definitions as it is merged.

Could you review this PR?