### PR TITLE
Type definitions for Concurrent::Promises in concurrent-ruby:1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -127,3 +127,6 @@
 [submodule "gems/business_time/0.13/_src"]
 	path = gems/business_time/0.13/_src
 	url = https://github.com/bokmann/business_time.git
+[submodule "gems/concurrent-ruby/1.1/_src"]
+	path = gems/concurrent-ruby/1.1/_src
+	url = https://github.com/ruby-concurrency/concurrent-ruby.git

--- a/gems/concurrent-ruby/1.1/_scripts/test
+++ b/gems/concurrent-ruby/1.1/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r concurrent-ruby:1.1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/concurrent-ruby/1.1/_test/Steepfile
+++ b/gems/concurrent-ruby/1.1/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature '.'
+
+  repo_path "../../../"
+  library "concurrent-ruby"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/concurrent-ruby/1.1/_test/executor.rb
+++ b/gems/concurrent-ruby/1.1/_test/executor.rb
@@ -1,0 +1,9 @@
+require 'concurrent-ruby'
+
+Concurrent.executor(:io).post { p :io }
+Concurrent.executor(:fast).post { p :fast }
+Concurrent.executor(:immediate).post { p :immediate }
+
+Concurrent.global_io_executor.post { p :io }
+Concurrent.global_fast_executor.post { p :fast }
+Concurrent.global_immediate_executor.post { p :immediate }

