### PR TITLE
Fix untyped call of testing code in aws-sdk-core

### DIFF
--- a/gems/aws-sdk-core/3/_scripts/test
+++ b/gems/aws-sdk-core/3/_scripts/test
@@ -18,5 +18,4 @@ cd ${RBS_DIR}/_test
 # Run type checks
 bundle exec steep check
 
-# FIXME: https://github.com/ruby/gem_rbs_collection/pull/256
-# $(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/aws-sdk-core/3/_test/client_test.rb
+++ b/gems/aws-sdk-core/3/_test/client_test.rb
@@ -15,14 +15,12 @@ client = Client.new(
 )
 
 # instance methods
-client.config.endpoint
-client.config.api
+client.config
 client.handlers
 client.operation_names
 
 # HandlerBuilder
-handler = client.handle_request { |c| c }
-handler.new(->(_) { }).call('context')
+client.handle_request { |c| c }
 
 # ClientStubs
 client.api_requests


### PR DESCRIPTION
- `#config` is a struct whose structure changes dynamically depending on the plugin.
- `#handle_request` returns an anonymous class.