### PR TITLE
Fix definition mismatch

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -7065,7 +7065,8 @@ module ActiveRecord
       end
     end
 
-    SchemaCreation: untyped
+    class SchemaCreation
+    end
   end
 end
 


### PR DESCRIPTION
I am trying to type a Rails application based on `rbs prototype runtime`.
However, I have encountered a mismatch between the generated types and the existing types.

In v6.0, `ActiveRecord::ConnectionAdapters::SchemaCreation` is a class. Also, `ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation` exists. However, `ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation` has been removed since v6.1. This also changes `SchemaCreation` in mysql, postgresql and sqlite3. It is possible to separate these changes, but the changes are larger. The smallest change I want is just to have `ActiveRecord::ConnectionAdapters::SchemaCreation` be a class. Therefore, I only change `ActiveRecord::ConnectionAdapters::SchemaCreation` to class and do not fix the other mismatches.