### PR TITLE
active-record: add missing after_* callbacks

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -62,6 +62,9 @@ module ActiveRecord
     def self.after_save: (*untyped) ?{ () -> untyped} -> void
     def self.after_update: (*untyped) ?{ () -> untyped} -> void
     def self.after_validation: (*untyped) ?{ () -> untyped} -> void
+    def self.after_initialize: (*untyped) ?{ () -> untyped} -> void
+    def self.after_find: (*untyped) ?{ () -> untyped} -> void
+    def self.after_touch: (*untyped) ?{ () -> untyped} -> void
     def self.around_create: (*untyped) ?{ () -> untyped} -> void
     def self.around_destroy: (*untyped) ?{ () -> untyped} -> void
     def self.around_save: (*untyped) ?{ () -> untyped} -> void


### PR DESCRIPTION
This PR adds three missing callbacks to ActiveRecord signatures:
- `after_initialize`, source: https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/activerecord/lib/active_record/callbacks.rb#L306
- `after_find`, source: https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/activerecord/lib/active_record/callbacks.rb#L314
- `after_touch`, source: https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/activerecord/lib/active_record/callbacks.rb#L322