### PR TITLE
Fix `ActiveRecord::Type` types

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -21996,21 +21996,29 @@ module ActiveRecord
 
     public
 
-    BigInteger: untyped
+    class BigInteger < ActiveModel::Type::BigInteger
+    end
 
-    Binary: untyped
+    class Binary < ActiveModel::Type::Binary
+    end
 
-    Boolean: untyped
+    class Boolean < ActiveModel::Type::Boolean
+    end
 
-    Decimal: untyped
+    class Decimal < ActiveModel::Type::Decimal
+    end
 
-    Float: untyped
+    class Float < ActiveModel::Type::Float
+    end
 
-    Integer: untyped
+    class Integer < ActiveModel::Type::Integer
+    end
 
-    String: untyped
+    class String < ActiveModel::Type::String
+    end
 
-    Value: untyped
+    class Value < ActiveModel::Type::Value
+    end
   end
 end
 


### PR DESCRIPTION
The `ActiveRecord::Type::**` classes are defined as aliases of `ActiveModel::Type::**`:

https://github.com/rails/rails/blob/87bfded6fd0b55d38f7ada5ffa4a4d5bed615604/activerecord/lib/active_record/type.rb#L59-L67

Since RBS doesn't allow defining class/module aliases, I add class declarations inheriting the classes.