### PR TITLE
Fix test due to rack's RBS improvement

### DIFF
--- a/gems/actionpack/6.0/_scripts/test
+++ b/gems/actionpack/6.0/_scripts/test
@@ -15,7 +15,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 bundle exec rbs --repo $REPO_DIR -r actionpack:6.0 \
   -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime -ractivesupport \
   -ractionview \
-  -rrack \
+  -rrack -rcgi -ruri \
   validate --silent
 
 # TODO

--- a/gems/actionview/6.0/_scripts/test
+++ b/gems/actionview/6.0/_scripts/test
@@ -15,7 +15,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 bundle exec rbs --repo $REPO_DIR -r actionview:6.0 \
   -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime -ractivesupport \
   -ractionpack \
-  -rrack \
+  -rrack -rcgi -ruri \
   validate --silent
 
 # TODO

--- a/gems/activejob/6.0/_scripts/test
+++ b/gems/activejob/6.0/_scripts/test
@@ -17,7 +17,7 @@ bundle exec rbs --repo $REPO_DIR -r activejob:6.0 \
   -rrailties -rtsort \
   -ractionpack \
   -ractionview \
-  -rrack \
+  -rrack -rcgi -ruri \
   validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/activerecord/6.0/_test/Steepfile
+++ b/gems/activerecord/6.0/_test/Steepfile
@@ -13,7 +13,6 @@ target :test do
   library "monitor"
   library "singleton"
   library "tsort"
-  library 'rack'
   library 'time'
 
   library "activerecord:6.0"

--- a/gems/activerecord/6.1/_test/Steepfile
+++ b/gems/activerecord/6.1/_test/Steepfile
@@ -13,7 +13,6 @@ target :test do
   library "monitor"
   library "singleton"
   library "tsort"
-  library "rack"
   library "time"
 
   library "activerecord:6.1"

--- a/gems/activesupport/6.0/_test/Steepfile
+++ b/gems/activesupport/6.0/_test/Steepfile
@@ -13,7 +13,6 @@ target :test do
   library "monitor"
   library "singleton"
   library "tsort"
-  library 'rack'
   library 'time'
 
   library "activesupport:6.0"

--- a/gems/delayed_job/4.1/_test/Steepfile
+++ b/gems/delayed_job/4.1/_test/Steepfile
@@ -17,6 +17,8 @@ target :test do
   library 'time'
 
   library 'rack'
+  library 'cgi'
+  library 'uri'
   library 'activesupport'
   library 'actionpack'
   library 'activejob'


### PR DESCRIPTION
I found these problems during the test of all gems in #256.
Recently `uri` and `cgi` have been added as rack dependencies, but gems depend on Rack do not follow this change.
So this patch adds them as dependencies. 