### PR TITLE
Add `Faraday::Middleware` and `Faraday::MiddlewareRegistry`

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -94,3 +94,13 @@ if v = Faraday::FlatParamsEncoder.decode("a&b=1&b=2&c=true")
     end
   end
 end
+
+Faraday::Middleware.register_middleware(custom: Faraday::Middleware)
+Faraday::Middleware.registered_middleware.each { |k, v| [k, v] }
+Faraday::Middleware.lookup_middleware(:custom)
+Faraday::Middleware.unregister_middleware(:custom)
+custom_middleware = Faraday::Middleware.new(Object.new, { foo: 123 })
+custom_middleware.app
+custom_middleware.options.transform_keys
+custom_middleware.call(Object.new)
+custom_middleware.close

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -45,4 +45,27 @@ module Faraday
 
     attr_accessor self.sort_params: boolish
   end
+
+  class Middleware
+    extend MiddlewareRegistry
+
+    attr_reader app: untyped
+    attr_reader options: Hash[untyped, untyped]
+
+    def initialize: (?untyped? app, ?::Hash[untyped, untyped] options) -> void
+    def call: (untyped env) -> untyped
+    def close: () -> void
+  end
+
+  module MiddlewareRegistry
+    def registered_middleware: () -> Hash[Symbol, untyped]
+    def register_middleware: (**untyped mappings) -> void
+    def unregister_middleware: (Symbol key) -> void
+    def lookup_middleware: (Symbol key) -> untyped
+
+    private
+
+    def middleware_mutex: () ?{ () -> untyped } -> void
+    def load_middleware: (Symbol key) -> untyped
+  end
 end


### PR DESCRIPTION
I added `Faraday::Middleware` and `Faraday::MiddlewareRegistry`. These module signatures might be useful for Faraday plugin authors.