### PR TITLE
Add rbs for geocoder gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -163,3 +163,6 @@
 [submodule "gems/connection_pool/2.4/_src"]
 	path = gems/connection_pool/2.4/_src
 	url = https://github.com/mperham/connection_pool.git
+[submodule "gems/geocoder/1.8/_src"]
+	path = gems/geocoder/1.8/_src
+	url = https://github.com/alexreisner/geocoder.git

--- a/gems/geocoder/1.8/_scripts/test
+++ b/gems/geocoder/1.8/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r geocoder:1.8 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/geocoder/1.8/_test/Steepfile
+++ b/gems/geocoder/1.8/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "geocoder"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/geocoder/1.8/_test/test.rb
+++ b/gems/geocoder/1.8/_test/test.rb
@@ -1,4 +1,0 @@
-# Write Ruby code to test the RBS.
-# It is type checked by `steep check` command.
-
-require "geocoder"

--- a/gems/geocoder/1.8/_test/test.rb
+++ b/gems/geocoder/1.8/_test/test.rb
@@ -1,0 +1,4 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "geocoder"

--- a/gems/geocoder/1.8/_test/test_basic_search.rb
+++ b/gems/geocoder/1.8/_test/test_basic_search.rb
@@ -3,11 +3,11 @@
 require "geocoder"
 
 results = Geocoder.search("Paris")
-results.first.coordinates
+results.first&.coordinates
 
 results = Geocoder.search([48.856614, 2.3522219])
-results.first.address
+results.first&.address
 
 results = Geocoder.search("172.56.21.89")
-results.first.coordinates
-results.first.country
+results.first&.coordinates
+results.first&.country

--- a/gems/geocoder/1.8/_test/test_basic_search.rb
+++ b/gems/geocoder/1.8/_test/test_basic_search.rb
@@ -1,0 +1,13 @@
+#Taken from https://github.com/alexreisner/geocoder/tree/v1.8.0
+
+require "geocoder"
+
+results = Geocoder.search("Paris")
+results.first.coordinates
+
+results = Geocoder.search([48.856614, 2.3522219])
+results.first.address
+
+results = Geocoder.search("172.56.21.89")
+results.first.coordinates
+results.first.country

--- a/gems/geocoder/1.8/geocoder.rbs
+++ b/gems/geocoder/1.8/geocoder.rbs
@@ -1,0 +1,1 @@
+# Write the type definition here!

--- a/gems/geocoder/1.8/geocoder.rbs
+++ b/gems/geocoder/1.8/geocoder.rbs
@@ -1,1 +1,0 @@
-# Write the type definition here!

--- a/gems/geocoder/1.8/geocoder.rbs
+++ b/gems/geocoder/1.8/geocoder.rbs
@@ -2,16 +2,16 @@ module Geocoder
   #
   # Search for information about an address or a set of coordinates.
   #
-  def self.search: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
+  def self.search: (String | [Float, Float] | Query query, ?::Hash[Symbol, untyped] options) -> Array[Result::_Base]
 
   #
   # Look up the coordinates of the given street or IP address.
   #
-  def self.coordinates: (untyped address, ?::Hash[untyped, untyped] options) -> (untyped | nil)
+  def self.coordinates: (String | [Float, Float] | Query address, ?::Hash[Symbol, untyped] options) -> [Float, Float]?
 
   #
   # Look up the address of the given coordinates ([lat,lon])
   # or IP address (string).
   #
-  def self.address: (untyped query, ?::Hash[untyped, untyped] options) -> (untyped | nil)
+  def self.address: (String | [Float, Float] | Query query, ?::Hash[Symbol, untyped] options) -> String?
 end

--- a/gems/geocoder/1.8/geocoder.rbs
+++ b/gems/geocoder/1.8/geocoder.rbs
@@ -1,0 +1,17 @@
+module Geocoder
+  #
+  # Search for information about an address or a set of coordinates.
+  #
+  def self.search: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
+
+  #
+  # Look up the coordinates of the given street or IP address.
+  #
+  def self.coordinates: (untyped address, ?::Hash[untyped, untyped] options) -> (untyped | nil)
+
+  #
+  # Look up the address of the given coordinates ([lat,lon])
+  # or IP address (string).
+  #
+  def self.address: (untyped query, ?::Hash[untyped, untyped] options) -> (untyped | nil)
+end

