### PR TITLE
Add types for operator_recordable gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -187,3 +187,6 @@
 [submodule "gems/cancancan/3.5/_src"]
 	path = gems/cancancan/3.5/_src
 	url = https://github.com/CanCanCommunity/cancancan.git
+[submodule "gems/operator_recordable/2.0/_src"]
+	path = gems/operator_recordable/2.0/_src
+	url = https://github.com/yujideveloper/operator_recordable.git

--- a/gems/operator_recordable/2.0/_scripts/test
+++ b/gems/operator_recordable/2.0/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r operator_recordable:2.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/operator_recordable/2.0/_test/Steepfile
+++ b/gems/operator_recordable/2.0/_test/Steepfile
@@ -1,0 +1,22 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "operator_recordable"
+
+  library "activemodel"
+  library "activerecord"
+  library "activesupport"
+  library "date"
+  library "erb"
+  library "logger"
+  library "monitor"
+  library "mutex_m"
+  library "singleton"
+  library 'time'
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/operator_recordable/2.0/_test/test.rb
+++ b/gems/operator_recordable/2.0/_test/test.rb
@@ -1,0 +1,20 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "operator_recordable"
+require "active_record"
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  include OperatorRecordable::Extension
+end
+
+class Post < ApplicationRecord
+  record_operator_on :create, :update, :destroy
+end
+
+class Operator < ApplicationRecord
+end
+
+OperatorRecordable.operator = Operator.new

--- a/gems/operator_recordable/2.0/_test/test.rbs
+++ b/gems/operator_recordable/2.0/_test/test.rbs
@@ -1,0 +1,10 @@
+class ApplicationRecord < ActiveRecord::Base
+  include OperatorRecordable::Extension
+  extend OperatorRecordable::Extension::ClassMethods
+end
+
+class Post < ApplicationRecord
+end
+
+class Operator < ApplicationRecord
+end

--- a/gems/operator_recordable/2.0/operator_recordable.rbs
+++ b/gems/operator_recordable/2.0/operator_recordable.rbs
@@ -1,0 +1,11 @@
+module OperatorRecordable
+  module Extension
+    module ClassMethods
+      def record_operator_on: (*untyped) -> void
+    end
+  end
+
+  def self.config: () -> Hash[untyped, untyped]
+  def self.operator: () -> untyped
+  def self.operator=: (untyped operator) -> untyped
+end


### PR DESCRIPTION
OperatorRecordable is a Rails plugin gem that makes your ActiveRecord models to be saved or logically deleted with automatically set created_by, updated_by, and deleted_by.

refs: https://github.com/yujideveloper/operator_recordable