### PR TITLE
actionpack: ActionController::Base should provide .helper_method

### DIFF
--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -19,6 +19,7 @@ module ActionController
     include AbstractController::AssetPaths
     include Helpers
     extend Helpers::ClassMethods
+    extend AbstractController::Helpers::ClassMethods
     include UrlFor
     include Redirecting
     include ActionView::Layouts


### PR DESCRIPTION
Currently `ActionController::Base` does not provide `.helper_method` because it does not extend `AbstractController::Helpers::ClassMethods`. The module was indirectly used through `AbstractController::helpers`.

So it should be added the list of related modules.

refs: https://github.com/rails/rails/blob/v6.1.7.1/actionpack/lib/action_controller/metal/helpers.rb#L60

Before:

```
root@8eadc9fcf58d> rbs -Isig method --singleton ActionController::Base helper_method
Cannot find method: helper_method
```

After:
```
root@8eadc9fcf58d> rbs -Isig method --singleton ActionController::Base helper_method
::ActionController::Base.helper_method
  defined_in: ::AbstractController::Helpers::ClassMethods
  implementation: ::AbstractController::Helpers::ClassMethods
  accessibility: public
  types:
      (*untyped meths) -> untyped
```