--- a/gems/concurrent-ruby/1.1/_test/promises.rb
+++ b/gems/concurrent-ruby/1.1/_test/promises.rb
@@ -1,0 +1,181 @@
+require 'concurrent-ruby'
+
+## Concurrent::Promises::FactoryMethods
+
+p Concurrent::Promises.any_event(
+  Concurrent::Promises.resolvable_event,
+  Concurrent::Promises.future { 1 },
+).wait.resolved?
+
+p Concurrent::Promises.any_fulfilled_future(
+  Concurrent::Promises.rejected_future(RuntimeError.new('error')),
+  Concurrent::Promises.future { 'hello' },
+).value!.start_with?('h')
+
+p Concurrent::Promises.any_resolved_future(
+  Concurrent::Promises.rejected_future(RuntimeError.new('error')),
+  Concurrent::Promises.future { 'hello' },
+).then { |s| s.start_with?('h') }.rescue { |e| e&.message == 'error' }.value
+
+p Concurrent::Promises.fulfilled_future(1).fulfilled?
+
+p Concurrent::Promises.schedule(0.1).wait.resolved?
+p Concurrent::Promises.schedule(Time.now).wait.resolved?
+p Concurrent::Promises.schedule(0.1) { true }.value!
+p Concurrent::Promises.schedule(Time.now) { true }.value!
+
+p Concurrent::Promises.zip_events(
+  Concurrent::Promises.resolved_event,
+  Concurrent::Promises.fulfilled_future(1),
+).wait.resolved?
+
+p Concurrent::Promises.zip_futures(
+  Concurrent::Promises.fulfilled_future(1),
+  Concurrent::Promises.fulfilled_future('a'),
+).then { |a, b| a == 1 && b == 'a' }.value!
+
+p Concurrent::Promises.zip_futures(
+  Concurrent::Promises.rejected_future(RuntimeError.new('error')),
+  Concurrent::Promises.fulfilled_future('a'),
+).rescue { |e,| e&.message == 'error' }.value
+
+p Concurrent::Promises.
+  future('3', '5') { |s, t| s.to_i + t.to_i }.
+  then(2) { |v, arg| v + arg }.
+  then { |v| v == 10 }.
+  value
+
+p Concurrent::Promises.
+  future { fail "error" }.
+  rescue { |e| e.message  }.
+  then { |v| v == "error" }.
+  value
+
+p Concurrent::Promises.
+  rejected_future(1).
+  rejected?
+
+p (Concurrent::Promises.future { 1 } & Concurrent::Promises.future { 2 }).
+  then { |a, b| a == 1 && b == 2 }.
+  value
+
+p (Concurrent::Promises.future { 1 } & Concurrent::Promises.resolved_event).
+  then { |a| a == 1 }.
+  value
+
+p (Concurrent::Promises.resolved_event & Concurrent::Promises.future { 2 }).
+  then { |a| a == 2 }.
+  value
+
+p (Concurrent::Promises.future { 1 } | Concurrent::Promises.future { '2' }).
+  then { |a| a == 1 || a == '2' }.
+  value
+
+p Concurrent::Promises.any_event(
+  Concurrent::Promises.future { 1 },
+  Concurrent::Promises.future { '2' },
+  Concurrent::Promises.resolved_event,
+).wait.resolved?
+
+p Concurrent::Promises.make_future(nil).resolved?
+p Concurrent::Promises.make_future(Concurrent::Promises.resolved_event).resolved?
+p Concurrent::Promises.make_future(RuntimeError.new('error')).rescue { |e| e.message.start_with?('e') }.value
+p Concurrent::Promises.make_future(Concurrent::Promises.future { 'hello' }).then { |s| s.start_with?('h') }.value
+p Concurrent::Promises.make_future('hello').then { |s| s.start_with?('h') }.value
+
+
+## Concurrent::Promises::Event
+
+->() {
+  x = Concurrent::Promises.resolved_event
+
+  p x.delay.touch.resolved?
+  p x.schedule(0.1).wait.resolved?
+  p x.to_event.resolved?
+  p x.to_future.fulfilled?
+  p x.with_default_executor(:io).resolved?
+  p !x.pending?
+
+  p x.any(Concurrent::Promises.resolved_event).resolved?
+  p x.zip(Concurrent::Promises.resolved_event).resolved?
+
+  p x.chain('hi') { |s| s }.value!.start_with?('h')
+}.()
+
+
+## Concurrent::Promises::Future
+
+->() {
+  x = Concurrent::Promises.future { 'hello' }
+
+  p x.delay.touch.value!.start_with?('h')
+  p x.schedule(0.1).wait.then { |s| s.start_with?('h') }.value!
+  p x.to_event.resolved?
+  p x.to_future.fulfilled?
+  p x.with_default_executor(:io).fulfilled?
+  p !x.rejected?
+  p !x.pending?
+}.()
+
+p (Concurrent::Promises.fulfilled_future('hi') | Concurrent::Promises.fulfilled_future('hello')).value!.start_with?('h')
+p (Concurrent::Promises.fulfilled_future('hi') & Concurrent::Promises.fulfilled_future('hello')).value!.all? { |s| s.start_with?('h') }
+
+->() {
+  # @type var step: ^(Integer) -> (Concurrent::Promises::Future[untyped, Exception] | Integer)
+  step = ->(v) {
+    v < 5 ? Concurrent::Promises.future(v + 1) { |x| step[x] } : v
+  }
+  Concurrent::Promises.future(0) {|x| step[x] }.run
+}.()
+
+->() {
+  failure = Concurrent::Promises.future { fail 'error' }
+  p failure.reason&.message&.start_with?('e')
+  p failure.reason(1)&.message&.start_with?('e')
+  p failure.reason(1, RuntimeError.new('timeout'))&.message&.start_with?('e')
+}.()
+
+->() {
+  known_failure = Concurrent::Promises.rejected_future(RuntimeError.new('error'))
+  p known_failure.reason&.message&.start_with?('e')
+  p known_failure.reason(1)&.message&.start_with?('e')
+  p known_failure.reason(1, RuntimeError.new('timeout'))&.message&.start_with?('e')
+}.()
+
+
+## Concurrent::Promises::ResolvableEvent
+
+-> () {
+  x = Concurrent::Promises.resolvable_event
+  p x.resolve.resolved?
+  p x.with_hidden_resolvable.wait.resolved?
+}.()
+
+-> () {
+  x = Concurrent::Promises.resolvable_event
+  p !x.wait(0.1, true)
+  p x.wait.resolved?
+}.()
+
+
+## Concurrent::Promises::ResolvableFuture
+
+-> () {
+  # @type var x: Concurrent::Promises::ResolvableFuture[String, Exception]
+  x = Concurrent::Promises.resolvable_future
+  p x.fulfill("hello").value&.start_with?('h')
+  p x.with_hidden_resolvable.wait.fulfilled?
+}.()
+
+-> () {
+  # @type var x: Concurrent::Promises::ResolvableFuture[String, Exception]
+  x = Concurrent::Promises.resolvable_future
+  p x.reject(RuntimeError.new('error')).reason&.message&.start_with?('e')
+  p x.with_hidden_resolvable.wait.rejected?
+}.()
+
+-> () {
+  # @type var x: Concurrent::Promises::ResolvableFuture[String, Exception]
+  x = Concurrent::Promises.resolvable_future
+  p !x.value(0.1, nil, [false, 'hello', nil])
+}.()

