### PR TITLE
httparty: Fixed return type of HTTParty::Response#parsed_response

### DIFF
--- a/gems/httparty/0.18/_test/test_1.rb
+++ b/gems/httparty/0.18/_test/test_1.rb
@@ -23,7 +23,8 @@ class Foo
   end
 end
 
-Foo.get('https://reqres.in')
+api_response = Foo.get('https://reqres.in')
+api_response.parse_response
 Foo.mkcol('https://reqris.in')
 Foo.lock('https://reqres.in')
 Foo.unlock('https://reqres.in')

--- a/gems/httparty/0.18/httparty.rbs
+++ b/gems/httparty/0.18/httparty.rbs
@@ -424,7 +424,7 @@ module HTTParty
 
     def initialize: (HTTParty::Request request, untyped response, String parsed_block, ?Hash[untyped, untyped] options) -> instance
 
-    def parsed_response: () -> String
+    def parsed_response: () -> Object
 
     def code: () -> Integer
 


### PR DESCRIPTION
HTTParty::Response#parsed_response's return type is incorrect as described in this issue #466