### PR TITLE
Fix format of actionmailer manifest

### DIFF
--- a/gems/actionmailer/7.0/manifest.yaml
+++ b/gems/actionmailer/7.0/manifest.yaml
@@ -4,11 +4,11 @@
 # If all dependencies appear in the gemspec, you should remove this file.
 #
 dependencies:
-  - cgi
-  - date
-  - logger
-  - monitor
-  - mutex_m
-  - singleton
-  - time
-  - tsort
+  - name: cgi
+  - name: date
+  - name: logger
+  - name: monitor
+  - name: mutex_m
+  - name: singleton
+  - name: time
+  - name: tsort


### PR DESCRIPTION
Noticed this when trying to run `rbs collection install` locally and it failed with:
```
/Users/rmitchell/.rvm/rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems/dependency.rb:43:in `initialize': dependency name must be a String, was nil (ArgumentError)
	from /Users/rmitchell/.rvm/rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems/specification.rb:991:in `new'
	from /Users/rmitchell/.rvm/rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems/specification.rb:991:in `find_by_name'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/environment_loader.rb:28:in `gem_sig_path'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/sources/rubygems.rb:45:in `gem_sig_path'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/sources/rubygems.rb:14:in `has?'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:96:in `block in find_source'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:96:in `each'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:96:in `find'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:96:in `find_source'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:52:in `assign_gem'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:33:in `generate'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config/lockfile_generator.rb:12:in `generate'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/collection/config.rb:22:in `generate_lockfile'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/cli.rb:1041:in `run_collection'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/lib/rbs/cli.rb:130:in `run'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/gems/rbs-2.7.0/exe/rbs:7:in `<top (required)>'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/bin/rbs:25:in `load'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/bin/rbs:25:in `<main>'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/bin/ruby_executable_hooks:22:in `eval'
	from /Users/rmitchell/.rvm/gems/ruby-3.0.4/bin/ruby_executable_hooks:22:in `<main>'
```
Looks like these entries are expected to be hashes with a `name` value rather than strings?