### PR TITLE
Add `Faraday::Error` and its subclasses

### DIFF
--- a/gems/faraday/2.5/_test/test_errors.rb
+++ b/gems/faraday/2.5/_test/test_errors.rb
@@ -1,0 +1,42 @@
+Faraday::Error.new.tap do |error|
+  error.backtrace
+  error.inspect.downcase
+  error.response_status
+  error.response_headers
+  error.response_body
+  error.exc_msg_and_response!.downcase
+  error.exc_msg_and_response!(RuntimeError.new)
+  error.exc_msg_and_response!({ status: 500 })
+  error.exc_msg_and_response!("Error!")
+  error.exc_msg_and_response!(nil)
+  error.exc_msg_and_response!(nil, nil)
+  error.exc_msg_and_response!(nil, { status: 500 })
+  error.exc_msg_and_response.tap { _1[0]&.backtrace; _1[1].upcase; _1[2]&.fetch(:status, 503) }
+  error.exc_msg_and_response(RuntimeError.new)
+  error.exc_msg_and_response({ status: 500 })
+  error.exc_msg_and_response("Error!")
+  error.exc_msg_and_response(nil)
+  error.exc_msg_and_response(nil, nil)
+  error.exc_msg_and_response(nil, { status: 500 })
+end
+
+Faraday::Error.new(RuntimeError.new)
+Faraday::Error.new({ status: 500 })
+Faraday::Error.new("Error!")
+Faraday::Error.new(nil)
+Faraday::Error.new(nil, nil)
+Faraday::Error.new(nil, { status: 500 })
+Faraday::ClientError.new
+Faraday::BadRequestError.new
+Faraday::UnauthorizedError.new
+Faraday::ForbiddenError.new
+Faraday::ResourceNotFound.new
+Faraday::ProxyAuthError.new
+Faraday::ConflictError.new
+Faraday::UnprocessableEntityError.new
+Faraday::ServerError.new
+Faraday::TimeoutError.new
+Faraday::NilStatusError.new("nil")
+Faraday::ConnectionFailed.new
+Faraday::SSLError.new
+Faraday::ParsingError.new

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -112,6 +112,66 @@ module Faraday
     def patch: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
   end
 
+  class Error < StandardError
+    attr_reader response: Hash[Symbol, untyped]?
+    attr_reader wrapped_exception: Exception?
+
+    type exc = Exception | Hash[Symbol, untyped] | String
+
+    def initialize: (?exc? exc, ?Hash[Symbol, untyped]? response) -> void
+    def backtrace: () -> ::Array[String]?
+    def inspect: () -> ::String
+    def response_status: () -> untyped?
+    def response_headers: () -> untyped?
+    def response_body: () -> untyped?
+    def exc_msg_and_response!: (?exc? exc, ?Hash[Symbol, untyped]? response) -> String
+    def exc_msg_and_response: (?exc? exc, ?Hash[Symbol, untyped]? response) -> [Exception?, String, Hash[Symbol, untyped]?]
+  end
+
+  class ClientError < Error
+  end
+
+  class BadRequestError < ClientError
+  end
+
+  class UnauthorizedError < ClientError
+  end
+
+  class ForbiddenError < ClientError
+  end
+
+  class ResourceNotFound < ClientError
+  end
+
+  class ProxyAuthError < ClientError
+  end
+
+  class ConflictError < ClientError
+  end
+
+  class UnprocessableEntityError < ClientError
+  end
+
+  class ServerError < Error
+  end
+
+  class TimeoutError < ServerError
+    def initialize: (?(Exception | Hash[Symbol, untyped] | String)? exc, ?Hash[Symbol, untyped]? response) -> void
+  end
+
+  class NilStatusError < ServerError
+    def initialize: ((Exception | Hash[Symbol, untyped] | String)? exc, ?Hash[Symbol, untyped]? response) -> void
+  end
+
+  class ConnectionFailed < Error
+  end
+
+  class SSLError < Error
+  end
+
+  class ParsingError < Error
+  end
+
   class Response
     def status: () -> Integer
     def headers: () -> untyped

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -121,9 +121,9 @@ module Faraday
     def initialize: (?exc? exc, ?Hash[Symbol, untyped]? response) -> void
     def backtrace: () -> ::Array[String]?
     def inspect: () -> ::String
-    def response_status: () -> untyped?
-    def response_headers: () -> untyped?
-    def response_body: () -> untyped?
+    def response_status: () -> untyped
+    def response_headers: () -> untyped
+    def response_body: () -> untyped
     def exc_msg_and_response!: (?exc? exc, ?Hash[Symbol, untyped]? response) -> String
     def exc_msg_and_response: (?exc? exc, ?Hash[Symbol, untyped]? response) -> [Exception?, String, Hash[Symbol, untyped]?]
   end


### PR DESCRIPTION
This patch introduces signatures for `Faraday::Error` and its subclasses. These classes are used in `:raise_error` internally, but sometimes they would be used in other middlewares. For example, [faraday-retry](https://github.com/lostisland/faraday-retry) has an option of `exceptions`, and its default value includes `Faraday::TimeoutError`. If users want to append other Faraday errors like `Faraday::ServerError`, this patch might be helpful.