### PR TITLE
Improve `Rack::BodyProxy` type

### DIFF
--- a/gems/rack/2.2/_test/body_proxy.rb
+++ b/gems/rack/2.2/_test/body_proxy.rb
@@ -1,0 +1,19 @@
+# @type var app: Rack::_Application
+app = _ = nil
+
+middleware = -> (env) do
+  # @type var env: Rack::env
+  # @type block: Rack::response
+
+  status, headers, body = app.call(env)
+
+  body_proxy = Rack::BodyProxy.new(body) do
+    puts "Closed"
+  end #: Rack::BodyProxy & _Each[String]
+
+  body_proxy.close()
+
+  [status, headers, body_proxy]
+end
+
+middleware #: Rack::_Application

--- a/gems/rack/2.2/rack.rbs
+++ b/gems/rack/2.2/rack.rbs
@@ -377,12 +377,15 @@ module Rack
   end
 
   class BodyProxy
-    def initialize: ((Array[(Lint | String)?] | BodyProxy | Lint)? body) ?{ -> nil } -> void
-    def respond_to_missing?: (untyped method_name, ?false include_all) -> bool
+    def initialize: (untyped? body) ?{ () -> void } -> void
+
     def close: -> nil
+
     def closed?: -> bool
-    def each: () { (String) -> void } -> void
-    def method_missing: (:each method_name, *untyped args) ?{ -> (IO | StringIO) } -> untyped
+
+    def respond_to_missing?: (Symbol, ?bool include_all) -> bool
+
+    def method_missing: (Symbol, *untyped args, **untyped kwargs) ?{ () -> untyped } -> untyped
   end
 
   class Cascade


### PR DESCRIPTION
The `BodyProxy` receives any object, forward any method calls to the object, and it yields given block when `#close` is closed.

https://github.com/rack/rack/blob/main/lib/rack/body_proxy.rb