### PR TITLE
Add rbs for flipper gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,3 +169,6 @@
 [submodule "gems/shoryuken/6.0/_src"]
 	path = gems/shoryuken/6.0/_src
 	url = https://github.com/ruby-shoryuken/shoryuken.git
+[submodule "gems/flipper/0.28/_src"]
+	path = gems/flipper/0.28/_src
+	url = https://github.com/flippercloud/flipper.git

--- a/gems/flipper/0.28/_scripts/test
+++ b/gems/flipper/0.28/_scripts/test
@@ -12,7 +12,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r flipper:0.28 validate --silent
+bundle exec rbs --repo $REPO_DIR -r flipper:0.28 -r forwardable:0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/flipper/0.28/_scripts/test
+++ b/gems/flipper/0.28/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r flipper:0.28 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/flipper/0.28/_test/Steepfile
+++ b/gems/flipper/0.28/_test/Steepfile
@@ -6,6 +6,7 @@ target :test do
 
   repo_path "../../../"
   library "flipper"
+  library "forwardable"
 
   configure_code_diagnostics(D::Ruby.all_error)
 end

--- a/gems/flipper/0.28/_test/Steepfile
+++ b/gems/flipper/0.28/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "flipper"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/flipper/0.28/_test/test.rb
+++ b/gems/flipper/0.28/_test/test.rb
@@ -1,0 +1,4 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "flipper"

--- a/gems/flipper/0.28/_test/test.rb
+++ b/gems/flipper/0.28/_test/test.rb
@@ -1,4 +1,0 @@
-# Write Ruby code to test the RBS.
-# It is type checked by `steep check` command.
-
-require "flipper"

--- a/gems/flipper/0.28/_test/test_basic.rb
+++ b/gems/flipper/0.28/_test/test_basic.rb
@@ -1,0 +1,21 @@
+# Taken from https://github.com/flippercloud/flipper/blob/v0.28.0/examples/basic.rb
+
+require 'bundler/setup'
+require 'flipper'
+
+# check if search is enabled
+if Flipper.enabled?(:search)
+  puts 'Search away!'
+else
+  puts 'No search for you!'
+end
+
+puts 'Enabling Search...'
+Flipper.enable(:search)
+
+# check if search is enabled
+if Flipper.enabled?(:search)
+  puts 'Search away!'
+else
+  puts 'No search for you!'
+end

--- a/gems/flipper/0.28/_test/test_configuring_default.rb
+++ b/gems/flipper/0.28/_test/test_configuring_default.rb
@@ -1,0 +1,21 @@
+# Taken from https://github.com/flippercloud/flipper/blob/v0.28.0/examples/configuring_default.rb
+
+require 'bundler/setup'
+require 'flipper'
+
+# sets up default adapter so Flipper works like Flipper::DSL
+Flipper.configure do |config|
+  config.adapter { Flipper::Adapters::Memory.new }
+end
+
+puts Flipper.enabled?(:search) # => false
+Flipper.enable(:search)
+puts Flipper.enabled?(:search) # => true
+Flipper.disable(:search)
+
+enabled_actor = Flipper::Actor.new("1")
+disabled_actor = Flipper::Actor.new("2")
+Flipper.enable_actor(:search, enabled_actor)
+
+puts Flipper.enabled?(:search, enabled_actor)
+puts Flipper.enabled?(:search, disabled_actor)

--- a/gems/flipper/0.28/flipper.rbs
+++ b/gems/flipper/0.28/flipper.rbs
@@ -1,0 +1,1 @@
+# Write the type definition here!

--- a/gems/flipper/0.28/flipper.rbs
+++ b/gems/flipper/0.28/flipper.rbs
@@ -1,4 +1,6 @@
 module Flipper
+  type name_type = String | Symbol
+
   extend ::Flipper
 
   extend Forwardable
@@ -17,13 +19,13 @@ module Flipper
   #   end
   #
   # Yields Flipper::Configuration instance.
-  def configure: () ?{ (untyped) -> untyped } -> (untyped | nil)
+  def configure: () ?{ (Configuration) -> void } -> void
 
   # Public: Returns Flipper::Configuration instance.
-  def configuration: () -> untyped
+  def configuration: () -> Configuration
 
   # Public: Sets Flipper::Configuration instance.
