### PR TITLE
Add signatures for Circuitbox

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /gems/ast               @pocke
 /gems/aws-sdk-*         @ksss
 /gems/business_time     @ksss
+/gems/circuitbox        @yykamei
 /gems/dogstatsd-ruby    @VTRyo
 /gems/faraday           @yykamei
 /gems/globalid          @pocke

--- a/.gitmodules
+++ b/.gitmodules
@@ -139,3 +139,6 @@
 [submodule "gems/google-protobuf/3.22/_src"]
 	path = gems/google-protobuf/3.22/_src
 	url = https://github.com/protocolbuffers/protobuf.git
+[submodule "gems/circuitbox/2.0/_src"]
+	path = gems/circuitbox/2.0/_src
+	url = https://github.com/yammer/circuitbox.git

--- a/gems/circuitbox/2.0/_scripts/test
+++ b/gems/circuitbox/2.0/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r circuitbox:2.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/circuitbox/2.0/_test/Steepfile
+++ b/gems/circuitbox/2.0/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "circuitbox"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/circuitbox/2.0/_test/test.rb
+++ b/gems/circuitbox/2.0/_test/test.rb
@@ -1,0 +1,29 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "circuitbox"
+
+Circuitbox::VERSION
+Circuitbox::FaradayMiddleware
+Circuitbox.circuit(:your_service, exceptions: [ArgumentError]) do
+  :processing!
+end.id2name
+circuit = Circuitbox.circuit(:your_service, exceptions: [ArgumentError])
+circuit.run(exception: false) { :ok }
+
+Circuitbox.configure do |config|
+  config.default_circuit_store
+  config.default_circuit_store = Circuitbox::MemoryStore.new
+  config.default_notifier
+  config.default_notifier = Circuitbox::Notifier::Null.new
+end
+
+notifier = Circuitbox::Notifier::Null.new
+notifier.notify(:your_service, :open)
+notifier.notify_warning(:your_service, :half_open)
+notifier.notify_run(:your_service) { :ok }
+
+notifier = Circuitbox::Notifier::ActiveSupport.new
+notifier.notify(:your_service, :open)
+notifier.notify_warning(:your_service, :half_open)
+notifier.notify_run(:your_service) { :ok }

--- a/gems/circuitbox/2.0/circuitbox.rbs
+++ b/gems/circuitbox/2.0/circuitbox.rbs
@@ -1,0 +1,51 @@
+class Circuitbox
+  VERSION: String
+
+  class CircuitBreaker
+    def run: (?exception: bool) { () -> untyped } -> untyped
+  end
+
+  module Configuration
+    attr_writer default_circuit_store: untyped
+
+    attr_writer default_notifier: untyped
+
+    def self.extended: (untyped base) -> untyped
+
+    def configure: () { (self) -> void } -> nil
+
+    def default_circuit_store: () -> untyped
+
+    def default_notifier: () -> untyped
+  end
+
+  class FaradayMiddleware
+  end
+
+  class MemoryStore
+  end
+
+  module Notifier
+    class ActiveSupport
+      def notify: (untyped circuit_name, _ToS event) -> untyped
+
+      def notify_warning: (untyped circuit_name, untyped message) -> untyped
+
+      def notify_run: (untyped circuit_name) { () -> untyped } -> untyped
+    end
+
+    class Null
+      def notify: (untyped _circuit_name, _ToS _event) -> nil
+
+      def notify_warning: (untyped _circuit_name, untyped _message) -> nil
+
+      def notify_run: (untyped _circuit_name) { () -> untyped } -> untyped
+    end
+  end
+
+  extend Configuration
+
+  # def self.circuit: [T] (String | Symbol service_name, Hash[untyped, untyped] options) ?{ () -> T } -> (CircuitBreaker | T)
+  def self.circuit: (String | Symbol service_name, Hash[untyped, untyped] options) -> CircuitBreaker
+                  | [T] (String | Symbol service_name, Hash[untyped, untyped] options) ?{ () -> T } -> T
+end

--- a/gems/circuitbox/2.0/manifest.yaml
+++ b/gems/circuitbox/2.0/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname


### PR DESCRIPTION
[Circuitbox](https://github.com/yammer/circuitbox) is a [circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) implementation.

This patch adds the fundamental signatures for Circuitbox and is not intended to provide holistic types. I hope Circuitbox users can enjoy typing with the new signatures.