### PR TITLE
Add types for `attr_internal_**` methods

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -30,3 +30,12 @@ hash.deep_stringify_keys!
 
 hash.deep_symbolize_keys
 hash.deep_symbolize_keys!
+
+class TestAttrInternal
+  attr_internal_reader :internal_variable_reader_1
+  attr_internal_reader 'internal_variable_reader_2', :internal_variable_reader_3
+  attr_internal_writer :internal_variable_writer_1
+  attr_internal_writer 'internal_variable_writer_2'
+  attr_internal_writer :internal_variable_accessor_1
+  attr_internal_writer 'internal_variable_accessor_2'
+end

--- a/gems/activesupport/6.0/_test/test.rbs
+++ b/gems/activesupport/6.0/_test/test.rbs
@@ -1,0 +1,2 @@
+class TestAttrInternal
+end

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -3552,28 +3552,6 @@ class Module
   def anonymous?: () -> untyped
 end
 
-class Module
-  # Declares an attribute reader backed by an internally-named instance variable.
-  def attr_internal_reader: (*untyped attrs) -> untyped
-
-  # Declares an attribute writer backed by an internally-named instance variable.
-  def attr_internal_writer: (*untyped attrs) -> untyped
-
-  # Declares an attribute reader and writer backed by an internally-named instance
-  # variable.
-  def attr_internal_accessor: (*untyped attrs) -> untyped
-
-  alias attr_internal attr_internal_accessor
-
-  attr_accessor self.attr_internal_naming_format: untyped
-
-  private
-
-  def attr_internal_ivar_name: (untyped attr) -> untyped
-
-  def attr_internal_define: (untyped attr_name, untyped `type`) -> untyped
-end
-
 # Extends the module object with class/module and instance accessors for
 # class/module attributes, just like the native attr* accessors for instance
 # attributes.

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -194,6 +194,28 @@ class Module
   # Manual definition to make block optional
   def mattr_accessor: (*untyped syms, ?default: untyped? default, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> untyped
                     | ...
+
+  # TODO: Fix to use `interned` in attrs params after releasing ruby/rbs#1499
+  def attr_internal_reader: (*(Symbol | String) attrs) -> void
+
+  # TODO: Fix to use `interned` in attrs params after releasing ruby/rbs#1499
+  def attr_internal_writer: (*(Symbol | String) attrs) -> void
+
+  # TODO: Fix to use `interned` in attrs params after releasing ruby/rbs#1499
+  def attr_internal_accessor: (*(Symbol | String) attrs) -> void
+
+  alias attr_internal attr_internal_accessor
+
+  attr_accessor self.attr_internal_naming_format: String
+
+  private
+
+  # TODO: Fix to use `interned` in attr params after releasing ruby/rbs#1499
+  def attr_internal_ivar_name: ((Symbol | String) attr) -> String
+
+  type access_type = :reader | :writer
+  # TODO: Fix to use `interned` in attr params after releasing ruby/rbs#1499
+  def attr_internal_define: ((Symbol | String) attr_name, access_type `type`) -> void
 end
 
 class Integer


### PR DESCRIPTION
This PR adds types to `attr_internal_**` methods which is written in [active_support/core_ext/module/attr_internal.rb](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/module/attr_internal.rb)

Also, I use `(Symbol | String)` type in the attr parameter of these methods instead of `interned` because RBS has been decided on using `internal` instead of (Symbol | String) or (String | Symbol) but that hasn't been released yet. (https://github.com/ruby/rbs/pull/1499)

So. I added TODO comments and will fix them after releasing the `interned` keyword.