### PR TITLE
Update dependencies for activesupport

### DIFF
--- a/gems/actionmailer/7.0/_scripts/test
+++ b/gems/actionmailer/7.0/_scripts/test
@@ -14,7 +14,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR -r actionmailer:7.0 \
   -r actionpack:7.0 -r activesupport:7.0 -r actionview:7.0 -r rack \
-  -r cgi -r date -r logger -r monitor -r mutex_m -r singleton -r time -r tsort \
+  -r cgi -r date -r erb -r logger -r monitor -r mutex_m -r singleton -r time -r tsort \
   validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/actionmailer/7.0/_test/Steepfile
+++ b/gems/actionmailer/7.0/_test/Steepfile
@@ -13,6 +13,7 @@ target :test do
 
   library "cgi"
   library "date"
+  library "erb"
   library "logger"
   library "monitor"
   library "mutex_m"

--- a/gems/actionpack/6.0/_scripts/test
+++ b/gems/actionpack/6.0/_scripts/test
@@ -13,7 +13,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR -r actionpack:6.0 \
-  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime -ractivesupport \
+  -rmonitor -rdate -rerb -rsingleton -rlogger -rmutex_m -rtime -ractivesupport \
   -ractionview \
   -rrack -rcgi -ruri \
   validate --silent

--- a/gems/actionview/6.0/_scripts/test
+++ b/gems/actionview/6.0/_scripts/test
@@ -15,7 +15,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 bundle exec rbs --repo $REPO_DIR -r actionview:6.0 \
   -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime -ractivesupport \
   -ractionpack \
-  -rrack -rcgi -ruri \
+  -rrack -rcgi -ruri -rerb \
   validate --silent
 
 # TODO

--- a/gems/activejob/6.0/_scripts/test
+++ b/gems/activejob/6.0/_scripts/test
@@ -17,7 +17,7 @@ bundle exec rbs --repo $REPO_DIR -r activejob:6.0 \
   -rrailties -rtsort \
   -ractionpack \
   -ractionview \
-  -rrack -rcgi -ruri \
+  -rrack -rcgi -ruri -rerb \
   validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/activejob/6.0/_test/Steepfile
+++ b/gems/activejob/6.0/_test/Steepfile
@@ -12,6 +12,7 @@ target :test do
   library "logger"
   library "mutex_m"
   library "date"
+  library "erb"
   library "monitor"
   library "singleton"
   library "time"

--- a/gems/activemodel/6.0/_scripts/test
+++ b/gems/activemodel/6.0/_scripts/test
@@ -4,7 +4,7 @@ set -xe
 
 REPO=$(git rev-parse --show-toplevel)/gems
 bundle exec rbs --repo=$REPO \
-  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -ractivesupport -rtime \
+  -rmonitor -rdate -rerb -rsingleton -rlogger -rmutex_m -ractivesupport -rtime \
   -ractivemodel validate --silent
 
 # TODO

--- a/gems/activemodel/7.0/_scripts/test
+++ b/gems/activemodel/7.0/_scripts/test
@@ -12,7 +12,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r date -r logger -r monitor -r mutex_m -r singleton -r time  -r activemodel:7.0 -r activesupport:7.0 validate --silent
+bundle exec rbs --repo $REPO_DIR -r date -r erb -r logger -r monitor -r mutex_m -r singleton -r time  -r activemodel:7.0 -r activesupport:7.0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/activemodel/7.0/_test/Steepfile
+++ b/gems/activemodel/7.0/_test/Steepfile
@@ -9,6 +9,7 @@ target :test do
   library "activesupport:7.0"
 
   library "date"
+  library "erb"
   library "logger"
   library "monitor"
   library "mutex_m"

--- a/gems/activerecord/6.0/_scripts/test
+++ b/gems/activerecord/6.0/_scripts/test
@@ -14,7 +14,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR -r activerecord:6.0 \
   -r activesupport:6.0 -r activemodel:6.0 \
-  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime \
+  -rmonitor -rdate -rerb -rsingleton -rlogger -rmutex_m -rtime \
   validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/activerecord/6.0/_test/Steepfile
+++ b/gems/activerecord/6.0/_test/Steepfile
@@ -10,6 +10,7 @@ target :test do
   library "logger"
   library "mutex_m"
   library "date"
+  library "erb"
   library "monitor"
   library "singleton"
   library "tsort"

--- a/gems/activerecord/6.1/_scripts/test
+++ b/gems/activerecord/6.1/_scripts/test
@@ -14,7 +14,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR -r activerecord:6.1 \
   -r activesupport:6.1 -r activemodel:6.1 \
-  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -rtime \
+  -rmonitor -rdate -rerb -rsingleton -rlogger -rmutex_m -rtime \
   validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/activerecord/6.1/_test/Steepfile
+++ b/gems/activerecord/6.1/_test/Steepfile
@@ -10,6 +10,7 @@ target :test do
   library "logger"
   library "mutex_m"
   library "date"