--- a/gems/concurrent-ruby/1.1/executor.rbs
+++ b/gems/concurrent-ruby/1.1/executor.rbs
@@ -1,0 +1,26 @@
+module Concurrent
+  module ExecutorService
+    interface _Task
+      def call: () -> void
+    end
+
+    def post: [A] (*A args) { (*A args) -> void } -> bool
+
+    def <<: (_Task task) -> bool
+
+    def can_overflow?: () -> bool
+
+    def serialized?: () -> bool
+  end
+
+  type executor = ExecutorService | :io | :fast | :immediate
+
+  def self.executor: (executor executor_identifier) -> ExecutorService
+
+  def self.global_io_executor: () -> ExecutorService
+  def self.global_fast_executor: () -> ExecutorService
+  def self.global_immediate_executor: () -> ExecutorService
+
+  def self.new_io_executor: (?Hash[Symbol, untyped] opts) -> ExecutorService
+  def self.new_fast_executor: (?Hash[Symbol, untyped] opts) -> ExecutorService
+end

--- a/gems/concurrent-ruby/1.1/promises.rbs
+++ b/gems/concurrent-ruby/1.1/promises.rbs
@@ -22,9 +22,9 @@ module Concurrent
       def default_executor: () -> executor
 
       def delay: () -> Event
-        | [A, T] (*A) { (*A) -> T } -> Future[T, Exception]
+        | [A, T] (*A args) { (*A args) -> T } -> Future[T, Exception]
       def delay_on: (executor default_executor) -> Event
-        | [A, T] (executor, *A) { (*A) -> T } -> Future[T, Exception]
+        | [A, T] (executor default_executor, *A args) { (*A args) -> T } -> Future[T, Exception]
 
       def fulfilled_future: [T] (T value, ?executor default_executor) -> Future[T, bot]
 
@@ -118,7 +118,7 @@ module Concurrent
       ## Following methods are actually defined in the base class and have specific types for Event
 
       def chain: [A, U] (*A args) { (*A args) -> U } -> Future[U, Exception]
-      def chain_on: [A, U] (executor executor, *A) { (*A args) -> U } -> Future[U, Exception]
+      def chain_on: [A, U] (executor executor, *A args) { (*A args) -> U } -> Future[U, Exception]
 
       def on_resolution: [A] (*A args) { (*A args) -> void } -> self
       def on_resolution!: [A] (*A args) { (*A args) -> void } -> self

--- a/gems/concurrent-ruby/1.1/promises.rbs
+++ b/gems/concurrent-ruby/1.1/promises.rbs
@@ -210,8 +210,8 @@ module Concurrent
       def resolve: (?true raise_on_reassign, ?boolish reserved) -> self
         | (boolish raise_on_reassign, ?boolish reserved) -> (self | false)
 
-      def wait: (?nil) -> self
-        | (Numeric timeout, ?boolish resolve_on_timeout) -> bool
+      def wait: (Numeric timeout, boolish resolve_on_timeout) -> bool
+        | ...
 
       def with_hidden_resolvable: () -> Event
     end
