### PR TITLE
Add the type definition for `Faraday::Adapter`

### DIFF
--- a/gems/faraday/2.5/_test/test_adapter.rb
+++ b/gems/faraday/2.5/_test/test_adapter.rb
@@ -1,0 +1,32 @@
+Faraday::Adapter.register_middleware(custom: Faraday::Adapter)
+Faraday::Adapter.registered_middleware.each { |k, v| [k, v] }
+Faraday::Adapter.lookup_middleware(:custom)
+Faraday::Adapter.unregister_middleware(:custom)
+Faraday::Adapter::CONTENT_LENGTH.chomp
+Faraday::Adapter.supports_parallel = true
+Faraday::Adapter.supports_parallel
+Faraday::Adapter.supports_parallel?
+
+class MyAdapter < Faraday::Adapter
+end
+
+MyAdapter.supports_parallel?
+
+MyAdapter.new(Object.new, { test: 1234 })
+MyAdapter.new(Object.new)
+my_adapter = MyAdapter.new(Object.new) {}
+my_adapter.connection(Object.new)
+my_adapter.connection(Object.new) {}
+my_adapter.close
+my_adapter.send(:save_response, Object.new, 200, "🚀")
+my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 })
+my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 }, "No problem!")
+my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 }, "No problem!", true)
+my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 }, "No problem!", true) {}
+my_adapter.send(:request_timeout, :read, { read_timeout: "ok" })
+my_adapter.send(:request_timeout, :open, { timeout: "ok" })
+response = my_adapter.call(Object.new)
+response.status
+response.headers
+response.success?
+MyAdapter::TIMEOUT_KEYS.slice(:read, :open, :write)

--- a/gems/faraday/2.5/_test/test_adapter.rbs
+++ b/gems/faraday/2.5/_test/test_adapter.rbs
@@ -1,0 +1,2 @@
+class MyAdapter < Faraday::Adapter
+end

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -5,6 +5,39 @@ module Faraday
 
   def self.new: (?untyped url, ?untyped options) ?{ (?untyped) -> void } -> Faraday::Connection
 
+  class Adapter
+    extend MiddlewareRegistry
+
+    CONTENT_LENGTH: "Content-Length"
+
+    interface _SupportsParallel
+      def supports_parallel: () -> boolish
+      def supports_parallel=: (boolish value) -> void
+      def supports_parallel?: () -> boolish
+    end
+
+    module Parallelism
+      include _SupportsParallel
+
+      def inherited: (_SupportsParallel subclass) -> void
+    end
+
+    extend Parallelism
+
+    def initialize: (?untyped? _app, ?::Hash[untyped, untyped] opts) ?{ () -> untyped } -> void
+    def connection: (untyped env) ?{ (untyped) -> untyped } -> untyped
+    def close: () -> void
+    def call: (untyped env) -> Response
+
+    private
+
+    # TODO: The block parameter should be `Utils::Headers`, but it has not yet been defined.
+    def save_response: (untyped env, Integer status, String body, ?Hash[untyped, untyped]? headers, ?String? reason_phrase, ?finished: bool) ?{ (untyped) -> void } -> Response
+    def request_timeout: (:read | :open | :write `type`, Hash[Symbol, untyped] options) -> Integer?
+
+    TIMEOUT_KEYS: { read: :read_timeout, open: :open_timeout, write: :write_timeout }
+  end
+
   class Connection
     attr_reader headers: Hash[String, String]
 


### PR DESCRIPTION
`Faraday::Adapter` is a base class for Faraday adapters, such as [faraday-net_http](https://github.com/lostisland/faraday-net_http) and [faraday-httpclient](https://github.com/lostisland/faraday-httpclient). I think this new declaration might help Faraday plugin developers to know what kind of methods are available for their adapters.