### PR TITLE
Improve testing CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,13 @@ on:
       - main
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   syntax_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: rubylang/ruby:3.2-dev-jammy
     steps:
@@ -17,9 +21,11 @@ jobs:
       run: 'gem install rbs'
     - name: 'Test syntax check'
       run: 'rbs parse gems/**/*.rbs'
+
   test_on_changed_gems:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -30,18 +36,31 @@ jobs:
       id: changes
       run: |
         END_MARKER="$(uuidgen)"
-        echo "gems<<${END_MARKER}" >> $GITHUB_OUTPUT
-        gh pr diff ${{ github.event.number }} --name-only | \
+        echo "gems<<${END_MARKER}" >> "$GITHUB_OUTPUT"
+        gh pr diff '${{ github.event.number }}' --name-only | \
           grep '^gems/' | \
           awk -F / '{printf "%s/%s/%s\n", $1, $2, $3}' | \
           sort -u | \
-          tee -a $GITHUB_OUTPUT
-        echo "${END_MARKER}" >> $GITHUB_OUTPUT
+          tee -a "$GITHUB_OUTPUT"
+        echo "${END_MARKER}" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: 'Run test on changed gems'
+    - name: Run test on changed gems
       if: steps.changes.outputs.gems
       run: |
         cat <<EOD | xargs bin/test --verbose
           ${{ steps.changes.outputs.gems }}
         EOD
+
+  test_all_gems:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+    - name: Run test on all gems
+      run: bin/test --all --verbose

--- a/bin/test
+++ b/bin/test
@@ -4,30 +4,30 @@ require "pathname"
 require "optparse"
 require "open3"
 
+@all = false
 @verbose = false
 @repo_root = Pathname(__dir__) + "../gems"
 @repos = []
 
 OptionParser.new do |opts|
+  opts.banner = "Usage: bin/test [options] <gem...>"
+
   opts.on("--root=PATH", "Specify repository root") do |path|
     @repo_root = Pathname(path)
   end
   opts.on("--repo=PATH", "Add more repositories") do |path|
     @repos << Pathname(path)
   end
+  opts.on("-a", "--all", "Test all gems") do @all = true end
   opts.on("-v", "--verbose", "Print more messages") do @verbose = true end
 end.parse!(ARGV)
 
-dirs = ARGV.map {|path| Pathname(path) }
-# if dirs.empty?
-#   (Pathname(__dir__) + "../gems").children.flat_map(&:children).each do |path|
-#     if path.directory?
-#       unless path.basename.to_s.start_with?(".")
-#         dirs << path.relative_path_from(Pathname.pwd)
-#       end
-#     end
-#   end
-# end
+dirs =
+  if @all
+    Pathname(__dir__).glob("../gems/*/*").map {|dir| dir.relative_path_from(Dir.pwd) }
+  else
+    ARGV.map {|path| Pathname(path) }
+  end
 
 def putv(message)
   if @verbose
@@ -37,40 +37,66 @@ def putv(message)
   end
 end
 
-failed_libs = []
+def putci(message)
+  puts message if ENV["CI"]
+end
+
+passed_gems = []
+failed_gems = []
 
 dirs.each do |dir|
-  test_path = dir + "_scripts/test"
+  test_script = dir + "_scripts/test"
   case
-  when !test_path.file?
-    puts "Skipping: cannot find test script at `#{test_path}`..."
-  when !test_path.executable?
-    puts "Skipping: `#{test_path}` is not executable..."
+  when !dir.exist?
+    puts "Skipping: `#{dir}` is not found..."
+    putci "::warning ::`#{dir}` is not found"
+  when !dir.directory?
+    puts "Skipping: `#{dir}` is not a directory..."
+    putci "::warning ::`#{dir}` is not a directory"
+  when !test_script.exist?
+    puts "Skipping: `#{test_script}` is not found..."
+    putci "::warning ::`#{test_script}` is not found"
+  when !test_script.file?
+    puts "Skipping: `#{test_script}` is not a file..."
+    putci "::warning ::`#{test_script}` is not a file"
+  when !test_script.executable?
+    puts "Skipping: `#{test_script}` is not executable..."
+    putci "::warning ::`#{test_script}` is not executable"
   else
-    puts "::group::Test for #{dir}" if ENV['CI']
-    puts "Detected test script: #{test_path}"
+    putci "::group::Test for #{dir}"
+    puts "Detected test script: #{test_script}"
 
     env = {
       "REPO_ROOT" => @repo_root.to_s,
       "REPOS" => @repos.join(File::PATH_SEPARATOR),
       "RBS_DIR" => dir.to_s
     }
-    stdout, status = Open3.capture2(env, test_path.to_s)
-
-    putv(stdout)
+    status = Open3.popen2e(env, test_script.to_s) do |_stdin, stdout_stderr, thread|
+      putv stdout_stderr
+      thread.value
+    end
 
     if status.success?
       puts " => Success 💪"
+      passed_gems << dir
     else
       puts " => Failure 🚨"
-      failed_libs << dir
+      putci "::error ::`#{dir}` test failed"
+      failed_gems << dir
     end
 
-    puts "::endgroup::" if ENV['CI']
+    putci "::endgroup::"
   end
 end
 
-unless failed_libs.empty?
-  puts "Failed: #{failed_libs.join(', ')}"
+unless failed_gems.empty?
+  puts ""
+  puts "# Failed gems"
+  failed_gems.each {|gem| puts gem }
+  exit 1
+end
+
+if passed_gems.empty?
+  puts "No succeeded gems"
   exit 1
 end

--- a/gems/activemodel/6.0/_scripts/test
+++ b/gems/activemodel/6.0/_scripts/test
@@ -3,7 +3,7 @@
 set -xe
 
 REPO=$(git rev-parse --show-toplevel)/gems
-rbs --repo=$REPO \
+bundle exec rbs --repo=$REPO \
   -rmonitor -rdate -rsingleton -rlogger -rmutex_m -ractivesupport -rtime \
   -ractivemodel validate --silent
 


### PR DESCRIPTION
This change mainly does two things.

1. Improve the `bin/test` script
    - add `--all` option
    - fix `--verbose` output
    - add more messages (warnings) for GitHub Actions
    - see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
2. Run test for all gems on CI
    - add a new job
    - run the job only on the `main` branch
    - see the [actual sample on my fork](https://github.com/ybiquitous/gem_rbs_collection/actions/runs/5229039132)
      - <img width="262" alt="image" src="https://github.com/ruby/gem_rbs_collection/assets/473530/56871c69-1be8-4b26-b2e4-0b178b1d9252">
