### PR TITLE
Remove set library from business_time gem

### DIFF
--- a/gems/business_time/0.13/manifest.yaml
+++ b/gems/business_time/0.13/manifest.yaml
@@ -1,2 +1,0 @@
-dependencies:
-  - name: set


### PR DESCRIPTION
Due to https://github.com/ruby/rbs/issues/1250