### PR TITLE
Specify `rbs` syntax to code snippets in Markdown files

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Focus on the APIs your app is using.
 
 We don't recommend adding top-level type aliases and interfaces.
 
-```
+```rbs
 # Don't do this.
 
 type redis_config = { host: String?, port: Integer? }

--- a/gems/enumerize/2.5/README.md
+++ b/gems/enumerize/2.5/README.md
@@ -8,7 +8,7 @@ The directory that defines the RBS files for the [enumerize](https://github.com/
 
 The most common use cases for this gem would be:
 
-```rb
+```ruby
 # user.rb
 require 'enumerize'
 
@@ -21,7 +21,7 @@ end
 
 In this case, the RBS file should be written as follows:
 
-```
+```rbs
 # user.rbs
 class User
   extend Enumerize


### PR DESCRIPTION
This PR has the same purpose as <https://github.com/ruby/rbs/pull/1366>.
