### PR TITLE
`scope` should utilize `Relation` as the context for both Proc and block

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -440,6 +440,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def select: (*Symbol | String) -> Relation
             | () { (Model) -> boolish } -> Array[Model]
   def reselect: (*Symbol | String) -> Relation
+  def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void }) ?{ (Module extention) [self: Relation] -> void } -> void
 end
 
 # https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/unary.rb


### PR DESCRIPTION
Added support for handling `Relation` within scope to `_ActiveRecord_Relation_ClassMethods`.
Enabled the use of self-type-binding to check for other `Relation` methods within a `Proc`.
The context within block arguments is technically just an instance of the `Module`, but since this module is included in `Relation`, it can effectively be considered as `Relation`.