### PR TITLE
Fix Rack::Builder#use type

### DIFF
--- a/gems/rack/2.2/rack.rbs
+++ b/gems/rack/2.2/rack.rbs
@@ -365,7 +365,7 @@ module Rack
     def self.new_from_string: (String builder_script, ?String file) -> _Application
     def initialize: (?_Application? default_app) ?{ (self) -> void } -> void
     def self.app: (?_Application? default_app) ?{ (self) -> void } -> _Application
-    def use: (_Application middleware, *untyped args, **untyped kwargs) ?{ (*untyped) -> void } -> void
+    def use: (Class middleware, *untyped args, **untyped kwargs) ?{ (*untyped) -> void } -> void
     def run: (_Application app) -> _Application
     def warmup: (?(^(_Application) -> void)?) ?{ (_Application) -> void } -> (^(_Application) -> void)?
     def map: (String path) { (Builder) -> void } -> ^(Builder) -> void
@@ -419,7 +419,7 @@ module Rack
 
   class Config
     include _Application
-    
+
     def initialize: (_Application app) {(env) -> void} -> void
   end
 


### PR DESCRIPTION
`#use` should accept a class where the instance implements `_Application`. But the type definition accepted the instance.


---


This type definition is too loose because it accepts any classes.
I have no idea to write the correct type definition smartly, so I just replaced it with `Class`... Probably the following code works but it's ugly.

```ruby
interface _ApplicationClass0
  def new: () -> _Application
end

interface _ApplicationClass1
  def new: (untyped) -> _Application
end

def use: (_ApplicationClass0) -> void
       | (_ApplicationClass1, untyped) -> void
       ....
```


----

This change fixes sentry-ruby gem's test.