### PR TITLE
Add RBS signatures for moneta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /gems/globalid          @pocke
 /gems/httpclient        @ksss
 /gems/i18n              @takahashim
+/gems/moneta            @yykamei
 /gems/rolify            @ksss
 /gems/stackprof         @pocke
 /gems/rails-dom-testing @ksss

--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,6 @@
 [submodule "gems/circuitbox/2.0/_src"]
 	path = gems/circuitbox/2.0/_src
 	url = https://github.com/yammer/circuitbox.git
+[submodule "gems/moneta/1.6/_src"]
+	path = gems/moneta/1.6/_src
+	url = https://github.com/moneta-rb/moneta.git

--- a/gems/moneta/1.6/_scripts/test
+++ b/gems/moneta/1.6/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r moneta:1.6 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/moneta/1.6/_test/Steepfile
+++ b/gems/moneta/1.6/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "moneta"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/moneta/1.6/_test/test.rb
+++ b/gems/moneta/1.6/_test/test.rb
@@ -1,0 +1,36 @@
+require "moneta"
+
+# @type var key_transformer: ::Moneta::_KeyValueTransformer
+key_transformer = _ = Moneta.new(:File, dir: "data")
+key_transformer.key?("key")
+key_transformer.each_key { |key| key }
+key_transformer.increment("key", 1, { expires: false })
+key_transformer.load("key")
+key_transformer.store("key", 34, expires: 3)
+key_transformer.delete("key", raw: true)
+key_transformer.create("key", "val1", expires: false)
+key_transformer.values_at("key1", "key2")
+key_transformer.fetch_values("key1", "key2", expires: false)
+key_transformer.slice("key1", "key2", expires: false)
+key_transformer.merge!([["key1", 12], ["key2", :ok]], expires: false)
+
+# @type var value_transformer: ::Moneta::_ValueTransformer
+value_transformer = _ = Moneta.new(:File, dir: "data")
+value_transformer.load("key")
+value_transformer.store("key", 34, expires: 3)
+value_transformer.delete("key", raw: true)
+value_transformer.create("key", "val1", expires: false)
+value_transformer.values_at("key1", "key2")
+value_transformer.fetch_values("key1", "key2", expires: false)
+value_transformer.slice("key1", "key2", expires: false)
+value_transformer.merge!({ key1: 1, key2: true }, expires: false)
+
+m = Moneta.build { use :Transformer, key: [:json]; adapter :Memory }
+m.load("key")
+m.store("key", 34, expires: 3)
+m.delete("key", raw: true)
+m.create("key", "val1", expires: false)
+m.values_at("key1", "key2")
+m.fetch_values("key1", "key2", expires: false)
+m.slice("key1", "key2", expires: false)
+m.merge!({ key1: 1, key2: true }, expires: false)

--- a/gems/moneta/1.6/manifest.yaml
+++ b/gems/moneta/1.6/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname

--- a/gems/moneta/1.6/moneta.rbs
+++ b/gems/moneta/1.6/moneta.rbs
@@ -1,0 +1,57 @@
+module Moneta
+  interface _ValueTransformer
+    def load: (untyped key, ?::Hash[untyped, untyped] options) -> untyped
+
+    def store: (untyped key, untyped value, ?::Hash[untyped, untyped] options) -> untyped
+
+    def delete: (untyped key, ?::Hash[untyped, untyped] options) -> untyped
+
+    def create: (untyped key, untyped value, ?::Hash[untyped, untyped] options) -> untyped
+
+    def values_at: (*untyped keys, **untyped options) -> untyped
+
+    def fetch_values: (*untyped keys, **untyped options) ?{ (untyped) -> untyped } -> untyped
+
+    def slice: (*untyped keys, **untyped options) -> untyped
+
+    def merge!: (untyped pairs, ?::Hash[untyped, untyped] options) ?{ (untyped) -> untyped } -> untyped
+  end
+
+  interface _KeyValueTransformer
+    def key?: (untyped key, ?::Hash[untyped, untyped] options) -> bool
+
+    def each_key: () ?{ (untyped) -> untyped } -> untyped
+
+    def increment: (untyped key, ?Integer amount, ?::Hash[untyped, untyped] options) -> untyped
+
+    def load: (untyped key, ?::Hash[untyped, untyped] options) -> untyped
+
+    def store: (untyped key, untyped value, ?::Hash[untyped, untyped] options) -> untyped
+
+    def delete: (untyped key, ?::Hash[untyped, untyped] options) -> untyped
+
+    def create: (untyped key, untyped value, ?::Hash[untyped, untyped] options) -> untyped
+
+    def values_at: (*untyped keys, **untyped options) -> untyped
+
+    def fetch_values: (*untyped keys, **untyped options) ?{ (untyped) -> untyped } -> untyped
+
+    def slice: (*untyped keys, **untyped options) -> untyped
+
+    def merge!: (_ToA[_ToA[untyped]] pairs, ?::Hash[untyped, untyped] options) ?{ (untyped) -> untyped } -> untyped
+  end
+
+  class Builder
+    def initialize: () { () [self: self] -> void } -> void
+
+    def build: () -> Array[untyped]
+
+    def use: (Symbol | Class proxy, ?::Hash[untyped, untyped] options) ?{ (untyped) -> untyped } -> void
+
+    def adapter: (Symbol | Class proxy, ?::Hash[untyped, untyped] options) ?{ (untyped) -> untyped } -> void
+  end
+
+  def self.new: (Symbol name, ?::Hash[untyped, untyped] options) -> (_ValueTransformer | _KeyValueTransformer)
+
+  def self.build: () { () [self: Builder] -> void } -> (_ValueTransformer | _KeyValueTransformer)
+end


### PR DESCRIPTION
This patch adds RBS signatures for [moneta](https://github.com/moneta-rb/moneta).

Moneta is a Gem that provides a consistent interface by absorbing the differences between various types of data stores that support key/value data formats.

In this patch, only the basic interface of Moneta is added as RBS.