### PR TITLE
Add Faraday::FlatParamsEncoder

### DIFF
--- a/gems/faraday/2.5/_scripts/test
+++ b/gems/faraday/2.5/_scripts/test
@@ -12,7 +12,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r faraday:2.5 -r uri:0 validate --silent
+bundle exec rbs --repo $REPO_DIR -r faraday:2.5 -r uri:0 -r forwardable:0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/faraday/2.5/_test/Steepfile
+++ b/gems/faraday/2.5/_test/Steepfile
@@ -7,6 +7,7 @@ target :test do
   repo_path "../../../"
   library "faraday"
   library "uri"
+  library "forwardable"
 
   configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -72,3 +72,25 @@ response.status
 response.headers
 response.body
 response.success?
+
+Faraday::FlatParamsEncoder.sort_params = true
+Faraday::FlatParamsEncoder.sort_params
+Faraday::FlatParamsEncoder.encode(a: :x)
+Faraday::FlatParamsEncoder.encode(nil)
+if v = Faraday::FlatParamsEncoder.encode(a: [1, 2])
+  v.upcase!
+end
+
+Faraday::FlatParamsEncoder.decode(nil)
+if v = Faraday::FlatParamsEncoder.decode("a&b=1&b=2&c=true")
+  v.each do |key, value|
+    key.upcase!
+    case value
+    when true
+    when String
+      value.upcase!
+    else
+      value.each
+    end
+  end
+end

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -36,4 +36,13 @@ module Faraday
     def []: (untyped key) -> void
     def []=: (untyped key, untyped value) -> void
   end
+
+  module FlatParamsEncoder
+    extend Forwardable
+
+    def self.encode: (Hash[_ToS, _ToS | Array[_ToS]] | nil params) -> (nil | String)
+    def self.decode: (String | nil query) -> (nil | Hash[String, true | String | Array[String]])
+
+    attr_accessor self.sort_params: boolish
+  end
 end

--- a/gems/faraday/2.5/manifest.yaml
+++ b/gems/faraday/2.5/manifest.yaml
@@ -1,2 +1,3 @@
 dependencies:
   - name: uri
+  - name: forwardable


### PR DESCRIPTION
Previously, Faraday users may encounter the error of `UnknownConstant` when they configure the Faraday instance with `Faraday::FlatParamsEncoder`. This module is used for assuming URI params as a string including repetitive query keys, such as `a=123&a=234&a=30` (it will be decoded as `{ "a" => ["123", "234", "30"] }`). The usage is described on the [doc](https://lostisland.github.io/faraday/usage/customize). I think the module is worth being defined in this repository.

Note `Faraday::FlatParamsEncoder` is implemented in this file.

https://github.com/lostisland/faraday/blob/36916f07596f6e1ab71b688be56e5e087a1372df/lib/faraday/encoders/flat_params_encoder.rb

