### PR TITLE
Add types for addressable gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,3 +226,6 @@
 [submodule "gems/browser/5.3/_src"]
 	path = gems/browser/5.3/_src
 	url = https://github.com/fnando/browser.git
+[submodule "gems/addressable/2.8/_src"]
+	path = gems/addressable/2.8/_src
+	url = https://github.com/sporkmonger/addressable.git

--- a/gems/addressable/2.8/_scripts/test
+++ b/gems/addressable/2.8/_scripts/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r addressable:2.8 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb

--- a/gems/addressable/2.8/_test/Steepfile
+++ b/gems/addressable/2.8/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "addressable"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/addressable/2.8/_test/test.rb
+++ b/gems/addressable/2.8/_test/test.rb
@@ -1,0 +1,47 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "addressable/uri"
+
+uri = Addressable::URI.parse("http://example.com/path/to/resource/")
+uri.scheme
+#=> "http"
+uri.host
+#=> "example.com"
+uri.path
+#=> "/path/to/resource/"
+
+uri = Addressable::URI.parse("http://www.詹姆斯.com/")
+uri.normalize
+#=> #<Addressable::URI:0xc9a4c8 URI:http://www.xn--8ws00zhy3a.com/>
+
+require "addressable/template"
+
+template = Addressable::Template.new("http://example.com/{?query*}")
+template.expand({
+  "query" => {
+    'foo' => 'bar',
+    'color' => 'red'
+  }
+})
+#=> #<Addressable::URI:0xc9d95c URI:http://example.com/?foo=bar&color=red>
+
+template = Addressable::Template.new("http://example.com/{?one,two,three}")
+template.partial_expand({"one" => "1", "three" => 3}).pattern
+#=> "http://example.com/?one=1{&two}&three=3"
+
+template = Addressable::Template.new(
+  "http://{host}{/segments*}/{?one,two,bogus}{#fragment}"
+)
+uri = Addressable::URI.parse(
+  "http://example.com/a/b/c/?one=1&two=2#foo"
+)
+template.extract(uri)
+#=>
+# {
+#   "host" => "example.com",
+#   "segments" => ["a", "b", "c"],
+#   "one" => "1",
+#   "two" => "2",
+#   "fragment" => "foo"
+# }

--- a/gems/addressable/2.8/addressable.rbs
+++ b/gems/addressable/2.8/addressable.rbs
@@ -1,0 +1,59 @@
+module Addressable
+  class Template
+    attr_reader pattern: String
+
+    def initialize: (String pattern) -> void
+    def extract: (URI uri, ?untyped processor) -> Hash[String, String]
+    def partial_expand: (Hash[untyped, untyped] mapping, ?untyped processor, ?bool normalize_values) -> self
+    def expand: (Hash[untyped, untyped] mapping, ?untyped processor, ?bool normalize_values) -> URI
+    def variables: () -> Array[String]
+    alias keys variables
+    alias names variables
+  end
+
+  class URI
+    def self.parse: (String | URI uri) -> instance
+
+    attr_reader scheme: String
+    def scheme=: (String new_scheme) -> String
+    attr_reader user: String?
+    def user=: (String? new_user) -> String?
+    attr_reader password: String?
+    def password=: (String? new_password) -> String?
+    def userinfo: () -> String?
+    def userinfo=: (String? new_userinfo) -> String?
+    attr_reader host: String
+    def host=: (String new_host) -> String
+    def hostname: () -> String
+    def hostname=: (String new_hostname) -> String
+    def tld: () -> String
+    def tld=: (String new_tld) -> String
+    def domain: () -> String
+    def authority: () -> String
+    def authority=: (String new_authority) -> String
+    def origin: () -> String
+    def origin=: (String new_origin) -> String
+    attr_reader port: Integer
+    def port=: (String | Integer? new_port) -> Integer
+    def inferred_port: () -> Integer
+    def default_port: () -> Integer
+    def site: () -> String
+    def site=: (String new_site) -> String
+    attr_reader path: String
+    def path=: (String new_path) -> String
+    def basename: () -> String
+    def extname: () -> String?
+    attr_reader query: String?
+    def query=: (String? new_query) -> String?
+    def query_values: (?singleton(Hash) return_type) -> Hash[String, String]?
+                    | (singleton(Array) return_type) -> Array[String]
+    def query_values=: (Hash[String, String]? new_query_values) -> Hash[String, String]?
+                     | (Array[String] new_query_values) -> Array[String]
+    def request_uri: () -> String
+    def request_uri=: (String new_request_uri) -> String
+    def fragment: () -> String?
+    def fragment=: (String? new_fragment) -> String?
+
+    def normalize: () -> self
+  end
+end


### PR DESCRIPTION
Addressable is an alternative implementation to the URI implementation that is part of Ruby's standard library. It is flexible, offers heuristic parsing, and additionally provides extensive support for IRIs and URI templates.

refs: https://github.com/sporkmonger/addressable