### PR TITLE
Add AdapterRegistry in faraday@2.5

### DIFF
--- a/gems/faraday/2.5/_test/test_adapter_registry.rb
+++ b/gems/faraday/2.5/_test/test_adapter_registry.rb
@@ -1,0 +1,8 @@
+registry = Faraday::AdapterRegistry.new
+registry.get('Faraday::Connection')
+registry.get(:Faraday)
+registry.set(:Wind)
+registry.set(:Wave, nil)
+registry.set(:Sea, :new_name)
+registry.set(:Mountain, "another")
+registry.set(:Star, 123)

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -90,6 +90,15 @@ module Faraday
     end
   end
 
+  class AdapterRegistry
+    @lock: untyped # TODO: Replace this with `Monitor`
+    @constants: Hash[String, untyped]
+
+    def initialize: () -> void
+    def get: (Symbol | String name) -> untyped
+    def set: (untyped klass, ?_ToS? name) -> void
+  end
+
   class Connection
     attr_reader headers: Hash[String, String]
 


### PR DESCRIPTION
`AdapterRegistry` is defined [here](https://github.com/lostisland/faraday/blob/main/lib/faraday/adapter_registry.rb).

This module seems to be intended for internal use only, but it might be helpful to check the faraday gem itself.