### PR TITLE
Move `rescue_from` type from an interface to ActiveSupport::Rescuable::ClassMethods

### DIFF
--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -4,14 +4,8 @@ module ActionController
     def flash: () -> untyped
   end
 
-  interface _API_and_Base_singletion
-    def rescue_from: (*Class, ?with: Symbol | Proc) -> void
-                   | (*Class) { (Exception) -> void } -> void
-  end
-
   class Base < Metal
     include _API_and_Base
-    extend _API_and_Base_singletion
 
     # https://github.com/rails/rails/blob/v6.0.3.2/actionpack/lib/action_controller/base.rb#L205-L255
     include AbstractController::Rendering
@@ -59,6 +53,8 @@ module ActionController
     include AbstractController::Callbacks
     extend AbstractController::Callbacks::ClassMethods
     include Rescue
+    include ActiveSupport::Rescuable
+    extend ActiveSupport::Rescuable::ClassMethods
     include Instrumentation
     extend Instrumentation::ClassMethods
     include ParamsWrapper
@@ -67,7 +63,6 @@ module ActionController
 
   class API < Metal
     include _API_and_Base
-    extend _API_and_Base_singletion
 
     # https://github.com/rails/rails/blob/v6.0.3.2/actionpack/lib/action_controller/api.rb#L112-L145
     include AbstractController::Rendering
@@ -87,6 +82,8 @@ module ActionController
     include AbstractController::Callbacks
     extend AbstractController::Callbacks::ClassMethods
     include Rescue
+    include ActiveSupport::Rescuable
+    extend ActiveSupport::Rescuable::ClassMethods
     include Instrumentation
     extend Instrumentation::ClassMethods
     include ParamsWrapper

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -10819,7 +10819,8 @@ module ActiveSupport
       #   end
       #
       # Exceptions raised inside exception handlers are not propagated up.
-      def rescue_from: (*untyped klasses, ?with: untyped? with) { () -> untyped } -> untyped
+      def rescue_from: (*Class, ?with: Symbol | Proc) -> void
+                     | (*Class) { (Exception) -> void } -> void
 
       # Matches an exception to a handler based on the exception class.
       #


### PR DESCRIPTION
Close #438

PR #438 ignores the well-typed `rescue_from` definition, so I replaced the type of `ActiveSupport::Rescuable::ClassMethods#rescue_from` with the definition defiend in the interface.