### PR TITLE
httparty: Fixed return type of HTTParty::Response#parsed_response

### DIFF
--- a/gems/httparty/0.18/httparty.rbs
+++ b/gems/httparty/0.18/httparty.rbs
@@ -424,7 +424,7 @@ module HTTParty
 
     def initialize: (HTTParty::Request request, untyped response, String parsed_block, ?Hash[untyped, untyped] options) -> instance
 
-    def parsed_response: () -> String
+    def parsed_response: () -> Object
 
     def code: () -> Integer
 


### PR DESCRIPTION
Changed return type form parsed_response from String to Object as discussed in the issue #466.