### PR TITLE
Update RBS to v3.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (2.8.4)
+    rbs (3.1.0)
     securerandom (0.2.2)
     steep (1.4.0)
       activesupport (>= 5.1)


### PR DESCRIPTION
Only protobuf gem's test fails on RBS v3.1.0. I ignore the failure because I do not maintain the gem.