### PR TITLE
use downcase instead of underscore for aws sdk gem name conversion

### DIFF
--- a/generators/aws-sdk-rbs-generator/lib/aws-sdk-rbs-generator/service.rb
+++ b/generators/aws-sdk-rbs-generator/lib/aws-sdk-rbs-generator/service.rb
@@ -44,7 +44,7 @@ module AwsSdkRbsGenerator
     private
 
     def gem_name
-      "aws-sdk-#{@name.underscore}"
+      "aws-sdk-#{@name.downcase}"
     end
 
     def gem_major_version


### PR DESCRIPTION
aws sdk gem names are not separated by underscore

ex. )
O AppRunner -> aws-sdk-apprunner
X AppRunner -> aws-sdk-app_runner