### PR TITLE
Add type signatures for `Faraday::Utils::Headers`

### DIFF
--- a/gems/faraday/2.5/_test/test_utils_headers.rb
+++ b/gems/faraday/2.5/_test/test_utils_headers.rb
@@ -1,0 +1,44 @@
+Faraday::Utils::Headers.from({}).instance_variable_get(:@names)
+Faraday::Utils::Headers.allocate.instance_variable_get(:@names)
+h = Faraday::Utils::Headers.new
+h.initialize_names
+h.initialize_copy(Faraday::Utils::Headers.new).instance_variable_get(:@names)
+h[:test] = 2134
+h[:test] = :df
+h[:test] = nil
+h[:test] = "test"
+
+h[:test]
+h["test"]
+
+h.fetch(:test)
+h.fetch("test")
+
+h.delete(:test)
+h.delete("test")
+
+h.include?(:test) ^ true
+h.include?('test') ^ true
+h.has_key?(:test) ^ true
+h.has_key?('test') ^ true
+h.member?(:test) ^ true
+h.member?('test') ^ true
+h.key?(:test) ^ true
+h.key?('test') ^ true
+
+h.merge!({ ok: 2134, foo: "m" }).parse("Authorization: Bearer token")
+
+h.update({ ok: 2134, foo: "m" }).parse("Authorization: Bearer token")
+
+h.merge({ ok: 2134, foo: "m" }).parse("Authorization: Bearer token")
+
+h.replace({ ok: 2134, foo: "m" }).parse("Authorization: Bearer token")
+
+h.to_hash.parse("Authorization: Bearer token")
+
+h.parse("Authorization: Bearer token")
+h.parse(nil)
+
+h.send(:names)
+h.send(:add_parsed, 'key', 'value')
+h.send(:add_parsed, :key, "123")

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -101,4 +101,42 @@ module Faraday
     def middleware_mutex: () ?{ () -> untyped } -> void
     def load_middleware: (Symbol key) -> untyped
   end
+
+  module Utils
+    class Headers < ::Hash[Symbol | String, untyped]
+      @names: ::Hash[String, String]
+
+      def self.from: (untyped value) -> Headers
+      def self.allocate: () -> Headers
+      def initialize: (?::Hash[Symbol | String, untyped]? hash) -> void
+      def initialize_names: () -> void
+      def initialize_copy: (self other) -> self
+
+      KeyMap: ::Hash[Symbol, String]
+
+      def []: (String | Symbol key) -> untyped?
+      def []=: (String | Symbol key, untyped val) -> untyped
+      def fetch: (String | Symbol key, *untyped args) ?{ () -> untyped } -> untyped
+      def delete: (String | Symbol key) -> untyped?
+      def include?: (String | Symbol key) -> bool
+
+      alias has_key? include?
+      alias member? include?
+      alias key? include?
+
+      def merge!: (::Hash[Symbol | String, untyped] other) -> self
+      alias update merge!
+
+      def merge: (::Hash[Symbol | String, untyped] other) -> Headers
+      def replace: (::Hash[Symbol | String, untyped] other) -> self
+      def to_hash: () -> Headers
+      def parse: (String? header_string) -> Array[untyped]?
+
+      attr_reader names: ::Hash[String, String]
+
+      private
+
+      def add_parsed: (Symbol | String key, String value) -> untyped
+    end
+  end
 end


### PR DESCRIPTION
`Faraday::Utils::Headers` is defined here.

https://github.com/lostisland/faraday/blob/26a35fd76a83ea78e328774b4e475e60c809d868/lib/faraday/utils/headers.rb

I tried to add specific types, but I couldn't avoid `untyped` completely.