-  def configuration=: (untyped configuration) -> untyped
+  def configuration=: (Configuration configuration) -> untyped
 
   # Public: Default per thread flipper instance if configured. You should not
   # need to use this directly as most of the Flipper::DSL methods are delegated
@@ -32,6 +34,8 @@ module Flipper
   #
   # Returns Flipper::DSL instance.
   def instance: () -> untyped
+  
+  include DSL::_DelegateMethods
 
   # Public: Set the flipper instance. It is most common to use the
   # Configuration#default to set this instance, but for things like the test

--- a/gems/flipper/0.28/flipper.rbs
+++ b/gems/flipper/0.28/flipper.rbs
@@ -1,1 +1,91 @@
-# Write the type definition here!
+module Flipper
+  extend ::Flipper
+
+  extend Forwardable
+
+  # Private: The namespace for all instrumented events.
+  InstrumentationNamespace: :flipper
+
+  # Public: Start here. Given an adapter returns a handy DSL to all the flipper
+  # goodness. To see supported options, check out dsl.rb.
+  def new: (untyped adapter, ?::Hash[untyped, untyped] options) -> untyped
+
+  # Public: Configure flipper.
+  #
+  #   Flipper.configure do |config|
+  #     config.adapter { ... }
+  #   end
+  #
+  # Yields Flipper::Configuration instance.
+  def configure: () ?{ (untyped) -> untyped } -> (untyped | nil)
+
+  # Public: Returns Flipper::Configuration instance.
+  def configuration: () -> untyped
+
+  # Public: Sets Flipper::Configuration instance.
+  def configuration=: (untyped configuration) -> untyped
+
+  # Public: Default per thread flipper instance if configured. You should not
+  # need to use this directly as most of the Flipper::DSL methods are delegated
+  # from Flipper module itself. Instead of doing Flipper.instance.enabled?(:search),
+  # you can use Flipper.enabled?(:search) for the same result.
+  #
+  # Returns Flipper::DSL instance.
+  def instance: () -> untyped
+
+  # Public: Set the flipper instance. It is most common to use the
+  # Configuration#default to set this instance, but for things like the test
+  # environment, this writer is actually useful.
+  def instance=: (untyped flipper) -> untyped
+
+  # Public: Use this to register a group by name.
+  #
+  # name - The Symbol name of the group.
+  # block - The block that should be used to determine if the group matches a
+  #         given actor.
+  #
+  # Examples
+  #
+  #   Flipper.register(:admins) { |actor|
+  #     actor.respond_to?(:admin?) && actor.admin?
+  #   }
+  #
+  # Returns a Flipper::Group.
+  # Raises Flipper::DuplicateGroup if the group is already registered.
+  def register: (untyped name) { () -> untyped } -> untyped
+
+  # Public: Returns a Set of registered Types::Group instances.
+  def groups: () -> untyped
+
+  # Public: Returns a Set of symbols where each symbol is a registered
+  # group name. If you just want the names, this is more efficient than doing
+  # `Flipper.groups.map(&:name)`.
+  def group_names: () -> untyped
+
+  # Public: Clears the group registry.
+  #
+  # Returns nothing.
+  def unregister_groups: () -> untyped
+
+  # Public: Check if a group exists
+  #
+  # Returns boolean
+  def group_exists?: (untyped name) -> untyped
+
+  # Public: Fetches a group by name.
+  #
+  # name - The Symbol name of the group.
+  #
+  # Examples
+  #
+  #   Flipper.group(:admins)
+  #
+  # Returns Flipper::Group.
+  def group: (untyped name) -> untyped
+
+  # Internal: Registry of all groups_registry.
+  def groups_registry: () -> untyped
+
+  # Internal: Change the groups_registry registry.
+  def groups_registry=: (untyped registry) -> untyped
+end

--- a/gems/flipper/0.28/flipper/actor.rbs
+++ b/gems/flipper/0.28/flipper/actor.rbs
@@ -1,0 +1,15 @@
+# Simple class for turning a flipper_id into an actor that can be based
+# to Flipper::Feature#enabled?.
+module Flipper
+  class Actor
+    attr_reader flipper_id: untyped
+
+    def initialize: (untyped flipper_id) -> void
+
+    def eql?: (untyped other) -> untyped
+
+    alias == eql?
+
+    def hash: () -> untyped
+  end
+end

