### PR TITLE
Declare dependency from activesupport to securerandom

### DIFF
--- a/gems/activesupport/6.0/manifest.yaml
+++ b/gems/activesupport/6.0/manifest.yaml
@@ -6,3 +6,4 @@ dependencies:
   - name: mutex_m
   - name: time
   - name: pathname
+  - name: securerandom

--- a/gems/activesupport/7.0/manifest.yaml
+++ b/gems/activesupport/7.0/manifest.yaml
@@ -10,3 +10,4 @@ dependencies:
   - name: mutex_m
   - name: singleton
   - name: time
+  - name: securerandom


### PR DESCRIPTION
ActiveSupport implicitly depends on securerandom currently.