### PR TITLE
activesupport Array#in_groups block turn to optional

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -14,3 +14,5 @@ nil.try('round', 2)
 nil.try(:tap) { |n| p n }
 nil.try { p 'hello' }
 nil.try { |n| p n }
+[1, 2, 3, 4].try { |n| p n.in_groups(2) }
+[1, 2, 3, 4].try { |n| n.in_groups(2) { |group| p group } }

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -2174,25 +2174,6 @@ class Array[unchecked out Elem]
   #   ["5"]
   def in_groups_of: (untyped number, ?untyped? fill_with) { (untyped) -> untyped } -> untyped
 
-  # Splits or iterates over the array in +number+ of groups, padding any
-  # remaining slots with +fill_with+ unless it is +false+.
-  #
-  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3) {|group| p group}
-  #   ["1", "2", "3", "4"]
-  #   ["5", "6", "7", nil]
-  #   ["8", "9", "10", nil]
-  #
-  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3, '&nbsp;') {|group| p group}
-  #   ["1", "2", "3", "4"]
-  #   ["5", "6", "7", "&nbsp;"]
-  #   ["8", "9", "10", "&nbsp;"]
-  #
-  #   %w(1 2 3 4 5 6 7).in_groups(3, false) {|group| p group}
-  #   ["1", "2", "3"]
-  #   ["4", "5"]
-  #   ["6", "7"]
-  def in_groups: (untyped number, ?untyped? fill_with) { (untyped) -> untyped } -> untyped
-
   # Divides the array into one or more subarrays based on a delimiting +value+
   # or the result of an optional block.
   #

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -213,3 +213,7 @@ class NilClass
 
 end
 
+class Array[unchecked out Elem]
+  # Manual definition to make block optional
+  def in_groups: (untyped number, ?untyped? fill_with) ?{ (untyped) -> untyped } -> untyped
+end


### PR DESCRIPTION
Block was required in the definition, but in the actual  it was optional.
https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/array/grouping.rb#L62-L86