### PR TITLE
Add types for chunky_png gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -202,3 +202,6 @@
 [submodule "gems/recaptcha/5.15/_src"]
 	path = gems/recaptcha/5.15/_src
 	url = https://github.com/ambethia/recaptcha.git
+[submodule "gems/chunky_png/1.4/_src"]
+	path = gems/chunky_png/1.4/_src
+	url = https://github.com/wvanbergen/chunky_png.git

--- a/gems/chunky_png/1.4/_scripts/test
+++ b/gems/chunky_png/1.4/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r chunky_png:1.4 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/chunky_png/1.4/_test/Steepfile
+++ b/gems/chunky_png/1.4/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "chunky_png"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/chunky_png/1.4/_test/test.rb
+++ b/gems/chunky_png/1.4/_test/test.rb
@@ -1,0 +1,22 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "chunky_png"
+
+# Creating an image from scratch, save as an interlaced PNG
+png = ChunkyPNG::Image.new(16, 16, ChunkyPNG::Color::TRANSPARENT)
+png[1,1] = ChunkyPNG::Color.rgba(10, 20, 30, 128)
+png[2,1] = ChunkyPNG::Color('black @ 0.5')
+png.save('filename.png', :interlace => true)
+
+# Compose images using alpha blending.
+avatar = ChunkyPNG::Image.from_file('avatar.png')
+badge  = ChunkyPNG::Image.from_file('no_ie_badge.png')
+avatar.compose!(badge, 10, 10)
+avatar.save('composited.png', :fast_rgba) # Force the fast saving routine.
+
+# Accessing metadata
+image = ChunkyPNG::Image.from_file('with_metadata.png')
+puts image.metadata['Title']
+image.metadata['Author'] = 'Willem van Bergen'
+image.save('with_metadata.png') # Overwrite file

--- a/gems/chunky_png/1.4/chunky_png.rbs
+++ b/gems/chunky_png/1.4/chunky_png.rbs
@@ -1,0 +1,52 @@
+module ChunkyPNG
+  COLOR_GRAYSCALE: Integer
+  COLOR_TRUECOLOR: Integer
+  COLOR_INDEXED: Integer
+
+  class Canvas
+    module Operations
+      def compose!: (Canvas other, ?Integer offset_x, ?Integer offset_y) -> self
+      def compose: (Canvas other, ?Integer offset_x, ?Integer offset_y) -> self
+    end
+
+    module PNGDecoding
+      def from_file: (String filename) -> self
+    end
+
+    module PNGEncoding
+      def save: (String Filename, **untyped constraints) -> void
+      def to_blob: (**untyped constraints) -> String
+
+      alias to_string to_blob
+      alias to_s to_blob
+
+      def []=: (Integer x, Integer x, Integer color) -> Integer
+    end
+
+    include PNGEncoding
+    extend PNGDecoding
+    include Operations
+  end
+
+  def self.Color: (Integer r, Integer g, Integer b, Integer a) -> Integer
+                | (Integer r, Integer g, Integer b) -> Integer
+                | (String hex_value, ?Integer opacity) -> Integer
+                | (String | Symbol color_name, ?Integer opacity) -> Integer
+                | (Integer color_value, ?Integer opacity) -> Integer
+
+  class Color
+    BLACK: Integer
+    WHITE: Integer
+    TRANSPARENT: Integer
+
+    def rgba: (Integer r, Integer g, Integer b, Integer a) -> Integer
+    def rgb: (Integer r, Integer g, Integer b) -> Integer
+  end
+
+  class Image < Canvas
+    attr_accessor metadata: Hash[untyped, untyped]
+
+    def initialize: (Integer width, Integer height, ?Integer bg_color, Hash[untyped, untyped] metadata) -> void
+    def initialize_copy: (Image) -> void
+  end
+end


### PR DESCRIPTION
This library can read and write PNG files. It is written in pure Ruby for maximum portability. Let me rephrase: it does NOT require RMagick or any other memory leaking image library.

refs: https://github.com/wvanbergen/chunky_png