### PR TITLE
Fix init_new_gems

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,12 @@
 # except files which have code owners.
 *                    @pocke
 
+# Misc
+/generators/aws-sdk-rbs-generator @ksss
+/generators/yard-generator @ksss
+
+# *** DON'T EDIT LINES BELOW (see bin/init_new_gem) ***
+
 # Maintainer of individual gems (alphabetical order)
 /gems/ast               @pocke
 /gems/aws-sdk-*         @ksss
@@ -21,7 +27,3 @@
 /gems/stackprof         @pocke
 /gems/rails-dom-testing @ksss
 /gems/yard              @ksss
-
-# Misc
-/generators/aws-sdk-rbs-generator @ksss
-/generators/yard-generator @ksss

--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -124,25 +124,25 @@ if git_repo
 end
 
 if github_account
+  github_account = "@#{github_account}" unless github_account.start_with?('@')
   update(Pathname('.github/CODEOWNERS')) do |content|
     lines = content.lines
-    insert_idx = nil
-    at_col = nil
-    entered = false
-    lines.each.with_index do |line, idx|
-      insert_idx = idx and break if entered && !line.match?(%r!^/gems/!)
-      next unless entered = line.match?(%r!^/gems/!)
-      insert_idx = idx
-      at_col ||= line.index('@')
 
-      break if "/gems/#{gem_name}" < line
+    pre_gems_lines, gems_lines = 
+      lines.map(&:chomp).slice_before('# Maintainer of individual gems (alphabetical order)').to_a
+    pre_gems_lines << gems_lines.shift
+
+    gems_lines << "/gems/#{gem_name} #{github_account}"
+    gems_lines.sort!
+
+    gems = gems_lines.map {|line| line.split }
+    longest_gem_size = gems.map {|gem, _| gem.size }.max
+    gem_lines = gems.map do |gem, owner|
+      space = " " * (longest_gem_size - gem.size)
+      "#{gem}#{space} #{owner}"
     end
 
-    insert_line = "/gems/#{gem_name}"
-    insert_line += ' ' * (at_col - insert_line.size)
-    insert_line += "@#{github_account}\n"
-    lines.insert(insert_idx, insert_line)
-    lines.join
+    (pre_gems_lines + gem_lines).join("\n")
   end
 end
 


### PR DESCRIPTION
This PR fixes `bin/init_new_gems` to support gems with names longer than existing ones.

It fails if we give longer name with the following error:

```
bin/init_new_gem:142:in `*': negative argument (ArgumentError)

    insert_line += ' ' * (at_col - insert_line.size)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
        from bin/init_new_gem:142:in `block in <main>'
        from bin/init_new_gem:34:in `update'
        from bin/init_new_gem:127:in `<main>'
```

The `insert_line.size` may be bigger than any existing gem names.