### PR TITLE
Add GraphQL::Dataloader::Source to graphql

### DIFF
--- a/gems/graphql/1.12/_test/test.rb
+++ b/gems/graphql/1.12/_test/test.rb
@@ -80,3 +80,14 @@ class MySchema < GraphQL::Schema
     raise "error!"
   end
 end
+
+# sample dataloader
+class MyDataloaderSchema < GraphQL::Schema
+  use GraphQL::Dataloader
+end
+
+class MyDataloader < GraphQL::Dataloader::Source
+  def fetch(keys)
+    keys.map { |key| nil }
+  end
+end

--- a/gems/graphql/1.12/_test/test.rbs
+++ b/gems/graphql/1.12/_test/test.rbs
@@ -65,3 +65,10 @@ end
 
 class MySchema < GraphQL::Schema
 end
+
+class MyDataloaderSchema < GraphQL::Schema
+end
+
+class MyDataloader < GraphQL::Dataloader::Source
+  def fetch: (Array[untyped]) -> Array[untyped]
+end

--- a/gems/graphql/1.12/graphql.rbs
+++ b/gems/graphql/1.12/graphql.rbs
@@ -196,5 +196,7 @@ module GraphQL
   class RequiredImplementationMissingError < Error
   end
   class Dataloader
+    class Source
+    end
   end
 end


### PR DESCRIPTION
Add `GraphQL::Dataloader::Source` to graphql gem.
Dataloader inherits from `GraphQL::Dataloader::Source`, so that is all that was added.

https://graphql-ruby.org/dataloader/sources.html
https://graphql-ruby.org/api-doc/1.12.0/GraphQL/Dataloader/Source.html