### PR TITLE
activesupport: Add Enumerable#compact_blank

### DIFF
--- a/gems/activesupport/7.0/activesupport-7.0.rbs
+++ b/gems/activesupport/7.0/activesupport-7.0.rbs
@@ -49,3 +49,43 @@ module ActiveSupport
                       | ...
   end
 end
+
+module Enumerable[unchecked out Elem]
+  # Returns a new +Array+ without the blank items.
+  # Uses Object#blank? for determining if an item is blank.
+  #
+  #   [1, "", nil, 2, " ", [], {}, false, true].compact_blank
+  #   # =>  [1, 2, true]
+  #
+  #   Set.new([nil, "", 1, false]).compact_blank
+  #   # => [1]
+  #
+  # When called on a +Hash+, returns a new +Hash+ without the blank values.
+  #
+  #   { a: "", b: 1, c: nil, d: [], e: false, f: true }.compact_blank
+  #   # => { b: 1, f: true }
+  def compact_blank: () -> Array[Elem]
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Hash#reject has its own definition, so this needs one too.
+  def compact_blank: () -> Hash[K, V]
+
+  # Removes all blank values from the +Hash+ in place and returns self.
+  # Uses Object#blank? for determining if a value is blank.
+  #
+  #   h = { a: "", b: 1, c: nil, d: [], e: false, f: true }
+  #   h.compact_blank!
+  #   # => { b: 1, f: true }
+  def compact_blank!: () -> Hash[K, V]
+end
+
+class Array[unchecked out Elem]
+  # Removes all blank elements from the +Array+ in place and returns self.
+  # Uses Object#blank? for determining if an item is blank.
+  #
+  #   a = [1, "", nil, 2, " ", [], {}, false, true]
+  #   a.compact_blank!
+  #   # =>  [1, 2, true]
+  def compact_blank!: () -> Array[Elem]
+end


### PR DESCRIPTION
Enumerable#compact_blank has been added since Rails 6.1.

refs: https://github.com/rails/rails/blob/6-1-stable/activesupport/CHANGELOG.md#rails-610-december-09-2020