### PR TITLE
Add types for carrierwave gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -187,3 +187,6 @@
 [submodule "gems/cancancan/3.5/_src"]
 	path = gems/cancancan/3.5/_src
 	url = https://github.com/CanCanCommunity/cancancan.git
+[submodule "gems/carrierwave/3.0/_src"]
+	path = gems/carrierwave/3.0/_src
+	url = https://github.com/carrierwaveuploader/carrierwave.git

--- a/gems/carrierwave/3.0/_scripts/test
+++ b/gems/carrierwave/3.0/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r carrierwave:3.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/carrierwave/3.0/_test/Steepfile
+++ b/gems/carrierwave/3.0/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "carrierwave"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/carrierwave/3.0/_test/test.rb
+++ b/gems/carrierwave/3.0/_test/test.rb
@@ -1,0 +1,25 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "carrierwave"
+
+class AvatarUploader < CarrierWave::Uploader::Base
+  storage :file
+end
+
+class MyUploader < CarrierWave::Uploader::Base
+  include CarrierWave::RMagick
+
+  process resize_to_fit: [800, 800]
+
+  version :thumb do
+    process resize_to_fill: [200,200]
+  end
+end
+
+class ApplicationRecord < ActiveRecord::Base
+end
+
+class User < ApplicationRecord
+  mount_uploader :avatar, AvatarUploader
+end

--- a/gems/carrierwave/3.0/_test/test.rbs
+++ b/gems/carrierwave/3.0/_test/test.rbs
@@ -1,0 +1,12 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+end
+
+class MyUploader < CarrierWave::Uploader::Base
+  include CarrierWave::RMagick
+end
+
+class ApplicationRecord < ActiveRecord::Base
+end
+
+class User < ApplicationRecord
+end

--- a/gems/carrierwave/3.0/carrierwave.rbs
+++ b/gems/carrierwave/3.0/carrierwave.rbs
@@ -1,0 +1,86 @@
+module CarrierWave
+  module ActiveRecord
+    include CarrierWave::Mount
+  end
+
+  module Mount
+    def uploaders: () -> Hash[Symbol, CarrierWave::Uploader::Base]
+    def uploader_options: () -> Hash[untyped, untyped]
+    def uploader_option: (Symbol, Symbol) -> untyped
+    def mount_uploader: (Symbol, singleton(CarrierWave::Uploader::Base), **untyped) ? { () -> void } -> void
+    def mount_uploaders: (Symbol, singleton(CarrierWave::Uploader::Base), **untyped) ? { () -> void } -> void
+  end
+
+  module Uploader
+    module Configuration
+      module ClassMethods
+        def storage: (untyped) -> untyped
+        alias storage= storage
+
+        def cache_storage: (untyped) -> untyped
+        alias cache_storage= cache_storage
+
+        def add_config: (untyped) -> void
+        def add_deprecated_config: (untyped) -> void
+        def configure: () { (self) -> void } -> void
+        def reset_config: () -> void
+      end
+    end
+
+    module Mountable
+      attr_reader model: untyped
+      attr_reader mounted_as: Symbol
+
+      def index: () -> Integer
+    end
+
+    module Processing
+      module ClassMethods
+        def process: (*untyped) -> void
+      end
+
+      def process!: (untyped) -> void
+    end
+
+    module Versions
+      module ClassMethods
+        def version: (String | Symbol name, **untyped) ? { () -> void } -> void
+      end
+
+      def versions: () -> Hash[Symbol, CarrierWave::Uploader::Base]
+      def version_name: () -> String
+      def version_exists?: (String | Symbol) -> bool
+      def cache: (*untyped) -> void
+      def url: (*Symbol) -> String
+             | (Hash[untyped, untyped]) -> String
+      def recreate_versions!: (*untyped) -> void
+    end
+
+    class Base
+      include CarrierWave::Uploader::Configuration
+      extend CarrierWave::Uploader::Configuration::ClassMethods
+
+      include CarrierWave::Uploader::Mountable
+
+      include CarrierWave::Uploader::Processing
+      extend CarrierWave::Uploader::Processing::ClassMethods
+
+      include CarrierWave::Uploader::Versions
+      extend CarrierWave::Uploader::Versions::ClassMethods
+
+      attr_reader file: untyped
+    end
+  end
+end
+
+module CarrierWave
+  module RMagick
+    def manipulate!: (*untyped) ? { (untyped, untyped, untyped) -> void } -> void
+  end
+end
+
+module ActiveRecord
+  class Base
+    extend CarrierWave::ActiveRecord
+  end
+end


### PR DESCRIPTION
This gem provides a simple and extremely flexible way to upload files from Ruby applications. It works well with Rack based web applications, such as Ruby on Rails.

refs: https://github.com/carrierwaveuploader/carrierwave

Note: I added types only to the modules I'm using.