### PR TITLE
Add CODEOWNER for Parallel/Rainbow/Retryable gems

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 /gems/httpclient        @ksss
 /gems/i18n              @takahashim
 /gems/moneta            @yykamei
+/gems/parallel          @ybiquitous
+/gems/rainbow           @ybiquitous
+/gems/retryable         @ybiquitous
 /gems/rolify            @ksss
 /gems/simplecov         @ybiquitous
 /gems/stackprof         @pocke


### PR DESCRIPTION
I previously updated the Rainbow gem and added the Parallel/Retryable gems.
- #1
- #6
- #21