### PR TITLE
Rewrite readme to use `rbs collection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gem_rbs_collection: A collection of RBS for gems
 
 [RBS](https://github.com/ruby/rbs) is a standard type signature syntax for Ruby programs.
-This is a community managed collection of RBS files for gems which ships without RBS.
+This is a community-managed collection of RBS files for gems that ship without RBS.
 
 ## Loading RBS from the repository
 

--- a/README.md
+++ b/README.md
@@ -5,44 +5,20 @@ This is a community-managed collection of RBS files for gems that ship without R
 
 ## Loading RBS from the repository
 
-`git submodule` is the easiest way to import this collection to your project.
+You can use `rbs collection` command to load RBS files from this repository.
 
-```
-# Add new submodule inside your project
-$ git submodule add https://github.com/ruby/gem_rbs_collection.git vendor/rbs/gem_rbs_collection
-```
+```console
+# Create rbs_collection.yaml
+$ rbs collection init
 
-### Using gem RBS from `rbs` command
-
-Specify the path with `--repo` option and use `-r` option to require RBS of a library.
-
-```
-$ rbs --repo vendor/rbs/gem_rbs_collection/gems -r redis list
+# Resolve dependencies and install RBS files from this repository
+$ rbs collection install
 ```
 
-### Using gem RBS from Steep
+If `rbs_collection.yaml` exists, the installed RBSs are loaded automatically.
+You do not need any configuration for `rbs` and `steep` commands.
 
-Steep uses `Steepfile` to configure library RBSs to load.
-
-```rb
-target(:lib) do
-  repo_path "vendor/rbs/gem_rbs_collection/gems"
-  library "redis"
-end
-```
-
-### Loading RBS directory from the repository directory
-
-> This is not recommended, but I'm writing this section to load RBS files for other tools which doesn't support this feature yet.
-
-You can load RBS files through directory path.
-
-```
-$ rbs -I vendor/rbs/gem_rbs_collection/gems/redis/4.2 list
-```
-
-If you load RBS files with directory path, it loads everything in the directory.
-This is different from when loading RBS files with library name that ignores directories starting with `_` (underscore).
+See [collection.md](https://github.com/ruby/rbs/blob/master/docs/collection.md) in ruby/rbs repository for more details.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # gem_rbs_collection: A collection of RBS for gems
 
-**Naming note:** This repository was called `gem_rbs` before. We have renamed the repository to make it more clear that this is a collection of RBS files for gems.
-
 [RBS](https://github.com/ruby/rbs) is a standard type signature syntax for Ruby programs.
 This is a community managed collection of RBS files for gems which ships without RBS.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contribution Guide
 
+## Before you start💎
+
+**If you are the owner of the gem:**
+Adding RBS files directory in your gem would be a better option.
+Write RBS files, put them in `sig` directory, and included the directory in the gem package.
+
 ## Adding RBS of a gem
 
 Adding RBS files for a gem can be done with 4 steps.


### PR DESCRIPTION
I rewrote the README in this PR.

In this day and age, we use `rbs collection` command to use RBSs in this repository.
So I rewrote the README to use `rbs collection`. 


Close #189.
This PR contains #189's changes without the reference for a gem owner. Currently, we do not have documentation for writing RBS by a gem owner. We can add a link to the CONTRIBUTING.md after we write the document. 