### PR TITLE
Fix sentry-ruby testing

### DIFF
--- a/gems/sentry-ruby/5.2/_test/Steepfile
+++ b/gems/sentry-ruby/5.2/_test/Steepfile
@@ -6,7 +6,7 @@ target :test do
 
   repo_path "../../../"
   library "sentry-ruby"
-  library "rack"
+  library "rack", 'uri', 'cgi'
 
   configure_code_diagnostics(D::Ruby.all_error)
 end


### PR DESCRIPTION
It failed due to rack gem's update. `uri` and `cgi` gems have been added as dependences of rack gem, but sentry-ruby gem wasn't updated.