### PR TITLE
activesupport: Add types for OrderedOptions and InheritableOptions

### DIFF
--- a/gems/actionview/6.0/actionview-generated.rbs
+++ b/gems/actionview/6.0/actionview-generated.rbs
@@ -173,7 +173,7 @@ module ActionView
 
     attr_reader lookup_context: untyped
 
-    attr_accessor config(@_config): untyped
+    attr_accessor config(@_config): ActiveSupport::InheritableOptions
 
     attr_accessor assigns(@_assigns): untyped
 

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -10541,59 +10541,6 @@ module ActiveSupport
 end
 
 module ActiveSupport
-  # Usually key value pairs are handled something like this:
-  #
-  #   h = {}
-  #   h[:boy] = 'John'
-  #   h[:girl] = 'Mary'
-  #   h[:boy]  # => 'John'
-  #   h[:girl] # => 'Mary'
-  #   h[:dog]  # => nil
-  #
-  # Using +OrderedOptions+, the above code could be reduced to:
-  #
-  #   h = ActiveSupport::OrderedOptions.new
-  #   h.boy = 'John'
-  #   h.girl = 'Mary'
-  #   h.boy  # => 'John'
-  #   h.girl # => 'Mary'
-  #   h.dog  # => nil
-  #
-  # To raise an exception when the value is blank, append a
-  # bang to the key name, like:
-  #
-  #   h.dog! # => raises KeyError: :dog is blank
-  #
-  class OrderedOptions[T, U] < Hash[T, U]
-    alias _get []
-
-    def []=: (untyped key, untyped value) -> untyped
-
-    def []: (untyped key) -> untyped
-
-    def method_missing: (untyped name, *untyped args) -> untyped
-
-    def respond_to_missing?: (untyped name, untyped include_private) -> ::TrueClass
-
-    def extractable_options?: () -> ::TrueClass
-  end
-
-  # +InheritableOptions+ provides a constructor to build an +OrderedOptions+
-  # hash inherited from another hash.
-  #
-  # Use this if you already have some hash and you want to create a new one based on it.
-  #
-  #   h = ActiveSupport::InheritableOptions.new({ girl: 'Mary', boy: 'John' })
-  #   h.girl # => 'Mary'
-  #   h.boy  # => 'John'
-  class InheritableOptions[T, U] < OrderedOptions[T, U]
-    def initialize: (?untyped? parent) -> untyped
-
-    def inheritable_copy: () -> untyped
-  end
-end
-
-module ActiveSupport
   # +ParameterFilter+ allows you to specify keys for sensitive data from
   # hash-like object and replace corresponding value. Filtering only certain
   # sub-keys from a hash is possible by using the dot notation:

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -1846,48 +1846,6 @@ module ActiveSupport
   end
 end
 
-module ActiveSupport
-  # Configurable provides a <tt>config</tt> method to store and retrieve
-  # configuration options as an <tt>OrderedHash</tt>.
-  module Configurable
-    extend ActiveSupport::Concern
-
-    class Configuration[T, U] < ActiveSupport::InheritableOptions[T, U]
-      def compile_methods!: () -> untyped
-
-      # Compiles reader methods so we don't have to go through method_missing.
-      def self.compile_methods!: (untyped keys) -> untyped
-    end
-
-    module ClassMethods
-      def config: () -> untyped
-
-      def configure: () { (untyped) -> untyped } -> untyped
-
-      private
-
-      def config_accessor: (*untyped names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) { () -> untyped } -> untyped
-    end
-
-    # Reads and writes attributes from a configuration <tt>OrderedHash</tt>.
-    #
-    #   require 'active_support/configurable'
-    #
-    #   class User
-    #     include ActiveSupport::Configurable
-    #   end
-    #
-    #   user = User.new
-    #
-    #   user.config.allowed_access = true
-    #   user.config.level = 1
-    #
-    #   user.config.allowed_access # => true
-    #   user.config.level          # => 1
-    def config: () -> untyped
-  end
-end
-
 class Array[unchecked out Elem]
   # Returns the tail of the array from +position+.
   #
@@ -7354,7 +7312,7 @@ module ActiveSupport
 
     private
 
-    def options: () -> untyped
+    def options: () -> InheritableOptions
 
     def deserialize: (untyped config) -> untyped
   end

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -152,6 +152,29 @@ module ActiveSupport
     def tv_usec: () -> Integer
     def wednesday?: () -> bool
   end
+
+  class OrderedOptions < Hash[Symbol, untyped]
+    alias _get []
+
+    # TODO: Fix to use `interned` in key params after releasing ruby/rbs#1499
+    def []=: ((String | Symbol) key, untyped value) -> untyped
+
+    # TODO: Fix to use `interned` in key params after releasing ruby/rbs#1499
+    def []: ((String | Symbol) key) -> untyped
+
+    def method_missing: (Symbol name, *untyped args) -> untyped
+
+    def respond_to_missing?: (Symbol name, ?bool include_private) -> true
+
+    def extractable_options?: () -> true
+  end
+
+  class InheritableOptions < OrderedOptions
+    # TODO: Fix to use `interned` in parent params after releasing ruby/rbs#1499
+    def initialize: (?Hash[(String | Symbol), untyped]? parent) -> void
+
+    def inheritable_copy: () -> instance
+  end
 end
 
 class Hash[unchecked out K, unchecked out V]

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -12,11 +12,27 @@ module ActiveSupport
   end
 
   module Configurable
-    module ClassMethods
-      # Manual definition to make block optional
-      def config_accessor: (*untyped names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> untyped
-                         | ...
+    extend Concern
+
+    class Configuration < InheritableOptions
+      def compile_methods!: () -> void
+
+      # Compiles reader methods so we don't have to go through method_missing.
+      def self.compile_methods!: (Array[Symbol | String] keys) -> void
     end
+
+    module ClassMethods
+      def config: () -> InheritableOptions
+
+      def configure: () { (InheritableOptions config) -> void } -> void
+
+      private
+
+      # TODO: Fix to use `interned` in names params after releasing ruby/rbs#1499
+      def config_accessor: (*(String | Symbol) names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> void
+    end
+
+    def config: () -> InheritableOptions
   end
 
   class Deprecation

--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -166,7 +166,7 @@ module Rails
 
       attr_accessor ssl_options: untyped
 
-      attr_accessor public_file_server: untyped
+      attr_accessor public_file_server: ActiveSupport::OrderedOptions
 
       attr_accessor session_options: untyped
 
@@ -194,7 +194,7 @@ module Rails
 
       attr_accessor require_master_key: untyped
 
-      attr_accessor credentials: untyped
+      attr_accessor credentials: ActiveSupport::OrderedOptions
 
       attr_accessor disable_sandbox: untyped
 
@@ -551,9 +551,9 @@ module Rails
     #
     # +Rails.application.secrets.namespace+ returns +my_app_production+ in the
     # production environment.
-    def secrets: () -> untyped
+    def secrets: () -> ActiveSupport::OrderedOptions
 
-    attr_writer secrets: untyped
+    attr_writer secrets: ActiveSupport::OrderedOptions
 
     # The secret_key_base is used as the input secret to the application's key generator, which in turn
     # is used to create all MessageVerifiers/MessageEncryptors, including the ones that sign and encrypt cookies.


### PR DESCRIPTION
This PR added the types for ActiveSupport::OrderOptions and ActiveSupport::IneritableOptions.
Besides, I replace the types for methods that use or return these classes' instances.

ref: [ActiveSupport::OrderedOptions and ActiveSupport::InheritableOptions](https://github.com/rails/rails/blob/v6.0.6.1/activesupport/lib/active_support/ordered_options.rb)