### PR TITLE
Run `git config` manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 100
+    - name: 'git config --add safe.directory'
+      run: |
+        git config --global --add safe.directory /__w/gem_rbs_collection/gem_rbs_collection
     - name: 'Install dependencies'
       run: 'bundle install --frozen'
     - name: Get changed files


### PR DESCRIPTION
I don't know why this happens, but recently the tests have failed because of the following error:

[Example](https://github.com/ruby/gem_rbs_collection/actions/runs/3583146499/jobs/6028232106#step:5:48)

```
fatal: detected dubious ownership in repository at '/__w/gem_rbs_collection/gem_rbs_collection'
To add an exception for this directory, call:
  
	git config --global --add safe.directory /__w/gem_rbs_collection/gem_rbs_collection
```