### PR TITLE
Add #empty? type definitions to activerecord

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -939,7 +939,7 @@ module ActiveRecord
       # <tt>collection.exists?</tt>. If the collection has not already been
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
-      def empty?: () -> untyped
+      def empty?: () -> bool
 
       # Replace this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.


### PR DESCRIPTION
Added type definition for ActiveRecord::CollectionAssociation::CollectionAssociation#empty?.

empty? method returns true or false. 