--- a/gems/flipper/0.28/flipper/adapter.rbs
+++ b/gems/flipper/0.28/flipper/adapter.rbs
@@ -1,0 +1,38 @@
+module Flipper
+  # Adding a module include so we have some hooks for stuff down the road
+  module Adapter
+    def self.included: (untyped base) -> untyped
+
+    module ClassMethods
+      # Public: Default config for a feature's gate values.
+      def default_config: () -> { boolean: nil, groups: untyped, actors: untyped, percentage_of_actors: nil, percentage_of_time: nil }
+
+      def from: (untyped source) -> untyped
+    end
+
+    # Public: Get all features and gate values in one call. Defaults to one call
+    # to features and another to get_multi. Feel free to override per adapter to
+    # make this more efficient.
+    def get_all: () -> untyped
+
+    # Public: Get multiple features in one call. Defaults to one get per
+    # feature. Feel free to override per adapter to make this more efficient and
+    # reduce network calls.
+    def get_multi: (untyped features) -> untyped
+
+    # Public: Ensure that adapter is in sync with source adapter provided.
+    #
+    # source - The source dsl, adapter or export to import.
+    #
+    # Returns true if successful.
+    def import: (untyped source) -> true
+
+    # Public: Exports the adapter in a given format for a given format version.
+    #
+    # Returns a Flipper::Export instance.
+    def export: (?format: ::Symbol, ?version: ::Integer) -> untyped
+
+    # Public: Default config for a feature's gate values.
+    def default_config: () -> untyped
+  end
+end

--- a/gems/flipper/0.28/flipper/adapters/memory.rbs
+++ b/gems/flipper/0.28/flipper/adapters/memory.rbs
@@ -1,0 +1,49 @@
+module Flipper
+  module Adapters
+    # Public: Adapter for storing everything in memory.
+    # Useful for tests/specs.
+    class Memory
+      include ::Flipper::Adapter
+
+      FeaturesKey: :features
+
+      # Public: The name of the adapter.
+      attr_reader name: untyped
+
+      # Public
+      def initialize: (?untyped? source) -> void
+
+      # Public: The set of known features.
+      def features: () -> untyped
+
+      # Public: Adds a feature to the set of known features.
+      def add: (untyped feature) -> true
+
+      # Public: Removes a feature from the set of known features and clears
+      # all the values for the feature.
+      def remove: (untyped feature) -> true
+
+      # Public: Clears all the gate values for a feature.
+      def clear: (untyped feature) -> true
+
+      # Public
+      def get: (untyped feature) -> untyped
+
+      def get_multi: (untyped features) -> untyped
+
+      def get_all: () -> untyped
+
+      # Public
+      def enable: (untyped feature, untyped gate, untyped thing) -> untyped
+
+      # Public
+      def disable: (untyped feature, untyped gate, untyped thing) -> untyped
+
+      # Public
+      def inspect: () -> ::String
+
+      # Public: a more efficient implementation of import for this adapter
+      def import: (untyped source) -> true
+    end
+  end
+end

--- a/gems/flipper/0.28/flipper/configuration.rbs
+++ b/gems/flipper/0.28/flipper/configuration.rbs
@@ -1,0 +1,43 @@
+module Flipper
+  class Configuration
+    def initialize: (?::Hash[untyped, untyped] options) -> void
+
+    # The default adapter to use.
+    #
+    # Pass a block to assign the adapter, and invoke without a block to
+    # return the configured adapter instance.
+    #
+    #   Flipper.configure do |config|
+    #     config.adapter # => instance of default Memory adapter
+    #
+    #     # Configure it to use the ActiveRecord adapter
+    #     config.adapter do
+    #       require "flipper/adapters/active_record"
+    #       Flipper::Adapters::ActiveRecord.new
+    #     end
+    #
+    #     config.adapter # => instance of ActiveRecord adapter
+    #  end
+    #
+    def adapter: () ?{ () -> untyped } -> untyped
+
+    # Controls the default instance for flipper. When used with a block it
+    # assigns a new default block to use to generate an instance. When used
+    # without a block, it performs a block invocation and returns the result.
+    #
+    #   configuration = Flipper::Configuration.new
+    #   configuration.default # => Flipper::DSL instance using Memory adapter
+    #
+    #   # sets the default block to generate a new instance using ActiveRecord adapter
+    #   configuration.default do
+    #     require "flipper/adapters/active_record"
+    #     Flipper.new(Flipper::Adapters::ActiveRecord.new)
+    #   end
+    #
+    #   configuration.default # => Flipper::DSL instance using ActiveRecord adapter
+    #
+    # Returns result of default block invocation if called without block. If
+    # called with block, assigns the default block.
+    def default: () ?{ () -> untyped } -> untyped
+  end
+end

