### PR TITLE
Add type signatures for activesupport/core_ext/hash/keys.rb

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -16,3 +16,10 @@ nil.try { p 'hello' }
 nil.try { |n| p n }
 [1, 2, 3, 4].in_groups(2)
 [1, 2, 3, 4].in_groups(2) { |group| p group }
+
+hash = { a: 1, b: 2, c: 3 }
+hash.stringify_keys
+hash.stringify_keys!
+
+hash.symbolize_keys
+hash.symbolize_keys!

--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -23,3 +23,10 @@ hash.stringify_keys!
 
 hash.symbolize_keys
 hash.symbolize_keys!
+
+hash = { hoge: { hogefuga: { hogehoge: 1 }, fugahoge: 2 }, fuga: 3 }
+hash.deep_stringify_keys
+hash.deep_stringify_keys!
+
+hash.deep_symbolize_keys
+hash.deep_symbolize_keys!

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -3369,36 +3369,6 @@ class Hash[unchecked out K, unchecked out V]
   # nested hashes and arrays.
   def deep_transform_keys!: () { () -> untyped } -> untyped
 
-  # Returns a new hash with all keys converted to strings.
-  # This includes the keys from the root hash and from all
-  # nested hashes and arrays.
-  #
-  #   hash = { person: { name: 'Rob', age: '28' } }
-  #
-  #   hash.deep_stringify_keys
-  #   # => {"person"=>{"name"=>"Rob", "age"=>"28"}}
-  def deep_stringify_keys: () -> untyped
-
-  # Destructively converts all keys to strings.
-  # This includes the keys from the root hash and from all
-  # nested hashes and arrays.
-  def deep_stringify_keys!: () -> untyped
-
-  # Returns a new hash with all keys converted to symbols, as long as
-  # they respond to +to_sym+. This includes the keys from the root hash
-  # and from all nested hashes and arrays.
-  #
-  #   hash = { 'person' => { 'name' => 'Rob', 'age' => '28' } }
-  #
-  #   hash.deep_symbolize_keys
-  #   # => {:person=>{:name=>"Rob", :age=>"28"}}
-  def deep_symbolize_keys: () -> untyped
-
-  # Destructively converts all keys to symbols, as long as they respond
-  # to +to_sym+. This includes the keys from the root hash and from all
-  # nested hashes and arrays.
-  def deep_symbolize_keys!: () -> untyped
-
   private
 
   # support methods for deep transforming nested hashes and arrays

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -3343,35 +3343,6 @@ class Hash[unchecked out K, unchecked out V]
 end
 
 class Hash[unchecked out K, unchecked out V]
-  # Returns a new hash with all keys converted to strings.
-  #
-  #   hash = { name: 'Rob', age: '28' }
-  #
-  #   hash.stringify_keys
-  #   # => {"name"=>"Rob", "age"=>"28"}
-  def stringify_keys: () -> untyped
-
-  # Destructively converts all keys to strings. Same as
-  # +stringify_keys+, but modifies +self+.
-  def stringify_keys!: () -> untyped
-
-  # Returns a new hash with all keys converted to symbols, as long as
-  # they respond to +to_sym+.
-  #
-  #   hash = { 'name' => 'Rob', 'age' => '28' }
-  #
-  #   hash.symbolize_keys
-  #   # => {:name=>"Rob", :age=>"28"}
-  def symbolize_keys: () -> untyped
-
-  alias to_options symbolize_keys
-
-  # Destructively converts all keys to symbols, as long as they respond
-  # to +to_sym+. Same as +symbolize_keys+, but modifies +self+.
-  def symbolize_keys!: () -> untyped
-
-  alias to_options! symbolize_keys!
-
   # Validates all keys in a hash match <tt>*valid_keys</tt>, raising
   # +ArgumentError+ on a mismatch.
   #

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -173,11 +173,11 @@ class Hash[unchecked out K, unchecked out V]
   def symbolize_keys!: () -> self
   alias to_options! symbolize_keys!
 
-  def deep_stringify_keys: () -> Hash[String, V]
+  def deep_stringify_keys: () -> Hash[String, untyped]
 
   def deep_stringify_keys!: () -> self
 
-  def deep_symbolize_keys: () -> Hash[Symbol, V]
+  def deep_symbolize_keys: () -> Hash[Symbol, untyped]
 
   def deep_symbolize_keys!: () -> self
 end

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -162,6 +162,16 @@ class Hash[unchecked out K, unchecked out V]
   # Manual definition to make block optional
   def deep_merge!: (untyped other_hash) ?{ () -> untyped } -> untyped
                  | ...
+
+  def stringify_keys: () -> Hash[String, V]
+
+  def stringify_keys!: () -> self
+
+  def symbolize_keys: () -> Hash[Symbol, V]
+  alias to_options symbolize_keys
+
+  def symbolize_keys!: () -> self
+  alias to_options! symbolize_keys!
 end
 
 class Module

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -172,6 +172,14 @@ class Hash[unchecked out K, unchecked out V]
 
   def symbolize_keys!: () -> self
   alias to_options! symbolize_keys!
+
+  def deep_stringify_keys: () -> Hash[String, V]
+
+  def deep_stringify_keys!: () -> self
+
+  def deep_symbolize_keys: () -> Hash[Symbol, V]
+
+  def deep_symbolize_keys!: () -> self
 end
 
 class Module


### PR DESCRIPTION
Add RBS signatures for bellow methods.

- Hash#stringify_keys
- Hash#stringify_keys!
- Hash#symbolize_keys
- Hash#symbolize_keys!
- Hash#deep_stringify_keys
- Hash#deep_stringify_keys!
- Hash#deep_symbolize_keys
- Hash#deep_symbolize_keys!