### PR TITLE
activesupport: Delete a dummy definition: Object#sum

### DIFF
--- a/gems/activesupport/6.0/patch.rbs
+++ b/gems/activesupport/6.0/patch.rbs
@@ -1,9 +1,3 @@
-class Object
-  # Object#sum is actually not defined, but rbs prototype rb generates it mistakenly due to `class << Benchmark`.
-  # So we need to define it to suppress the alias error.
-  def sum: () -> untyped
-end
-
 module ActiveSupport
   class TestCase < ::Minitest::Test
     # It is necessary to satisfy alias target.


### PR DESCRIPTION
It seems this definition was added to avoid the trouble on `rbs prototype rb` and refinements.  But it was gone away now because `rbs prototype rb` command ignores refinements now.

refs: https://github.com/ruby/rbs/pull/487