### PR TITLE
Add processor_counter methods

### DIFF
--- a/gems/concurrent-ruby/1.1/utility/processor_counter.rbs
+++ b/gems/concurrent-ruby/1.1/utility/processor_counter.rbs
@@ -1,0 +1,5 @@
+module Concurrent
+  def self.physical_processor_count: () -> Integer
+
+  def self.processor_count: () -> Integer
+end


### PR DESCRIPTION
Adding the two `ProcessorCounter` methods from https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent-ruby/concurrent/utility/processor_counter.rb.