--- a/gems/flipper/0.28/flipper/dsl.rbs
+++ b/gems/flipper/0.28/flipper/dsl.rbs
@@ -1,5 +1,201 @@
 module Flipper
   class DSL
+    interface _DelegateMethods
+      # Public: Check if a feature is enabled.
+      #
+      # name - The String or Symbol name of the feature.
+      # args - The args passed through to the enabled check.
+      #
+      # Returns true if feature is enabled, false if not.
+      def enabled?: (name_type name, *untyped args) -> bool
+
+      # Public: Enable a feature.
+      #
+      # name - The String or Symbol name of the feature.
+      # args - The args passed through to the feature instance enable call.
+      #
+      # Returns the result of the feature instance enable call.
+      def enable: (name_type name, *untyped args) -> bool
+
+      # Public: Enable a feature for an actor.
+      #
+      # name - The String or Symbol name of the feature.
+      # actor - a Flipper::Types::Actor instance or an object that responds
+      #         to flipper_id.
+      #
+      # Returns result of Feature#enable.
+      def enable_actor: (name_type name, untyped actor) -> untyped
+
+      # Public: Enable a feature for a group.
+      #
+      # name - The String or Symbol name of the feature.
+      # group - a Flipper::Types::Group instance or a String or Symbol name of a
+      #         registered group.
+      #
+      # Returns result of Feature#enable.
+      def enable_group: (name_type name, untyped group) -> untyped
+
+      # Public: Enable a feature a percentage of time.
+      #
+      # name - The String or Symbol name of the feature.
+      # percentage - a Flipper::Types::PercentageOfTime instance or an object
+      #              that responds to to_i.
+      #
+      # Returns result of Feature#enable.
+      def enable_percentage_of_time: (name_type name, untyped percentage) -> untyped
+
+      # Public: Enable a feature for a percentage of actors.
+      #
+      # name - The String or Symbol name of the feature.
+      # percentage - a Flipper::Types::PercentageOfActors instance or an object
+      #              that responds to to_i.
+      #
+      # Returns result of Feature#enable.
+      def enable_percentage_of_actors: (name_type name, untyped percentage) -> untyped
+
+      # Public: Disable a feature.
+      #
+      # name - The String or Symbol name of the feature.
+      # args - The args passed through to the feature instance enable call.
+      #
+      # Returns the result of the feature instance disable call.
+      def disable: (name_type name, *untyped args) -> bool
+
+      # Public: Disable a feature for an actor.
+      #
+      # name - The String or Symbol name of the feature.
+      # actor - a Flipper::Types::Actor instance or an object that responds
+      #         to flipper_id.
+      #
+      # Returns result of disable.
+      def disable_actor: (name_type name, untyped actor) -> untyped
+
+      # Public: Disable a feature for a group.
+      #
+      # name - The String or Symbol name of the feature.
+      # group - a Flipper::Types::Group instance or a String or Symbol name of a
+      #         registered group.
+      #
+      # Returns result of disable.
+      def disable_group: (name_type name, untyped group) -> untyped
+
+      # Public: Disable a feature a percentage of time.
+      #
+      # name - The String or Symbol name of the feature.
+      # percentage - a Flipper::Types::PercentageOfTime instance or an object
+      #              that responds to to_i.
+      #
+      # Returns result of disable.
+      def disable_percentage_of_time: (name_type name) -> untyped
+
+      # Public: Disable a feature for a percentage of actors.
+      #
+      # name - The String or Symbol name of the feature.
+      # percentage - a Flipper::Types::PercentageOfActors instance or an object
+      #              that responds to to_i.
+      #
+      # Returns result of disable.
+      def disable_percentage_of_actors: (name_type name) -> untyped
+
+      # Public: Add a feature.
+      #
+      # name - The String or Symbol name of the feature.
+      #
+      # Returns result of add.
+      def add: (name_type name) -> untyped
+
+      # Public: Has a feature been added in the adapter.
+      #
+      # name - The String or Symbol name of the feature.
+      #
+      # Returns true if added else false.
+      def exist?: (name_type name) -> untyped
+
+      # Public: Remove a feature.
+      #
+      # name - The String or Symbol name of the feature.
+      #
+      # Returns result of remove.
+      def remove: (name_type name) -> untyped
+
+      # Public: Access a feature instance by name.
+      #
+      # name - The String or Symbol name of the feature.
+      #
+      # Returns an instance of Flipper::Feature.
+      def feature: (name_type name) -> untyped
+
+      # Public: Preload the features with the given names.
+      #
+      # names - An Array of String or Symbol names of the features.
+      #
+      # Returns an Array of Flipper::Feature.
+      def preload: (untyped names) -> untyped
+
+      # Public: Preload all the adapters features.
+      #
+      # Returns an Array of Flipper::Feature.
+      def preload_all: () -> untyped
+
+      # Public: Shortcut access to a feature instance by name.
+      #
+      # name - The String or Symbol name of the feature.
+      #
+      # Returns an instance of Flipper::Feature.
+      alias [] feature
+
+      # Public: Shortcut for getting a boolean type instance.
+      #
+      # value - The true or false value for the boolean.
+      #
+      # Returns a Flipper::Types::Boolean instance.
+      def boolean: (?bool value) -> untyped
+
+      # Public: Even shorter shortcut for getting a boolean type instance.
+      #
+      # value - The true or false value for the boolean.
+      #
+      # Returns a Flipper::Types::Boolean instance.
+      alias bool boolean
+
+      # Public: Wraps an object as a flipper actor.
+      #
+      # actor - The object that you would like to wrap.
+      #
+      # Returns an instance of Flipper::Types::Actor.
+      # Raises ArgumentError if actor does not respond to `flipper_id`.
+      def actor: (untyped actor) -> untyped
+
+      # Public: Shortcut for getting a percentage of time instance.
+      #
+      # number - The percentage of time that should be enabled.
+      #
+      # Returns Flipper::Types::PercentageOfTime.
+      def time: (untyped number) -> untyped
+
+      alias percentage_of_time time
+
+      # Public: Shortcut for getting a percentage of actors instance.
+      #
+      # number - The percentage of actors that should be enabled.
+      #
+      # Returns Flipper::Types::PercentageOfActors.
+      def actors: (untyped number) -> untyped
+
+      alias percentage_of_actors actors
+
+      # Public: Returns a Set of the known features for this adapter.
+      #
+      # Returns Set of Flipper::Feature instances.
+      def features: () -> untyped
+
+      # Cloud DSL method that does nothing for open source version.
+      def sync: () -> nil
+
+      # Cloud DSL method that does nothing for open source version.
+      def sync_secret: () -> nil
+    end
+
     extend Forwardable
 
     # Private