--- a/gems/geocoder/1.8/geocoder/query.rbs
+++ b/gems/geocoder/1.8/geocoder/query.rbs
@@ -1,0 +1,75 @@
+module Geocoder
+  class Query
+    attr_accessor text: untyped
+
+    attr_accessor options: untyped
+
+    def initialize: (untyped text, ?::Hash[untyped, untyped] options) -> void
+
+    def execute: () -> untyped
+
+    def to_s: () -> untyped
+
+    def sanitized_text: () -> untyped
+
+    #
+    # Get a Lookup object (which communicates with the remote geocoding API)
+    # appropriate to the Query text.
+    #
+    def lookup: () -> untyped
+
+    def url: () -> untyped
+
+    #
+    # Is the Query blank? (ie, should we not bother searching?)
+    # A query is considered blank if its text is nil or empty string AND
+    # no URL parameters are specified.
+    #
+    def blank?: () -> untyped
+
+    #
+    # Does the Query text look like an IP address?
+    #
+    # Does not check for actual validity, just the appearance of four
+    # dot-delimited numbers.
+    #
+    def ip_address?: () -> untyped
+
+    #
+    # Is the Query text a loopback or private IP address?
+    #
+    def internal_ip_address?: () -> untyped
+
+    #
+    # Is the Query text a loopback IP address?
+    #
+    def loopback_ip_address?: () -> untyped
+
+    #
+    # Is the Query text a private IP address?
+    #
+    def private_ip_address?: () -> untyped
+
+    #
+    # Does the given string look like latitude/longitude coordinates?
+    #
+    def coordinates?: () -> untyped
+
+    #
+    # Return the latitude/longitude coordinates specified in the query,
+    # or nil if none.
+    #
+    def coordinates: () -> (untyped | nil)
+
+    #
+    # Should reverse geocoding be performed for this query?
+    #
+    def reverse_geocode?: () -> untyped
+
+    def language: () -> untyped
+
+    private
+
+    def params_given?: () -> untyped
+  end
+end

--- a/gems/geocoder/1.8/geocoder/results/base.rbs
+++ b/gems/geocoder/1.8/geocoder/results/base.rbs
@@ -1,0 +1,48 @@
+module Geocoder
+  module Result
+    class Base
+      # data (hash) fetched from geocoding service
+      attr_accessor data: untyped
+
+      # true if result came from cache, false if from request to geocoding
+      # service; nil if cache is not configured
+      attr_accessor cache_hit: untyped
+
+      #
+      # Takes a hash of data from a parsed geocoding service response.
+      #
+      def initialize: (untyped data) -> void
+
+      #
+      # A string in the given format.
+      #
+      # This default implementation dumbly follows the United States address
+      # format and will return incorrect results for most countries. Some APIs
+      # return properly formatted addresses and those should be funneled
+      # through this method.
+      #
+      def address: (?::Symbol format) -> untyped
+
+      #
+      # A two-element array: [lat, lon].
+      #
+      def coordinates: () -> ::Array[untyped]
+
+      def latitude: () -> untyped
+
+      def longitude: () -> untyped
+
+      def state: () -> untyped
+
+      def province: () -> untyped
+
+      def state_code: () -> untyped
+
+      def province_code: () -> untyped
+
+      def country: () -> untyped
+
+      def country_code: () -> untyped
+    end
+  end
+end

--- a/gems/geocoder/1.8/geocoder/results/base.rbs
+++ b/gems/geocoder/1.8/geocoder/results/base.rbs
@@ -1,5 +1,38 @@
 module Geocoder
   module Result
+    interface _Base
+      #
+      # A string in the given format.
+      #
+      # This default implementation dumbly follows the United States address
+      # format and will return incorrect results for most countries. Some APIs
+      # return properly formatted addresses and those should be funneled
+      # through this method.
+      #
+      def address: (?::Symbol format) -> String?
+
+      #
+      # A two-element array: [lat, lon].
+      #
+      def coordinates: () -> [Float, Float]
+
+      def latitude: () -> Float
+
+      def longitude: () -> Float
+
+      def state: () -> String?
+
+      def province: () -> String?
+
+      def state_code: () -> String?
+
+      def province_code: () -> String?
+
+      def country: () -> String?
+
+      def country_code: () -> String?
+    end
+
     class Base
       # data (hash) fetched from geocoding service
       attr_accessor data: untyped
@@ -13,36 +46,7 @@ module Geocoder
       #
       def initialize: (untyped data) -> void
 
-      #
-      # A string in the given format.
-      #
-      # This default implementation dumbly follows the United States address
-      # format and will return incorrect results for most countries. Some APIs
-      # return properly formatted addresses and those should be funneled
-      # through this method.
-      #
-      def address: (?::Symbol format) -> untyped
-
-      #
-      # A two-element array: [lat, lon].
-      #
-      def coordinates: () -> ::Array[untyped]
-
-      def latitude: () -> untyped
-
-      def longitude: () -> untyped
-
-      def state: () -> untyped
-
-      def province: () -> untyped
-
-      def state_code: () -> untyped
-
-      def province_code: () -> untyped
-
-      def country: () -> untyped
-
-      def country_code: () -> untyped
+      include _Base
     end
   end
 end

--- a/gems/geocoder/1.8/manifest.yaml
+++ b/gems/geocoder/1.8/manifest.yaml
@@ -1,7 +1,0 @@
-# manifest.yaml describes dependencies which do not appear in the gemspec.
-# If this gem includes such dependencies, comment-out the following lines and
-# declare the dependencies.
-# If all dependencies appear in the gemspec, you should remove this file.
-#
-# dependencies:
-#   - name: pathname

--- a/gems/geocoder/1.8/manifest.yaml
+++ b/gems/geocoder/1.8/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname


### PR DESCRIPTION
Add rbs for [geocoder](https://github.com/alexreisner/geocoder) gem.
Geocoder is "Complete geocoding solution for Ruby."

- Add test for ["Basic Search"](https://github.com/alexreisner/geocoder/tree/v1.8.0#basic-search).
- Add class and module definitions with `rbs prototype rb`
- Update geocoder rbs for "Basic Search".