### PR TITLE
geocoder: Add modules for ActiveRecord

### DIFF
--- a/gems/geocoder/1.8/_test/models.rb
+++ b/gems/geocoder/1.8/_test/models.rb
@@ -1,0 +1,12 @@
+require "active_record"
+
+class Venue < ActiveRecord::Base
+  geocoded_by :address
+end
+
+obj = Venue.new
+obj.distance_to([43.9,-98.6])  # distance from obj to point
+obj.bearing_to([43.9,-98.6])   # bearing from obj to point
+
+obj2 = Venue.new
+obj.bearing_from(obj2)         # bearing from obj2 to obj

--- a/gems/geocoder/1.8/_test/models.rbs
+++ b/gems/geocoder/1.8/_test/models.rbs
@@ -1,0 +1,5 @@
+class Venue < ActiveRecord::Base
+  # Note: Geocoder::Store::ActiveRecord is automatically loaded by `.geocoded_by` call on Ruby.
+  #       But there is no special way to do it on RBS side.  Therefore, developers should include it manually in their types.
+  include Geocoder::Store::ActiveRecord
+end

--- a/gems/geocoder/1.8/geocoder.rbs
+++ b/gems/geocoder/1.8/geocoder.rbs
@@ -15,3 +15,50 @@ module Geocoder
   #
   def self.address: (String | [Float, Float] | Query query, ?::Hash[Symbol, untyped] options) -> String?
 end
+
+module Geocoder
+  module Model
+    module Base
+      def geocoder_options: () -> Hash[untyped, untyped]
+      def geocoded_by: () -> bot
+      def reverse_geocoded_by: () -> bot
+    end
+
+    module ActiveRecord
+      include Base
+
+      def geocoded_by: (Symbol address_attr, **untyped) ? { () -> void } -> void
+      def reverse_geocoded_by: (Symbol latitude_attr, Symbol longitude_attr, **untyped) ? { () -> void } -> void
+    end
+  end
+
+  module Store
+    module Base
+      def geocoded: () -> bool
+      def to_coordinates: () -> [Float?, Float?]
+      def distance_to: (untyped point, ?Symbol? units) -> Float
+      alias distance_from distance_to
+
+      def bearing_to: (untyped point, **untyped) -> Float
+      def bearing_from: (untyped point, **untyped) -> Float
+      def geocode: () -> bot
+      def reverse_geocode: () -> bot
+    end
+
+    module ActiveRecord
+      include Base
+
+      def geocode: () -> [Float, Float]?
+      alias fetch_coordinates geocode
+
+      def reverse_geocode: () -> String?
+      alias fetch_address reverse_geocode
+    end
+  end
+end
+
+module ActiveRecord
+  class Base
+    extend Geocoder::Model::ActiveRecord
+  end
+end


### PR DESCRIPTION
Add `Geocoder::Model::ActiveRecord` and `Geocoder::Store::ActiveRecord`. It helps to check types of Rails application using geocoder.

Note: This does not contain types of dynamic defined methods. It's difficult                                                                                                                                                          
to define them on RBS. We need some "generator" to support them.