@@ -16,205 +212,13 @@ module Flipper
     #           :memoize - Should adapter be wrapped by memoize adapter or not.
     def initialize: (untyped adapter, ?::Hash[untyped, untyped] options) -> void
 
-    # Public: Check if a feature is enabled.
-    #
-    # name - The String or Symbol name of the feature.
-    # args - The args passed through to the enabled check.
-    #
-    # Returns true if feature is enabled, false if not.
-    def enabled?: (untyped name, *untyped args) -> untyped
-
-    # Public: Enable a feature.
-    #
-    # name - The String or Symbol name of the feature.
-    # args - The args passed through to the feature instance enable call.
-    #
-    # Returns the result of the feature instance enable call.
-    def enable: (untyped name, *untyped args) -> untyped
-
-    # Public: Enable a feature for an actor.
-    #
-    # name - The String or Symbol name of the feature.
-    # actor - a Flipper::Types::Actor instance or an object that responds
-    #         to flipper_id.
-    #
-    # Returns result of Feature#enable.
-    def enable_actor: (untyped name, untyped actor) -> untyped
-
-    # Public: Enable a feature for a group.
-    #
-    # name - The String or Symbol name of the feature.
-    # group - a Flipper::Types::Group instance or a String or Symbol name of a
-    #         registered group.
-    #
-    # Returns result of Feature#enable.
-    def enable_group: (untyped name, untyped group) -> untyped
-
-    # Public: Enable a feature a percentage of time.
-    #
-    # name - The String or Symbol name of the feature.
-    # percentage - a Flipper::Types::PercentageOfTime instance or an object
-    #              that responds to to_i.
-    #
-    # Returns result of Feature#enable.
-    def enable_percentage_of_time: (untyped name, untyped percentage) -> untyped
-
-    # Public: Enable a feature for a percentage of actors.
-    #
-    # name - The String or Symbol name of the feature.
-    # percentage - a Flipper::Types::PercentageOfActors instance or an object
-    #              that responds to to_i.
-    #
-    # Returns result of Feature#enable.
-    def enable_percentage_of_actors: (untyped name, untyped percentage) -> untyped
-
-    # Public: Disable a feature.
-    #
-    # name - The String or Symbol name of the feature.
-    # args - The args passed through to the feature instance enable call.
-    #
-    # Returns the result of the feature instance disable call.
-    def disable: (untyped name, *untyped args) -> untyped
-
-    # Public: Disable a feature for an actor.
-    #
-    # name - The String or Symbol name of the feature.
-    # actor - a Flipper::Types::Actor instance or an object that responds
-    #         to flipper_id.
-    #
-    # Returns result of disable.
-    def disable_actor: (untyped name, untyped actor) -> untyped
-
-    # Public: Disable a feature for a group.
-    #
-    # name - The String or Symbol name of the feature.
-    # group - a Flipper::Types::Group instance or a String or Symbol name of a
-    #         registered group.
-    #
-    # Returns result of disable.
-    def disable_group: (untyped name, untyped group) -> untyped
-
-    # Public: Disable a feature a percentage of time.
-    #
-    # name - The String or Symbol name of the feature.
-    # percentage - a Flipper::Types::PercentageOfTime instance or an object
-    #              that responds to to_i.
-    #
-    # Returns result of disable.
-    def disable_percentage_of_time: (untyped name) -> untyped
-
-    # Public: Disable a feature for a percentage of actors.
-    #
-    # name - The String or Symbol name of the feature.
-    # percentage - a Flipper::Types::PercentageOfActors instance or an object
-    #              that responds to to_i.
-    #
-    # Returns result of disable.
-    def disable_percentage_of_actors: (untyped name) -> untyped
-
-    # Public: Add a feature.
-    #
-    # name - The String or Symbol name of the feature.
-    #
-    # Returns result of add.
-    def add: (untyped name) -> untyped
-
-    # Public: Has a feature been added in the adapter.
-    #
-    # name - The String or Symbol name of the feature.
-    #
-    # Returns true if added else false.
-    def exist?: (untyped name) -> untyped
-
-    # Public: Remove a feature.
-    #
-    # name - The String or Symbol name of the feature.
-    #
-    # Returns result of remove.
-    def remove: (untyped name) -> untyped
-
-    # Public: Access a feature instance by name.
-    #
-    # name - The String or Symbol name of the feature.
-    #
-    # Returns an instance of Flipper::Feature.
-    def feature: (untyped name) -> untyped
-
-    # Public: Preload the features with the given names.
-    #
-    # names - An Array of String or Symbol names of the features.
-    #
-    # Returns an Array of Flipper::Feature.
-    def preload: (untyped names) -> untyped
-
-    # Public: Preload all the adapters features.
-    #
-    # Returns an Array of Flipper::Feature.
-    def preload_all: () -> untyped
-
-    # Public: Shortcut access to a feature instance by name.
-    #
-    # name - The String or Symbol name of the feature.
-    #
-    # Returns an instance of Flipper::Feature.
-    alias [] feature
-
-    # Public: Shortcut for getting a boolean type instance.
-    #
-    # value - The true or false value for the boolean.
-    #
-    # Returns a Flipper::Types::Boolean instance.
-    def boolean: (?bool value) -> untyped
-
-    # Public: Even shorter shortcut for getting a boolean type instance.
-    #
-    # value - The true or false value for the boolean.
-    #
-    # Returns a Flipper::Types::Boolean instance.
-    alias bool boolean
+    include _DelegateMethods
 
     # Public: Access a flipper group by name.
     #
     # name - The String or Symbol name of the feature.
     #
     # Returns an instance of Flipper::Group.