+  library "erb"
   library "monitor"
   library "singleton"
   library "tsort"

--- a/gems/activerecord/7.0/_scripts/test
+++ b/gems/activerecord/7.0/_scripts/test
@@ -12,7 +12,7 @@ RBS_DIR=$(cd $(dirname $0)/..; pwd)
 # Set REPO_DIR variable to validate RBS files added to the corresponding folder
 REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
-bundle exec rbs --repo $REPO_DIR -r date -r logger -r monitor -r mutex_m -r singleton -r time -r activerecord:7.0 -r activesupport:7.0 -r activemodel:7.0 validate --silent
+bundle exec rbs --repo $REPO_DIR -r date -r erb -r logger -r monitor -r mutex_m -r singleton -r time -r activerecord:7.0 -r activesupport:7.0 -r activemodel:7.0 validate --silent
 
 cd ${RBS_DIR}/_test
 # Run type checks

--- a/gems/activerecord/7.0/_test/Steepfile
+++ b/gems/activerecord/7.0/_test/Steepfile
@@ -7,6 +7,7 @@ target :test do
   repo_path "../../../"
 
   library "date"
+  library "erb"
   library "logger"
   library "monitor"
   library "mutex_m"

--- a/gems/business_time/0.13/_scripts/test
+++ b/gems/business_time/0.13/_scripts/test
@@ -14,7 +14,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR \
   -r activesupport:6.0 \
-  -r date -r time -r logger -r mutex_m -r set -r monitor -r singleton \
+  -r date -r erb -r time -r logger -r mutex_m -r set -r monitor -r singleton \
   -r set \
   -r business_time:0.13 validate --silent
 

--- a/gems/business_time/0.13/_test/Steepfile
+++ b/gems/business_time/0.13/_test/Steepfile
@@ -10,6 +10,7 @@ target :test do
   library "logger"
   library "mutex_m"
   library "date"
+  library "erb"
   library "monitor"
   library "singleton"
   library "tsort"

--- a/gems/delayed_job/4.1/_scripts/test
+++ b/gems/delayed_job/4.1/_scripts/test
@@ -8,7 +8,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 GEM=delayed_job:4.1
 
 bundle exec rbs --repo $REPO_DIR \
-  -r activesupport -r pathname -r logger -r mutex_m -r time -r monitor -r date -r singleton \
+  -r activesupport -r pathname -r logger -r mutex_m -r time -r monitor -r date -r erb -r singleton \
   -r $GEM validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/delayed_job/4.1/_test/Steepfile
+++ b/gems/delayed_job/4.1/_test/Steepfile
@@ -11,6 +11,7 @@ target :test do
   library 'logger'
   library 'mutex_m'
   library 'date'
+  library 'erb'
   library 'monitor'
   library 'singleton'
   library 'tsort'

--- a/gems/delayed_job_active_record/4.1/_scripts/test
+++ b/gems/delayed_job_active_record/4.1/_scripts/test
@@ -14,7 +14,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 GEM=delayed_job_active_record:4.1
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR \
-  -r monitor -r date -r singleton -r logger -r mutex_m -r time \
+  -r monitor -r date -r erb -r singleton -r logger -r mutex_m -r time \
   -r activesupport -r activerecord -r activemodel \
   -r $GEM validate --silent
 

--- a/gems/delayed_job_active_record/4.1/_test/Steepfile
+++ b/gems/delayed_job_active_record/4.1/_test/Steepfile
@@ -7,6 +7,7 @@ target :test do
   library "delayed_job_active_record:4.1"
 
   library 'date'
+  library 'erb'
   library 'logger'
   library 'monitor'
   library 'mutex_m'

--- a/gems/paranoia/2.5/_scripts/test
+++ b/gems/paranoia/2.5/_scripts/test
@@ -14,7 +14,7 @@ REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
 # Validate RBS files, using the bundler environment present
 bundle exec rbs --repo $REPO_DIR -r paranoia:2.5 \
        -r activerecord -r activesupport -r activemodel \
-       -r time -r mutex_m -r monitor -r date -r singleton -r logger \
+       -r time -r mutex_m -r monitor -r date -r erb -r singleton -r logger \
        validate --silent
 
 cd ${RBS_DIR}/_test

--- a/gems/paranoia/2.5/_test/Steepfile
+++ b/gems/paranoia/2.5/_test/Steepfile
@@ -11,6 +11,7 @@ target :test do
   library "activemodel"
   library "monitor"
   library "date"
+  library "erb"
   library "time"
   library "singleton"
   library "logger"


### PR DESCRIPTION
Since #396, activesupport gem has depended on erb.  But the dependencies of some gems are not updated yet.

This adds a new dependency "erb" to gems using activesupport.

refs: https://github.com/ruby/gem_rbs_collection/pull/401#issuecomment-1698911421