### PR TITLE
Add `Faraday::VERSION` and add @yykamei to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /gems/ast            @pocke
 /gems/aws-sdk-*      @ksss
 /gems/dogstatsd-ruby @VTRyo
+/gems/faraday        @yykamei
 /gems/i18n           @takahashim
 /gems/rolify         @ksss
 /gems/stackprof      @pocke

--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -3,6 +3,7 @@
 
 require "faraday"
 
+Faraday::VERSION
 Faraday.default_adapter
 
 conn = Faraday.new('http://example.com/test1')

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -1,4 +1,6 @@
 module Faraday
+  VERSION: ::String
+
   attr_reader self.default_adapter: Symbol
 
   def self.new: (?untyped url, ?untyped options) ?{ (?untyped) -> void } -> Faraday::Connection


### PR DESCRIPTION
I got hit with an error of `Faraday::VERSION` is missing when I run `steep check` on my gem.

`Faraday::VERSION` is defined here.

https://github.com/lostisland/faraday/blob/4024f4d4029e090e533c68c3f933c7509280592d/lib/faraday/version.rb#L4

By the way, I'm interested in maintaining Faraday signatures, so I also updated `CODEOWNERS`.