### PR TITLE
Add types for email_address gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,3 +226,6 @@
 [submodule "gems/browser/5.3/_src"]
 	path = gems/browser/5.3/_src
 	url = https://github.com/fnando/browser.git
+[submodule "gems/email_address/0.2/_src"]
+	path = gems/email_address/0.2/_src
+	url = https://github.com/afair/email_address.git

--- a/gems/email_address/0.2/_scripts/test
+++ b/gems/email_address/0.2/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r email_address:0.2 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/email_address/0.2/_test/Steepfile
+++ b/gems/email_address/0.2/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "email_address"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/email_address/0.2/_test/test.rb
+++ b/gems/email_address/0.2/_test/test.rb
@@ -1,0 +1,38 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "email_address"
+
+address = "Clark.Kent+scoops@gmail.com"
+EmailAddress.valid?(address)    #=> true
+EmailAddress.normal(address)    #=> "clark.kent+scoops@gmail.com"
+EmailAddress.canonical(address) #=> "clarkkent@gmail.com"
+EmailAddress.reference(address) #=> "c5be3597c391169a5ad2870f9ca51901"
+EmailAddress.redact(address)    #=> "{bea3f3560a757f8142d38d212a931237b218eb5e}@gmail.com"
+EmailAddress.munge(address)     #=> "cl*****@gm*****"
+EmailAddress.matches?(address, 'google') #=> 'google' (true)
+EmailAddress.error("#bad@example.com") #=> "Invalid Mailbox"
+
+email = EmailAddress.new(address) #=> #<EmailAddress::Address:0x007fe6ee150540 ...>
+email.normal        #=> "clark.kent+scoops@gmail.com"
+email.canonical     #=> "clarkkent@gmail.com"
+email.original      #=> "Clark.Kent+scoops@gmail.com"
+email.valid?        #=> true
+
+email.redact        #=> "{bea3f3560a757f8142d38d212a931237b218eb5e}@gmail.com"
+email.sha1          #=> "bea3f3560a757f8142d38d212a931237b218eb5e"
+email.sha256        #=> "9e2a0270f2d6778e5f647fc9eaf6992705ca183c23d1ed1166586fd54e859f75"
+email.md5           #=> "c5be3597c391169a5ad2870f9ca51901"
+email.host_name     #=> "gmail.com"
+email.provider      #=> :google
+email.mailbox       #=> "clark.kent"
+email.tag           #=> "scoops"
+
+exchanger = email.host.exchangers.first or raise
+exchanger[:ip]      #=> "2a00:1450:400b:c02::1a"
+email.host.txt_hash #=> {:v=>"spf1", :redirect=>"\_spf.google.com"}
+
+EmailAddress.normal("HIRO@こんにちは世界.com")
+                    #=> "hiro@xn--28j2a3ar1pp75ovm7c.com"
+EmailAddress.normal("hiro@xn--28j2a3ar1pp75ovm7c.com", host_encoding: :unicode)
+                    #=> "hiro@こんにちは世界.com"

--- a/gems/email_address/0.2/email_address.rbs
+++ b/gems/email_address/0.2/email_address.rbs
@@ -1,0 +1,74 @@
+class EmailAddress
+  class Address
+    include Rewriter
+
+    attr_accessor original: String
+    attr_accessor local: Local
+    attr_accessor host: Host
+    attr_accessor config: Hash[untyped, untyped]
+    attr_accessor reason: untyped
+    attr_accessor locale: String
+    attr_reader error_message: String?
+
+    def initialize: (String email_address, ?Hash[untyped, untyped] config, ?String locale) -> Address
+    def mailbox: () -> String
+    def tag: () -> String?
+    def host_name: () -> String?
+    def provider: () -> Symbol?
+
+    def normal: () -> String
+    alias to_s normal
+
+    def canonical: () -> String
+    def canonical?: () -> bool
+    def base: () -> String
+    def redact: () -> String
+    def redacted?: () -> bool
+    def munge: () -> String
+
+    def reference: (?Symbol form) -> String
+    alias md5 reference
+
+    def sha1: (?Symbol form) -> String
+    def sha256: (?Symbol form) -> String
+
+    def matches?: (*String | Array[String] rules) -> bool
+    def valid?: (?Hash[untyped, untyped] options) -> bool
+    def error: () -> String?
+  end
+
+  class Config
+  end
+
+  class Exchanger
+    type exchange = { host: String, ip: String, priority: Integer }
+    include Enumerable[exchange]
+
+    def each: () { (exchange) -> void } -> void
+  end
+
+  class Local
+  end
+
+  class Host
+    def valid?: (?Hash[untyped, untyped] rules) -> bool
+    def exchangers: () -> Exchanger
+    def txt_hash: (?String alternate_host) -> Hash[Symbol, String]
+  end
+
+  module Rewriter
+    def srs: (String sending_domain, ?Hash[untyped, untyped] options) ? { (String) -> String } -> String
+  end
+
+  def self.valid?: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> bool
+  def self.error: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String?
+  def self.normal: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String
+  def self.redact: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String
+  def self.munge: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String
+  def self.canonical: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String
+  def self.reference: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String
+  def self.base: (String email_address, ?Hash[untyped, untyped] config, ?String local) -> String
+
+  def self.new: (String email_address, ?Hash[untyped, untyped] config, ?String locale) -> Address
+  def self.matches?: (String email_address, String | Array[String] rules, ?Hash[untyped, untyped] config, ?String locale) -> Address
+end


### PR DESCRIPTION
The email_address gem provides a ruby language library for working with email addresses.

refs: https://github.com/afair/email_address