-    def group: (untyped name) -> untyped
-
-    # Public: Wraps an object as a flipper actor.
-    #
-    # actor - The object that you would like to wrap.
-    #
-    # Returns an instance of Flipper::Types::Actor.
-    # Raises ArgumentError if actor does not respond to `flipper_id`.
-    def actor: (untyped actor) -> untyped
-
-    # Public: Shortcut for getting a percentage of time instance.
-    #
-    # number - The percentage of time that should be enabled.
-    #
-    # Returns Flipper::Types::PercentageOfTime.
-    def time: (untyped number) -> untyped
-
-    alias percentage_of_time time
-
-    # Public: Shortcut for getting a percentage of actors instance.
-    #
-    # number - The percentage of actors that should be enabled.
-    #
-    # Returns Flipper::Types::PercentageOfActors.
-    def actors: (untyped number) -> untyped
-
-    alias percentage_of_actors actors
-
-    # Public: Returns a Set of the known features for this adapter.
-    #
-    # Returns Set of Flipper::Feature instances.
-    def features: () -> untyped
-
-    # Cloud DSL method that does nothing for open source version.
-    def sync: () -> nil
-
-    # Cloud DSL method that does nothing for open source version.
-    def sync_secret: () -> nil
+    def group: (name_type name) -> untyped
   end
 end

