### PR TITLE
Fix activesupport ERB definition

### DIFF
--- a/gems/activesupport/6.0/_scripts/test
+++ b/gems/activesupport/6.0/_scripts/test
@@ -12,8 +12,8 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo=$REPO_DIR \
-  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime \
+bundle exec rbs --no-collection --repo=$REPO_DIR \
+  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime -rerb \
   -ractivesupport validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/activesupport/6.0/_test/Steepfile
+++ b/gems/activesupport/6.0/_test/Steepfile
@@ -14,6 +14,7 @@ target :test do
   library "singleton"
   library "tsort"
   library 'time'
+  library 'erb'
 
   library "activesupport:6.0"
 

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -5609,9 +5609,9 @@ class ERB
     #
     #   puts html_escape('is a > 0 & a < 10?')
     #   # => is a &gt; 0 &amp; a &lt; 10?
-    def self?.html_escape: (untyped s) -> untyped
+    def self?.html_escape: ...
 
-    alias h html_escape
+    def self?.h: ...
 
     def self?.unwrapped_html_escape: (untyped s) -> untyped
 

--- a/gems/activesupport/6.0/manifest.yaml
+++ b/gems/activesupport/6.0/manifest.yaml
@@ -7,3 +7,4 @@ dependencies:
   - name: time
   - name: pathname
   - name: securerandom
+  - name: erb

--- a/gems/activesupport/7.0/_scripts/test
+++ b/gems/activesupport/7.0/_scripts/test
@@ -12,7 +12,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r date -r logger -r monitor -r mutex_m -r singleton -r time -r activesupport:7.0 validate --silent
+bundle exec rbs --no-collection --repo $REPO_DIR -r date -r logger -r monitor -r mutex_m -r singleton -r time -r erb -r activesupport:7.0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/activesupport/7.0/_test/Steepfile
+++ b/gems/activesupport/7.0/_test/Steepfile
@@ -14,6 +14,7 @@ target :test do
   library "singleton"
   library "tsort"
   library 'time'
+  library 'erb'
 
   library "activesupport:7.0"
 

--- a/gems/activesupport/7.0/manifest.yaml
+++ b/gems/activesupport/7.0/manifest.yaml
@@ -11,3 +11,4 @@ dependencies:
   - name: singleton
   - name: time
   - name: securerandom
+  - name: erb


### PR DESCRIPTION
The definition causes `RBS::DuplicatedMethodDefinitionError` with `erb` type definition library, and this PR fixes the problem by:

1. Adding `erb` as `activesupport`'s dependency
2. Make the `html_escape` and `h` methods overloads