### PR TITLE
Add types for cancancan gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -184,3 +184,6 @@
 [submodule "gems/rubyzip/2.3/_src"]
 	path = gems/rubyzip/2.3/_src
 	url = https://github.com/rubyzip/rubyzip.git
+[submodule "gems/cancancan/3.5/_src"]
+	path = gems/cancancan/3.5/_src
+	url = https://github.com/CanCanCommunity/cancancan.git

--- a/gems/cancancan/3.5/_scripts/test
+++ b/gems/cancancan/3.5/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r cancancan:3.5 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/cancancan/3.5/_test/Steepfile
+++ b/gems/cancancan/3.5/_test/Steepfile
@@ -1,0 +1,25 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "cancancan"
+
+  library "actionpack"
+  library "actionview"
+  library "activerecord"
+  library "activemodel"
+  library "activesupport"
+  library "cgi"
+  library "date"
+  library "logger"
+  library "mutex_m"
+  library "rack"
+  library "rails-dom-testing"
+  library "singleton"
+  library "time"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/cancancan/3.5/_test/test.rb
+++ b/gems/cancancan/3.5/_test/test.rb
@@ -1,0 +1,29 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "cancancan"
+require "active_record"
+
+class Post < ActiveRecord::Base
+end
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :read, Post, public: true
+
+    return unless user.present?  # additional permissions for logged in users (they can read their own posts)
+    can :read, Post, user: user
+
+    return unless user.admin?  # additional permissions for administrators
+    can :read, Post
+  end
+end
+
+class TestController < ActionController::Base
+  def show
+    @post = Post.find(1)
+    authorize! :read, @post
+  end
+end

--- a/gems/cancancan/3.5/_test/test.rbs
+++ b/gems/cancancan/3.5/_test/test.rbs
@@ -1,0 +1,18 @@
+class User
+  def admin?: () -> bool
+end
+
+class Post < ActiveRecord::Base
+end
+
+class Ability
+  include CanCan::Ability
+
+  def initialize: (User user) -> void
+end
+
+class TestController < ActionController::Base
+  @post: Post
+
+  def show: () -> void
+end

--- a/gems/cancancan/3.5/cancancan.rbs
+++ b/gems/cancancan/3.5/cancancan.rbs
@@ -1,0 +1,21 @@
+module CanCan
+  module Ability
+    def can: (?(Symbol | Array[Symbol]) action, ?untyped subject, **untyped conditions) -> void
+           | (?(Symbol | Array[Symbol]) action, ?untyped subject) ?{ (untyped object) -> bool } -> void
+           | () { (Symbol action, class object_class, untyped object) -> bool } -> void
+    def cannot: (?(Symbol | Array[Symbol]) action, ?untyped subject, **untyped conditions) -> void
+              | (?(Symbol | Array[Symbol]) action, ?untyped subject) ?{ (untyped object) -> bool } -> void
+              | () { (Symbol action, class object_class, untyped object) -> bool } -> void
+    def can?: (Symbol action, untyped subject, ?untyped attribute, *untyped) -> bool
+    def cannot?: (Symbol action, untyped subject, ?untyped attribute, *untyped) -> bool
+    def authorize!: (Symbol action, untyped subject, *untyped) -> void
+  end
+end
+
+module ActionController
+  class Base
+    def can?: (Symbol action, untyped subject, ?untyped attribute, *untyped) -> bool
+    def cannot?: (Symbol action, untyped subject, ?untyped attribute, *untyped) -> bool
+    def authorize!: (Symbol action, untyped subject, *untyped) -> void
+  end
+end


### PR DESCRIPTION
CanCanCan is an authorization library for Ruby and Ruby on Rails which restricts what resources a given user is allowed to access.

refs: https://github.com/CanCanCommunity/cancancan