--- a/gems/flipper/0.28/flipper/dsl.rbs
+++ b/gems/flipper/0.28/flipper/dsl.rbs
@@ -1,0 +1,220 @@
+module Flipper
+  class DSL
+    extend Forwardable
+
+    # Private
+    attr_reader adapter: untyped
+
+    # Private: What is being used to instrument all the things.
+    attr_reader instrumenter: untyped
+
+    # Public: Returns a new instance of the DSL.
+    #
+    # adapter - The adapter that this DSL instance should use.
+    # options - The Hash of options.
+    #           :instrumenter - What should be used to instrument all the things.
+    #           :memoize - Should adapter be wrapped by memoize adapter or not.
+    def initialize: (untyped adapter, ?::Hash[untyped, untyped] options) -> void
+
+    # Public: Check if a feature is enabled.
+    #
+    # name - The String or Symbol name of the feature.
+    # args - The args passed through to the enabled check.
+    #
+    # Returns true if feature is enabled, false if not.
+    def enabled?: (untyped name, *untyped args) -> untyped
+
+    # Public: Enable a feature.
+    #
+    # name - The String or Symbol name of the feature.
+    # args - The args passed through to the feature instance enable call.
+    #
+    # Returns the result of the feature instance enable call.
+    def enable: (untyped name, *untyped args) -> untyped
+
+    # Public: Enable a feature for an actor.
+    #
+    # name - The String or Symbol name of the feature.
+    # actor - a Flipper::Types::Actor instance or an object that responds
+    #         to flipper_id.
+    #
+    # Returns result of Feature#enable.
+    def enable_actor: (untyped name, untyped actor) -> untyped
+
+    # Public: Enable a feature for a group.
+    #
+    # name - The String or Symbol name of the feature.
+    # group - a Flipper::Types::Group instance or a String or Symbol name of a
+    #         registered group.
+    #
+    # Returns result of Feature#enable.
+    def enable_group: (untyped name, untyped group) -> untyped
+
+    # Public: Enable a feature a percentage of time.
+    #
+    # name - The String or Symbol name of the feature.
+    # percentage - a Flipper::Types::PercentageOfTime instance or an object
+    #              that responds to to_i.
+    #
+    # Returns result of Feature#enable.
+    def enable_percentage_of_time: (untyped name, untyped percentage) -> untyped
+
+    # Public: Enable a feature for a percentage of actors.
+    #
+    # name - The String or Symbol name of the feature.
+    # percentage - a Flipper::Types::PercentageOfActors instance or an object
+    #              that responds to to_i.
+    #
+    # Returns result of Feature#enable.
+    def enable_percentage_of_actors: (untyped name, untyped percentage) -> untyped
+
+    # Public: Disable a feature.
+    #
+    # name - The String or Symbol name of the feature.
+    # args - The args passed through to the feature instance enable call.
+    #
+    # Returns the result of the feature instance disable call.
+    def disable: (untyped name, *untyped args) -> untyped
+
+    # Public: Disable a feature for an actor.
+    #
+    # name - The String or Symbol name of the feature.
+    # actor - a Flipper::Types::Actor instance or an object that responds
+    #         to flipper_id.
+    #
+    # Returns result of disable.
+    def disable_actor: (untyped name, untyped actor) -> untyped
+
+    # Public: Disable a feature for a group.
+    #
+    # name - The String or Symbol name of the feature.
+    # group - a Flipper::Types::Group instance or a String or Symbol name of a
+    #         registered group.
+    #
+    # Returns result of disable.
+    def disable_group: (untyped name, untyped group) -> untyped
+
+    # Public: Disable a feature a percentage of time.
+    #
+    # name - The String or Symbol name of the feature.
+    # percentage - a Flipper::Types::PercentageOfTime instance or an object
+    #              that responds to to_i.
+    #
+    # Returns result of disable.
+    def disable_percentage_of_time: (untyped name) -> untyped
+
+    # Public: Disable a feature for a percentage of actors.
+    #
+    # name - The String or Symbol name of the feature.
+    # percentage - a Flipper::Types::PercentageOfActors instance or an object
+    #              that responds to to_i.
+    #
+    # Returns result of disable.
+    def disable_percentage_of_actors: (untyped name) -> untyped
+
+    # Public: Add a feature.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns result of add.
+    def add: (untyped name) -> untyped
+
+    # Public: Has a feature been added in the adapter.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns true if added else false.
+    def exist?: (untyped name) -> untyped
+
+    # Public: Remove a feature.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns result of remove.
+    def remove: (untyped name) -> untyped
+
+    # Public: Access a feature instance by name.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns an instance of Flipper::Feature.
+    def feature: (untyped name) -> untyped
+
+    # Public: Preload the features with the given names.
+    #
+    # names - An Array of String or Symbol names of the features.
+    #
+    # Returns an Array of Flipper::Feature.
+    def preload: (untyped names) -> untyped
+
+    # Public: Preload all the adapters features.
+    #
+    # Returns an Array of Flipper::Feature.
+    def preload_all: () -> untyped
+
+    # Public: Shortcut access to a feature instance by name.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns an instance of Flipper::Feature.
+    alias [] feature
+
+    # Public: Shortcut for getting a boolean type instance.
+    #
+    # value - The true or false value for the boolean.
+    #
+    # Returns a Flipper::Types::Boolean instance.
+    def boolean: (?bool value) -> untyped
+
+    # Public: Even shorter shortcut for getting a boolean type instance.
+    #
+    # value - The true or false value for the boolean.
+    #
+    # Returns a Flipper::Types::Boolean instance.
+    alias bool boolean
+
+    # Public: Access a flipper group by name.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns an instance of Flipper::Group.
+    def group: (untyped name) -> untyped
+
+    # Public: Wraps an object as a flipper actor.
+    #
+    # actor - The object that you would like to wrap.
+    #
+    # Returns an instance of Flipper::Types::Actor.
+    # Raises ArgumentError if actor does not respond to `flipper_id`.
+    def actor: (untyped actor) -> untyped
+
+    # Public: Shortcut for getting a percentage of time instance.
+    #
+    # number - The percentage of time that should be enabled.
+    #
+    # Returns Flipper::Types::PercentageOfTime.
+    def time: (untyped number) -> untyped
+
+    alias percentage_of_time time
+
+    # Public: Shortcut for getting a percentage of actors instance.
+    #
+    # number - The percentage of actors that should be enabled.
+    #
+    # Returns Flipper::Types::PercentageOfActors.
+    def actors: (untyped number) -> untyped
+
+    alias percentage_of_actors actors
+
+    # Public: Returns a Set of the known features for this adapter.
+    #
+    # Returns Set of Flipper::Feature instances.
+    def features: () -> untyped
+
+    # Cloud DSL method that does nothing for open source version.
+    def sync: () -> nil
+
+    # Cloud DSL method that does nothing for open source version.
+    def sync_secret: () -> nil
+  end
+end

--- a/gems/flipper/0.28/manifest.yaml
+++ b/gems/flipper/0.28/manifest.yaml
@@ -1,7 +1,0 @@
-# manifest.yaml describes dependencies which do not appear in the gemspec.
-# If this gem includes such dependencies, comment-out the following lines and
-# declare the dependencies.
-# If all dependencies appear in the gemspec, you should remove this file.
-#
-# dependencies:
-#   - name: pathname

--- a/gems/flipper/0.28/manifest.yaml
+++ b/gems/flipper/0.28/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname


### PR DESCRIPTION
Add rbs for [flipper](https://github.com/flippercloud/flipper) gem.
Flipper is "Beautiful, performant feature flags for Ruby."

- Add test for ["basic"](https://github.com/flippercloud/flipper/blob/v0.28.0/examples/basic.rb) and ["configuring_default"](https://github.com/flippercloud/flipper/blob/v0.28.0/examples/configuring_default.rb).
- Add class and module definitions with `rbs prototype rb`
- Update flipper rbs for "basic" and "configuring_default".