### PR TITLE
[activesupport] Use class alias syntax for HashWithIndifferentAccess

### DIFF
--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -7953,10 +7953,7 @@ module ActiveSupport
   end
 end
 
-# NOTE: HashWithIndifferentAccess and ActiveSupport::HashWithIndifferentAccess are the same object
-#       but RBS doesn't have class alias syntax
-class HashWithIndifferentAccess[T, U] < ActiveSupport::HashWithIndifferentAccess[T, U]
-end
+class HashWithIndifferentAccess = ActiveSupport::HashWithIndifferentAccess
 
 module I18n
   class Railtie < Rails::Railtie


### PR DESCRIPTION
RBS v3.0.0 introduces class alias feature, so let's use it for `HashWithIndifferentAccess`. 