### PR TITLE
Use gh-pr-diff(1) with --name-only to extract changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,14 @@ jobs:
     - name: Get changed gems
       id: changes
       run: |
-        echo 'gems<<GEMS' >> $GITHUB_OUTPUT
+        END_MARKER="$(uuidgen)"
+        echo "gems<<${END_MARKER}" >> $GITHUB_OUTPUT
         gh pr diff ${{ github.event.number }} --name-only | \
           grep '^gems/' | \
           awk -F / '{printf "%s/%s/%s\n", $1, $2, $3}' | \
           sort -u | \
           tee -a $GITHUB_OUTPUT
-        echo 'GEMS' >> $GITHUB_OUTPUT
+        echo "${END_MARKER}" >> $GITHUB_OUTPUT
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run test on changed gems'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,22 +18,29 @@ jobs:
     - name: 'Test syntax check'
       run: 'rbs parse gems/**/*.rbs'
   test_on_changed_gems:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    container:
-      image: rubylang/ruby:3.1-focal
     steps:
     - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
       with:
-        fetch-depth: 100
-    - name: 'Install dependencies'
-      run: 'bundle install --frozen'
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v34.4.0
-    - name: 'Run test on changed gems'
+        ruby-version: '3.1'
+        bundler-cache: true
+    - name: Get changed gems
+      id: changes
       run: |
-        CHANGED_GEMS="$(echo ${{ steps.changed-files.outputs.all_modified_files }} | ruby -e 'puts gets.split.filter_map{_1[%r!^(gems/[^/]+/[^/]+/)!, 1]}.uniq.join(%q! !)')"
-        echo "Changed gems: ${CHANGED_GEMS}"
-        if [ -n "${CHANGED_GEMS}" ]; then
-          bin/test $CHANGED_GEMS --verbose
-        fi
+        echo 'gems<<GEMS' >> $GITHUB_OUTPUT
+        gh pr diff ${{ github.event.number }} --name-only | \
+          grep '^gems/' | \
+          awk -F / '{printf "%s/%s/%s\n", $1, $2, $3}' | \
+          sort -u | \
+          tee -a $GITHUB_OUTPUT
+        echo 'GEMS' >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: 'Run test on changed gems'
+      if: steps.changes.outputs.gems
+      run: |
+        cat <<EOD | xargs bin/test --verbose
+          ${{ steps.changes.outputs.gems }}
+        EOD

--- a/bin/check-untyped-call.rb
+++ b/bin/check-untyped-call.rb
@@ -11,7 +11,7 @@ def green(str)
   "\e[32m#{str}\e[0m"
 end
 
-out, err, status = Open3.capture3('steep', 'stats', '--format=csv')
+out, err, status = Open3.capture3('bundle', 'exec', 'steep', 'stats', '--format=csv')
 unless status.success?
   raise <<~END
     steep stats` fails.


### PR DESCRIPTION
Lately, I got an error like below on my pull request. We can fix this problem by following the error message, but I wonder if we don't have to use a GitHub Action to detect pull request changes.

```
changed-files-diff-sha
  Verifying git version...
  Valid git version found: (2.38.1)
  Running on a pull request event...
  Fetching remote refs...
  fatal: detected dubious ownership in repository at '/__w/gem_rbs_collection/gem_rbs_collection'
  To add an exception for this directory, call:
  
  	git config --global --add safe.directory /__w/gem_rbs_collection/gem_rbs_collection
  Error: Process completed with exit code 128.
```

I want to suggest this PR with the use of [gh-pr-diff(1)](https://cli.github.com/manual/gh_pr_diff). This command allows us to detect file changes with `--name-only` for a specified pull request. The advantages of this command are:

* always available on GitHub runner images
* actively maintained
* official tool

Note this change has unfortunately a disadvantage in that `test_on_changed_gems` won't run on `push` event (gh-pr-diff(1) only works on `pull_request` event). Perhaps, it would be good to configure the workflow to have the `workflow_dispatch` trigger to let us run arbitrary gems on the `main` branch.