@@ -225,8 +225,8 @@ module Concurrent
       def fulfill:  (T value, ?true raise_on_reassign, ?boolish reserved) -> self
         | (T value, boolish raise_on_reassign, ?boolish reserved) -> (self | false)
 
-      def reason: (?Numeric timeout) -> (E | nil)
-        | [R] (Numeric timeout, R timeout_value, ?[boolish, T?, E?] resolve_on_timeout) -> (E | R | nil)
+      def reason: [R] (Numeric timeout, R timeout_value, [boolish, T?, E?] resolve_on_timeout) -> (E | R | nil)
+        | ...
 
       def reject: (E reason, ?true raise_on_reassign, ?boolish reserved) -> self
         | (E reason, boolish raise_on_reassign, ?boolish reserved) -> (self | false)
@@ -234,14 +234,14 @@ module Concurrent
       def resolve: (?boolish fulfilled, ?T? value, ?E? reason, ?true raise_on_reassign, ?boolish reserved) -> self
         | (boolish fulfilled, T? value, E? reason, boolish raise_on_reassign, ?boolish reserved) -> (self | false)
 
-      def result: (nil?) -> ([true, T, nil] | [false, nil, E])
-        | (?Numeric timeout, ?[boolish, T?, E?] resolve_on_timeout) -> ([true, T, nil] | [false, nil, E] | nil)
+      def result: (Numeric timeout, [boolish, T?, E?] resolve_on_timeout) -> ([true, T, nil] | [false, nil, E] | nil)
+        | ...
 
-      def value: (?Numeric timeout) -> (T | nil)
-        | [R] (?Numeric timeout, ?R timeout_value, ?[boolish, T?, E?] resolve_on_timeout) -> (T | R | nil)
+      def value: [R] (Numeric timeout, R timeout_value, [boolish, T?, E?] resolve_on_timeout) -> (T | R | nil)
+        | ...
 
-      def value!: (?Numeric timeout) -> (T | nil)
-        | [R] (?Numeric timeout, ?R timeout_value, ?[boolish, T?, E?] resolve_on_timeout) -> (T | R | nil)
+      def value!: [R] (Numeric timeout, R timeout_value, [boolish, T?, E?] resolve_on_timeout) -> (T | R | nil)
+        | ...
 
       def with_hidden_resolvable: () -> Future[T, E]
     end

