### PR TITLE
active_hash: Fix the type of block argument for ActiveHash::Relation#find

### DIFF
--- a/gems/active_hash/3.2/active_hash.rbs
+++ b/gems/active_hash/3.2/active_hash.rbs
@@ -68,7 +68,7 @@ module ActiveHash
             | (:first, *untyped args) -> T?
             | (Array[untyped] id) -> Array[T]
             | (untyped id) -> T?
-            | () { (instance) -> boolish } -> T?
+            | () { (T) -> boolish } -> T?
     def find_by: (untyped options) -> T?
     def find_by!: (untyped options) -> T
     def find_by_id: (untyped id) -> T?


### PR DESCRIPTION
The block should take an instance of ActiveHash::Base object, not a relation object itself.