### PR TITLE
Add a test script to gems not having it

### DIFF
--- a/gems/activestorage/6.0/_scripts/test
+++ b/gems/activestorage/6.0/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r pathname -r logger -r mutex_m -r cgi -r date -r erb -r monitor -r singleton -r tsort -r rack -r thor -r time -r tempfile -r activestorage:6.0 -r activerecord:6.0 -r activesupport:6.0 -r activemodel:6.0 -r actionpack:6.0 -r actionview:6.0 -r activestorage:6.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/activestorage/6.0/_test/Steepfile
+++ b/gems/activestorage/6.0/_test/Steepfile
@@ -8,11 +8,14 @@ target :test do
   library "pathname"
   library "logger"
   library "mutex_m"
+  library "cgi"
   library "date"
+  library "erb"
   library "monitor"
   library "singleton"
   library "tsort"
   library 'rack'
+  library 'thor'
   library 'time'
   library 'tempfile'
   library "activestorage:6.0"

--- a/gems/activestorage/6.1/_scripts/test
+++ b/gems/activestorage/6.1/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r pathname -r logger -r mutex_m -r cgi -r date -r erb -r monitor -r singleton -r tsort -r rack -r thor -r time -r tempfile -r activerecord:6.0 -r activerecord:6.0 -r activesupport:6.0 -r activemodel:6.0 -r actionpack:6.0 -r activejob:6.0 -r actionview:6.0 -r railties:6.0 -r activestorage:6.1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/chronic/0.10/_scripts/test
+++ b/gems/chronic/0.10/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r chronic:0.10 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/regexp_trie/1.0/_scripts/test
+++ b/gems/regexp_trie/1.0/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r regexp_trie:1.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/scanf/1.0/_scripts/test
+++ b/gems/scanf/1.0/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r scanf:1.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/ulid/1.3/_scripts/test
+++ b/gems/ulid/1.3/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r ulid:1.3 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/wavedash/0.1/_scripts/test
+++ b/gems/wavedash/0.1/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r wavedash:0.1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/woothee/1.11/_scripts/test
+++ b/gems/woothee/1.11/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r woothee:1.11 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/zengin_code/1.0/_scripts/test
+++ b/gems/zengin_code/1.0/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r chronic:0.10 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb


### PR DESCRIPTION
Add a test script (a.k.a. `_scripts/test`) to gems not having it.

Note: This contains https://github.com/ruby/gem_rbs_collection/pull/419