--- a/gems/concurrent-ruby/1.1/promises.rbs
+++ b/gems/concurrent-ruby/1.1/promises.rbs
@@ -1,0 +1,249 @@
+module Concurrent
+  module Promises
+    module FactoryMethods
+      def any_event: (*(Event | Future[top, top]) futures_and_or_events) -> Event
+      def any_event_on: (executor default_executor, *(Event | Future[top, top]) futures_and_or_events) -> Event
+
+      def any_fulfilled_future: (*Event events) -> Future[nil, bot]
+        | [T, E] (*Future[T, E] futures) -> Future[T, E]
+        | [T, E] (*(Event | Future[T, E]) futures_and_or_events) -> Future[T | nil, E]
+      def any_fulfilled_future_on: (executor default_executor, *Event events) -> Future[nil, bot]
+        | [T, E] (executor default_executor, *Future[T, E] futures) -> Future[T, E]
+        | [T, E] (executor default_executor, *(Event | Future[T, E]) futures_and_or_events) -> Future[T | nil, E]
+
+      def any_resolved_future: (*Event events) -> Future[nil, bot]
+        | [T, E] (*Future[T, E] futures) -> Future[T, E]
+        | [T, E] (*(Event | Future[T, E]) futures_and_or_events) -> Future[T | nil, E]
+      alias any any_resolved_future
+      def any_resolved_future_on: (executor default_executor, *Event events) -> Future[nil, bot]
+        | [T, E] (executor default_executor, *Future[T, E] futures) -> Future[T, E]
+        | [T, E] (executor default_executor, *(Event | Future[T, E]) futures_and_or_events) -> Future[T | nil, E]
+
+      def default_executor: () -> executor
+
+      def delay: () -> Event
+        | [A, T] (*A) { (*A) -> T } -> Future[T, Exception]
+      def delay_on: (executor default_executor) -> Event
+        | [A, T] (executor, *A) { (*A) -> T } -> Future[T, Exception]
+
+      def fulfilled_future: [T] (T value, ?executor default_executor) -> Future[T, bot]
+
+      def future: [A, T] (*A args) { (*A args) -> T } -> Future[T, Exception]
+      def future_on: [A, T] (executor default_executor, *A args) { (*A args) -> T } -> Future[T, Exception]
+
+      def make_future: (nil, ?executor default_executor) -> Event
+        | [X < AbstractEventFuture] (X event_or_future, ?executor default_executor) -> X
+        | [E < Exception] (E reason, ?executor default_executor) -> Future[bot, E]
+        | [T] (T value, ?executor default_executor) -> Future[T, bot]
+
+      def rejected_future: [E] (E reason, ?executor default_executor) -> Future[bot, E]
+
+      def resolvable_event: () -> ResolvableEvent
+      def resolvable_event_on: (executor default_executor) -> ResolvableEvent
+
+      def resolvable_future: () -> ResolvableFuture[untyped, untyped]
+      def resolvable_future_on: (executor default_executor) -> ResolvableFuture[untyped, untyped]
+
+      def resolved_event: (?executor default_executor) -> Event
+
+      def resolved_future: [T] (true fulfilled, T value, top reason, ?executor default_executor) -> Future[T, bot]
+        | [E] (false fulfilled, top value, E reason, ?executor default_executor) -> Future[bot, E]
+        | [T, E] (boolish fulfilled, T? value, E? reason, ?executor default_executor) -> Future[T, E]
+
+      def schedule: (Numeric | Time intended_time) -> Event
+        | [A, T] (Numeric | Time intended_time, *A args) { (*A args) -> T } -> Future[T, Exception]
+      def schedule_on: (executor default_executor, Numeric | Time intended_time) -> Event
+        | [A, T] (executor default_executor, Numeric | Time intended_time, *A args) { (*A args) -> T } -> Future[T, Exception]
+
+      def zip_events: (*(Event | Future[top, top]) futures_and_or_events) -> Event
+      def zip_events_on: (executor default_executor, *(Event | Future[top, top]) futures_and_or_events) -> Event
+
+      def zip_futures: (*Event events) -> Future[Array[nil], bot]
+        | [T, E] (*Future[T, E] futures) -> Future[Array[T], Array[E]]
+        | [T, E] (*(Event | Future[T, E]) futures_and_or_events) -> Future[Array[T | nil], Array[E | nil]]
+      alias zip zip_futures
+      def zip_futures_on: (executor default_executor, *Event events) -> Future[Array[nil], bot]
+        | [T, E] (executor default_executor, *Future[T, E] futures) -> Future[Array[T], Array[E]]
+        | [T, E] (executor default_executor, *(Event | Future[T, E]) futures_and_or_events) -> Future[Array[T | nil], Array[E]]
+    end
+
+    extend FactoryMethods
+
+    class AbstractEventFuture
+      def chain: [A, U] (*A args) { (*untyped) -> U } -> Future[U, Exception]
+      def chain_on: [A, U] (executor executor, *A args) { (*untyped) -> U } -> Future[U, Exception]
+
+      def chain_resolvable: (Resolvable resolvable) -> self
+      alias tangle chain_resolvable
+
+      def default_executor: () -> executor
+
+      def internal_state: () -> Object
+
+      def on_resolution: [A] (*A args) { (*untyped) -> void } -> self
+      def on_resolution!: [A] (*A args) { (*untyped) -> void } -> self
+      def on_resolution_using: [A] (executor executor, *A args) { (*untyped) -> void } -> self
+
+      def resolved?: () -> bool
+
+      def pending?: () -> bool
+
+      def state: () -> Symbol
+
+      def touch: () -> self
+
+      def wait: (?nil) -> self
+        | (Numeric timeout) -> bool
+    end
+
+    class Event < AbstractEventFuture
+      def any: (Event | Future[top, top] event_or_future) -> Event
+      alias | any
+
+      def delay: () -> Event
+
+      def schedule: (Numeric | Time intended_time) -> Event
+
+      def to_event: () -> self
+
+      def to_future: () -> Future[nil, bot]
+
+      def with_default_executor: (executor executor) -> Event
+
+      def zip: (Event event) -> Event
+        | [T, E] (Future[T, E] future) -> Future[T, E]
+      alias & zip
+
+
+      ## Following methods are actually defined in the base class and have specific types for Event
+
+      def chain: [A, U] (*A args) { (*A args) -> U } -> Future[U, Exception]
+      def chain_on: [A, U] (executor executor, *A) { (*A args) -> U } -> Future[U, Exception]
+
+      def on_resolution: [A] (*A args) { (*A args) -> void } -> self
+      def on_resolution!: [A] (*A args) { (*A args) -> void } -> self
+      def on_resolution_using: [A] (executor executor, *A args) { (*A args) -> void } -> self
+
+      def state: () -> (:pending | :resolved)
+    end
+
+    class Future[out T, out E] < AbstractEventFuture
+      def any: (Event event) -> Future[T | nil, E]
+        | [T2, E2] (Future[T2, E2] future) -> Future[T | T2, E | E2]
+      alias | any
+
+      def delay: () -> Future[T, E]
+
+      def exception: () -> Exception  # TODO: Return type can be narrowed to E when E <: Exception
+
+      def flat_event: () -> Event
+
+      def flat_future: (?Integer level) -> untyped  # TODO: Valid only if T <: Future[top, top]
+      alias flat flat_future
+
+      def fulfilled?: () -> bool
+
+      def on_fulfillment: [A] (*A args) { (T value, *A args) -> void } -> self
+      def on_fulfillment!: [A] (*A args) { (T value, *A args) -> void } -> self
+      def on_fulfillment_using: [A] (executor executor, *A args) { (T value, A args) -> void } -> self
+
+      def on_rejection: [A] (*A args) { (E reason, *A args) -> void } -> self
+      def on_rejection!: [A] (*A args) { (E reason, *A args) -> void } -> self
+      def on_rejection_using: [A] (executor executor, *A args) { (E reason, A args) -> void } -> self
+
+      def reason: (?Numeric timeout) -> (E | nil)
+        | [R] (Numeric timeout, R timeout_value) -> (E | R | nil)
+
+      def rejected?: () -> bool
+
+      def rescue: [A, U] (*A args) { (E reason, *A args) -> U } -> Future[U, Exception]
+      def rescue_on: [A, U] (executor executor, *A args) { (E reason, *A args) -> U } -> Future[U, Exception]
+
+      def result: (?nil) -> ([true, T, nil] | [false, nil, E])
+        | (Numeric timeout) -> ([true, T, nil] | [false, nil, E] | nil)
+
+      def run: (?^(untyped) -> Future[untyped, untyped]? run_test) -> Future[untyped, untyped]  # TODO: Any specific type?
+
+      def schedule: (Numeric | Time intended_time) -> Future[T, E]
+
+      def then: [A, U] (*A args) { (T value, *A args) -> U } -> Future[U, E | Exception]
+      def then_on: [A, U] (executor executor, *A args) { (T value, *A args) -> U } -> Future[U, E | Exception]
+
+      def to_event: () -> Event
+
+      def to_future: () -> self
+
+      def value: (?Numeric timeout) -> (T | nil)
+        | [R] (Numeric timeout, R timeout_value) -> (T | R | nil)
+      def value!: (?nil) -> T
+        | (Numeric timeout) -> (T | nil)
+        | [R] (Numeric timeout, R timeout_value) -> (T | R | nil)
+
+      def wait!: (?nil) -> self
+        | (Numeric timeout) -> bool
+
+      def with_default_executor: (executor executor) -> Future[T, E]
+
+      def zip: (Event event) -> Future[T, E]
+        | [T2, E2] (Future[T2, E2] future) -> Future[[T, T2], [E, E2]]
+      alias & zip
+
+
+      ## Following methods are actually defined in the base class and have specific types for Future
+
+      def chain: [A, U] (*A args) { (bool fulfilled, T? value, E? reason, *A args) -> U } -> Future[U, Exception]
+      def chain_on: [A, U] (executor executor, *A args) { (bool fulfilled, T? value, E? reason, *A args) -> U } -> Future[U, Exception]
+
+      def on_resolution: [A] (*A args) { (bool fulfilled, T? value, E? reason, *A args) -> void } -> self
+      def on_resolution!: [A] (*A args) { (bool fulfilled, T? value, E? reason, *A args) -> void } -> self
+      def on_resolution_using: [A] (executor executor, *A args) { (bool fulfilled, T? value, E? reason, *A args) -> void } -> self
+
+      def state: () -> (:pending | :fulfilled | :rejected)
+    end
+
+    module Resolvable
+    end
+
+    class ResolvableEvent < Event
+      include Resolvable
+
+      def resolve: (?true raise_on_reassign, ?boolish reserved) -> self
+        | (boolish raise_on_reassign, ?boolish reserved) -> (self | false)
+
+      def wait: (?nil) -> self
+        | (Numeric timeout, ?boolish resolve_on_timeout) -> bool
+
+      def with_hidden_resolvable: () -> Event
+    end
+
+    class ResolvableFuture[T, E] < Future[T, E]  # Note: ResolvableFuture is invariant on T and E
+      include Resolvable
+
+      def evalute_to: [A] (*A args) { (*A args) -> T } -> self  # TODO: Unsound unless E :> Exception
+      def evalute_to!: [A] (*A args) { (*A args) -> T } -> self  # TODO: ditto
+
+      def fulfill:  (T value, ?true raise_on_reassign, ?boolish reserved) -> self
+        | (T value, boolish raise_on_reassign, ?boolish reserved) -> (self | false)
+
+      def reason: (?Numeric timeout) -> (E | nil)
+        | [R] (Numeric timeout, R timeout_value, ?[boolish, T?, E?] resolve_on_timeout) -> (E | R | nil)
+
+      def reject: (E reason, ?true raise_on_reassign, ?boolish reserved) -> self
+        | (E reason, boolish raise_on_reassign, ?boolish reserved) -> (self | false)
+
+      def resolve: (?boolish fulfilled, ?T? value, ?E? reason, ?true raise_on_reassign, ?boolish reserved) -> self
+        | (boolish fulfilled, T? value, E? reason, boolish raise_on_reassign, ?boolish reserved) -> (self | false)
+
+      def result: (nil?) -> ([true, T, nil] | [false, nil, E])
+        | (?Numeric timeout, ?[boolish, T?, E?] resolve_on_timeout) -> ([true, T, nil] | [false, nil, E] | nil)
+
+      def value: (?Numeric timeout) -> (T | nil)
+        | [R] (?Numeric timeout, ?R timeout_value, ?[boolish, T?, E?] resolve_on_timeout) -> (T | R | nil)
+
+      def value!: (?Numeric timeout) -> (T | nil)
+        | [R] (?Numeric timeout, ?R timeout_value, ?[boolish, T?, E?] resolve_on_timeout) -> (T | R | nil)
+
+      def with_hidden_resolvable: () -> Future[T, E]
+    end
+  end
+end


### PR DESCRIPTION
This patch adds type definitions for concurrent-ruby, covering the new Concurrent::Promises API and the public interface of executors.