### PR TITLE
actionmailer: Fix return type of ActionMailer::Base#mail

### DIFF
--- a/gems/actionmailer/7.0/_test/railsguides.rb
+++ b/gems/actionmailer/7.0/_test/railsguides.rb
@@ -30,6 +30,4 @@ module RailsGuides
   NotifierMailer.welcome("first user").deliver_now
   NotifierMailer.welcome("first user").message
   NotifierMailer.welcome("first user").deliver_later
-
-  UserMailer.with(user: "an user").welcome_email.deliver_later
 end

--- a/gems/actionmailer/7.0/_test/railsguides.rbs
+++ b/gems/actionmailer/7.0/_test/railsguides.rbs
@@ -5,7 +5,7 @@ module RailsGuides
   class NotifierMailer < ApplicationMailer
     @account: untyped
 
-    def welcome: (untyped) -> ActionMailer::MessageDelivery
+    def welcome: (untyped) -> Mail::Message
 
     def self.welcome: (untyped) -> ActionMailer::MessageDelivery
   end
@@ -14,6 +14,6 @@ module RailsGuides
     @user: untyped
     @url: String
     
-    def welcome_email: () -> ActionMailer::MessageDelivery
+    def welcome_email: () -> Mail::Message
   end
 end

--- a/gems/actionmailer/7.0/actionmailer.rbs
+++ b/gems/actionmailer/7.0/actionmailer.rbs
@@ -6,7 +6,7 @@ module ActionMailer
 
     def mail: (**untyped) ?{ (untyped) -> void } -> Mail::Message
 
-    def self.with: (**untyped) -> instance
+    def self.with: (**untyped) -> untyped
 
     def params: () -> Hash[untyped, untyped]
 

--- a/gems/actionmailer/7.0/actionmailer.rbs
+++ b/gems/actionmailer/7.0/actionmailer.rbs
@@ -4,7 +4,7 @@ module ActionMailer
 
     def self.layout: (String) -> void
 
-    def mail: (**untyped) ?{ (untyped) -> void } -> MessageDelivery
+    def mail: (**untyped) ?{ (untyped) -> void } -> Mail::Message
 
     def self.with: (**untyped) -> instance
 


### PR DESCRIPTION
The return type of `ActionMailer::Base#mail` is `Mail::Message`, not `ActionMailer::MailDelivery`.

refs:

* https://github.com/rails/rails/blob/v7.0.8/actionmailer/lib/action_mailer/base.rb#L635
* https://github.com/rails/rails/blob/v7.0.8/actionmailer/lib/action_mailer/base.rb#L858