### PR TITLE
Update activerecord callbacks

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -51,29 +51,31 @@ module ActiveRecord
     def self.validates: (*untyped) -> void
 
     # callbacks
-    def self.after_commit: (*untyped) ?{ () -> untyped} -> void
-    def self.after_create_commit: (*untyped) -> void | ...
-    def self.after_update_commit: (*untyped) -> void | ...
-    def self.after_destroy_commit: (*untyped) -> void | ...
-    def self.after_save_commit: (*untyped) -> void | ...
-    def self.after_create: (*untyped) ?{ () -> untyped} -> void
-    def self.after_destroy: (*untyped) ?{ () -> untyped} -> void
-    def self.after_rollback: (*untyped) ?{ () -> untyped} -> void
-    def self.after_save: (*untyped) ?{ () -> untyped} -> void
-    def self.after_update: (*untyped) ?{ () -> untyped} -> void
-    def self.after_validation: (*untyped) ?{ () -> untyped} -> void
-    def self.after_initialize: (*untyped) ?{ () -> untyped} -> void
-    def self.after_find: (*untyped) ?{ () -> untyped} -> void
-    def self.after_touch: (*untyped) ?{ () -> untyped} -> void
-    def self.around_create: (*untyped) ?{ () -> untyped} -> void
-    def self.around_destroy: (*untyped) ?{ () -> untyped} -> void
-    def self.around_save: (*untyped) ?{ () -> untyped} -> void
-    def self.around_update: (*untyped) ?{ () -> untyped} -> void
-    def self.before_create: (*untyped) ?{ () -> untyped} -> void
-    def self.before_destroy: (*untyped) ?{ () -> untyped} -> void
-    def self.before_save: (*untyped) ?{ () -> untyped} -> void
-    def self.before_update: (*untyped) ?{ () -> untyped} -> void
-    def self.before_validation: (*untyped) ?{ () -> untyped} -> void
+    type callback = Symbol | ^() [self: instance] -> void
+    type condition = Symbol | ^() [self: instance] -> bool
+    def self.after_commit: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_create_commit: (*callback, ?if: condition, ?unless: condition, **untyped) -> void | ...
+    def self.after_update_commit: (*callback, ?if: condition, ?unless: condition, **untyped) -> void | ...
+    def self.after_destroy_commit: (*callback, ?if: condition, ?unless: condition, **untyped) -> void | ...
+    def self.after_save_commit: (*callback, ?if: condition, ?unless: condition, **untyped) -> void | ...
+    def self.after_create: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_destroy: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_rollback: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_save: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_update: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_validation: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_initialize: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_find: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_touch: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.around_create: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.around_destroy: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.around_save: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.around_update: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_create: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_destroy: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_save: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_update: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_validation: (*callback, ?if: condition, ?unless: condition, **untyped) ?{ () [self: instance] -> untyped } -> void
 
     def self.columns: () -> Array[untyped]
     def self.reflect_on_all_associations: (?Symbol) -> Array[untyped]


### PR DESCRIPTION
This updates signatures for callback methods (ex. `#before_save`) of
ActiveRecord::Base to give the self-types to the procs and blocks.

If this is okay, I'll post another PR for actionpack (Controllers).

Note: This contains https://github.com/ruby/gem_rbs_collection/pull/402.