### PR TITLE
activerecord: Fix return type of methods in _ActiveRecord_Relation_ClassMethods

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -347,18 +347,18 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def distinct: () -> self
   def or: (Relation) -> Relation
   def merge: (Relation) -> Relation
-  def joins: (*String | Symbol) -> self
-           | (Hash[untyped, untyped]) -> self
-  def left_joins: (*String | Symbol) -> self
-           | (Hash[untyped, untyped]) -> self
-  def left_outer_joins: (*String | Symbol) -> self
-                      | (Hash[untyped, untyped]) -> self
-  def includes: (*String | Symbol) -> self
-              | (Hash[untyped, untyped]) -> self
-  def eager_load: (*String | Symbol) -> self
-                | (Hash[untyped, untyped]) -> self
-  def preload: (*String | Symbol) -> self
-             | (Hash[untyped, untyped]) -> self
+  def joins: (*String | Symbol) -> Relation
+           | (Hash[untyped, untyped]) -> Relation
+  def left_joins: (*String | Symbol) -> Relation
+           | (Hash[untyped, untyped]) -> Relation
+  def left_outer_joins: (*String | Symbol) -> Relation
+                      | (Hash[untyped, untyped]) -> Relation
+  def includes: (*String | Symbol) -> Relation
+              | (Hash[untyped, untyped]) -> Relation
+  def eager_load: (*String | Symbol) -> Relation
+                | (Hash[untyped, untyped]) -> Relation
+  def preload: (*String | Symbol) -> Relation
+             | (Hash[untyped, untyped]) -> Relation
   def find_by: (*untyped) -> Model?
   def find_by!: (*untyped) -> Model
   def find: (PrimaryKey id) -> Model


### PR DESCRIPTION
The return types of some class methods of AR::Base are wrong.  They should return the relation object instead of itself.