### PR TITLE
activerecord: Add modules for define a subclass of ActiveRecord::Relation

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -289,6 +289,166 @@ module ActiveRecord
   end
 end
 
+module ActiveRecord
+  class Relation
+    module Methods[Model, PrimaryKey]
+      def all: () -> self
+      def ids: () -> Array[PrimaryKey]
+      def none: () -> self
+      def pluck: (Symbol | String column) -> Array[untyped]
+              | (*Symbol | String columns) -> Array[Array[untyped]]
+      def where: (*untyped) -> self
+      def not: (*untyped) -> self
+      def exists?: (*untyped) -> bool
+      def order: (*untyped) -> self
+      def group: (*Symbol | String) -> untyped
+      def distinct: () -> self
+      def or: (self) -> self
+      def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> self
+      def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def includes: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def preload: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def find_by: (*untyped) -> Model?
+      def find_by!: (*untyped) -> Model
+      def find: (PrimaryKey id) -> Model
+              | (Array[PrimaryKey]) -> Array[Model]
+              | (*PrimaryKey) -> Array[Model]
+              | () { (Model) -> boolish } -> Model?
+      def find_or_create_by: (*untyped) -> Model
+                          | (*untyped) { (Model) -> void } -> Model
+      def find_or_create_by!: (*untyped) -> Model
+                            | (*untyped) { (Model) -> void } -> Model
+      def find_or_initialize_by: (*untyped) -> Model
+                              | (*untyped) { (Model) -> void } -> Model
+      def create_or_find_by: (*untyped) -> Model
+                          | (*untyped) { (Model) -> void } -> Model
+      def create_or_find_by!: (*untyped) -> Model
+                            | (*untyped) { (Model) -> void } -> Model
+      def take: () -> Model
+              | (Integer limit) -> Array[Model]
+      def take!: () -> Model
+      def first: () -> Model?
+              | (Integer count) -> Array[Model]
+      def first!: () -> Model
+      def second: () -> Model?
+      def second!: () -> Model
+      def third: () -> Model?
+      def third!: () -> Model
+      def fourth: () -> Model?
+      def fourth!: () -> Model
+      def fifth: () -> Model?
+      def fifth!: () -> Model
+      def forty_two: () -> Model?
+      def forty_two!: () -> Model
+      def second_to_last: () -> Model?
+      def second_to_last!: () -> Model
+      def third_to_last: () -> Model?
+      def third_to_last!: () -> Model
+      def last: () -> Model?
+              | (Integer count) -> Array[Model]
+      def last!: () -> Model
+      def limit: (Integer | Arel::Nodes::SqlLiteral | nil) -> self
+      def limit!: (Integer | Arel::Nodes::SqlLiteral | nil) -> self
+      def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+      def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
+      def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
+      def destroy_all: () -> untyped
+      def delete_all: () -> untyped
+      def update_all: (*untyped) -> untyped
+      def touch_all: (*untyped, ?time: untyped) -> untyped
+      def destroy_by: (*untyped) -> untyped
+      def delete_by: (*untyped) -> untyped
+      def each: () { (Model) -> void } -> self
+      def select: (*Symbol | String) -> self
+                | () { (Model) -> boolish } -> Array[Model]
+      def reselect: (*Symbol | String) -> self
+    end
+
+    module ClassMethods[Model, Relation, PrimaryKey]
+      def all: () -> Relation
+      def ids: () -> Array[PrimaryKey]
+      def none: () -> Relation
+      def pluck: (Symbol | String column) -> Array[untyped]
+              | (*Symbol | String columns) -> Array[Array[untyped]]
+      def where: (*untyped) -> Relation
+      def exists?: (*untyped) -> bool
+      def any?: () -> bool
+              | () { (Model) -> boolish } -> bool
+      def many?: () -> bool
+              | () { (Model) -> boolish } -> bool
+      def none?: () -> bool
+              | () { (Model) -> boolish } -> bool
+      def one?: () -> bool
+              | () { (Model) -> boolish } -> bool
+      def order: (*untyped) -> Relation
+      def group: (*Symbol | String) -> untyped
+      def distinct: () -> Relation
+      def or: (Relation) -> Relation
+      def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> Relation
+      def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def includes: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def preload: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def find_by: (*untyped) -> Model?
+      def find_by!: (*untyped) -> Model
+      def find: (PrimaryKey id) -> Model
+              | (Array[PrimaryKey]) -> Array[Model]
+              | (*PrimaryKey) -> Array[Model]
+      def find_or_create_by: (*untyped) -> Model
+                          | (*untyped) { (Model) -> void } -> Model
+      def find_or_create_by!: (*untyped) -> Model
+                            | (*untyped) { (Model) -> void } -> Model
+      def find_or_initialize_by: (*untyped) -> Model
+                              | (*untyped) { (Model) -> void } -> Model
+      def create_or_find_by: (*untyped) -> Model
+                          | (*untyped) { (Model) -> void } -> Model
+      def create_or_find_by!: (*untyped) -> Model
+                            | (*untyped) { (Model) -> void } -> Model
+      def take: () -> Model
+              | (Integer limit) -> Array[Model]
+      def take!: () -> Model
+      def first: () -> Model?
+              | (Integer count) -> Array[Model]
+      def first!: () -> Model
+      def second: () -> Model?
+      def second!: () -> Model
+      def third: () -> Model?
+      def third!: () -> Model
+      def fourth: () -> Model?
+      def fourth!: () -> Model
+      def fifth: () -> Model?
+      def fifth!: () -> Model
+      def forty_two: () -> Model?
+      def forty_two!: () -> Model
+      def second_to_last: () -> Model?
+      def second_to_last!: () -> Model
+      def third_to_last: () -> Model?
+      def third_to_last!: () -> Model
+      def last: () -> Model?
+              | (Integer count) -> Array[Model]
+      def last!: () -> Model
+      def limit: (Integer | Arel::Nodes::SqlLiteral | nil) -> Relation
+      def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+      def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
+      def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
+      def destroy_all: () -> untyped
+      def delete_all: () -> untyped
+      def update_all: (*untyped) -> untyped
+      def touch_all: (*untyped, ?time: untyped) -> untyped
+      def destroy_by: (*untyped) -> untyped
+      def delete_by: (*untyped) -> untyped
+      def select: (*Symbol | String) -> Relation
+                | () { (Model) -> boolish } -> Array[Model]
+      def reselect: (*Symbol | String) -> Relation
+    end
+  end
+end
+
 interface _ActiveRecord_Relation[Model, PrimaryKey]
   def all: () -> self
   def ids: () -> Array[PrimaryKey]

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -433,6 +433,7 @@ module ActiveRecord
               | (Integer count) -> Array[Model]
       def last!: () -> Model
       def limit: (Integer | Arel::Nodes::SqlLiteral | nil) -> Relation
+      def lock: (?untyped locks) -> Relation
       def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil


### PR DESCRIPTION
Add new modules `ActiveRecord::Relation::Methods` and `ActiveRecord::
Relation::ClassMethods` to define a subclass of ActiveRecord::Relation.

So far, we have provided `_ActiveRecord_Relation` interface and
`_ActiveRecord_Relation_ClassMethods` interface for the same purpose.
However, using interfaces does not support enhancement.  For example,
users can't override the method types on the subclasses.

Therefore this starts providing modules to support the enhancement of the
subclasses.  The methods of them are the same as what the interface provides.                                                                                                                                                  

refs: https://github.com/pocke/rbs_rails/pull/254#issuecomment-1600115112

Note: Old interfaces should be keep as is for a while to keep
compatibility.