### PR TITLE
Add support for block form of ActiveSupport::Notifications.subscribe

### DIFF
--- a/gems/activesupport/7.0/activesupport-7.0.rbs
+++ b/gems/activesupport/7.0/activesupport-7.0.rbs
@@ -46,6 +46,7 @@ module ActiveSupport
     #     @event = event
     #   end
     def self.subscribe: (String | Regexp, _Callable5 | _Callable1) -> Subscriber
+                      | (String | Regexp) { (String, Time, Time, String, Hash[untyped, untyped]) -> void} -> Subscriber
                       | ...
   end
 end


### PR DESCRIPTION
Cf https://github.com/rails/rails/blob/main/activesupport/lib/active_support/notifications.rb#L212-L245 for the documentation about this