### PR TITLE
active_hash: Fix ActiveHash::Base.find does not return nil

### DIFF
--- a/gems/active_hash/3.2/active_hash.rbs
+++ b/gems/active_hash/3.2/active_hash.rbs
@@ -22,7 +22,7 @@ module ActiveHash
     def self.find: (:all) -> Relation[instance]
                  | (:first, *untyped args) -> instance?
                  | (Array[untyped] id) -> Array[instance]
-                 | (untyped id) -> instance?
+                 | (untyped id) -> instance
                  | () { (instance) -> boolish } -> instance?
     def self.find_by: (untyped options) -> instance?
     def self.find_by!: (untyped options) -> instance


### PR DESCRIPTION
It raises an exception if the target entry not found.  Therefore it would be better to use non-optional types for its retval.