### PR TITLE
Add type definitions for moji gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,3 +106,6 @@
 [submodule "gems/faker/2.23/_src"]
 	path = gems/faker/2.23/_src
 	url = https://github.com/faker-ruby/faker.git
+[submodule "gems/moji/1.6/_src"]
+	path = gems/moji/1.6/_src
+	url = https://github.com/gimite/moji.git

--- a/gems/moji/1.6/_scripts/test
+++ b/gems/moji/1.6/_scripts/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r moji:1.6 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check

--- a/gems/moji/1.6/_test/Steepfile
+++ b/gems/moji/1.6/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "moji"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/moji/1.6/_test/test.rb
+++ b/gems/moji/1.6/_test/test.rb
@@ -1,0 +1,4 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "moji"

--- a/gems/moji/1.6/_test/test.rb
+++ b/gems/moji/1.6/_test/test.rb
@@ -1,4 +1,5 @@
-# Write Ruby code to test the RBS.
-# It is type checked by `steep check` command.
-
 require "moji"
+
+Moji.han_to_zen('ABC')
+
+Moji.zen_to_han('ＡＢＣ')

--- a/gems/moji/1.6/manifest.yaml
+++ b/gems/moji/1.6/manifest.yaml
@@ -1,7 +1,0 @@
-# manifest.yaml describes dependencies which do not appear in the gemspec.
-# If this gem includes such dependencies, comment-out the following lines and
-# declare the dependencies.
-# If all dependencies appear in the gemspec, you should remove this file.
-#
-# dependencies:
-#   - name: pathname

--- a/gems/moji/1.6/manifest.yaml
+++ b/gems/moji/1.6/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname

--- a/gems/moji/1.6/moji.rbs
+++ b/gems/moji/1.6/moji.rbs
@@ -1,0 +1,1 @@
+# Write the type definition here!

--- a/gems/moji/1.6/moji.rbs
+++ b/gems/moji/1.6/moji.rbs
@@ -1,5 +1,5 @@
 module Moji
-  def self?.han_to_zen: (::String str, ?untyped tp) -> String
+  def self?.han_to_zen: (::String str, ?untyped type) -> String
 
-  def self?.zen_to_han: (::String str, ?untyped tp) -> String
+  def self?.zen_to_han: (::String str, ?untyped type) -> String
 end

--- a/gems/moji/1.6/moji.rbs
+++ b/gems/moji/1.6/moji.rbs
@@ -1,5 +1,5 @@
 module Moji
-  def self.han_to_zen: (::String str, ?untyped tp) -> String
+  def self?.han_to_zen: (::String str, ?untyped tp) -> String
 
-  def self.zen_to_han: (::String str, ?untyped tp) -> String
+  def self?.zen_to_han: (::String str, ?untyped tp) -> String
 end

--- a/gems/moji/1.6/moji.rbs
+++ b/gems/moji/1.6/moji.rbs
@@ -1,1 +1,5 @@
-# Write the type definition here!
+module Moji
+  def self.han_to_zen: (::String str, ?untyped tp) -> String
+
+  def self.zen_to_han: (::String str, ?untyped tp) -> String
+end


### PR DESCRIPTION
This PR adds RBS for [moji](https://github.com/gimite/moji) gem.

We will now add RBS for two methods, `Moji.han_to_zen` and `Moji.zen_to_han`.
These methods are defined at:
https://github.com/gimite/moji/blob/master/lib/moji.rb#L468-L510

These are defined as module functions.
https://github.com/gimite/moji/blob/master/lib/moji.rb#L546-L549

Therefore, RBS is also defined as singleton methods.