### PR TITLE
Add types for web-push gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -238,3 +238,6 @@
 [submodule "gems/json-jwt/1.16/_src"]
 	path = gems/json-jwt/1.16/_src
 	url = https://github.com/nov/json-jwt.git
+[submodule "gems/web-push/3.0/_src"]
+	path = gems/web-push/3.0/_src
+	url = https://github.com/pushpad/web-push.git

--- a/gems/web-push/3.0/_scripts/test
+++ b/gems/web-push/3.0/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r web-push:3.0 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/web-push/3.0/_test/Steepfile
+++ b/gems/web-push/3.0/_test/Steepfile
@@ -1,0 +1,13 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "web-push"
+
+  library "json"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/web-push/3.0/_test/test.rb
+++ b/gems/web-push/3.0/_test/test.rb
@@ -1,0 +1,30 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "web-push"
+require "json"
+
+# One-time, on the server
+vapid_key = WebPush.generate_key
+
+# Save these in your application server settings
+vapid_key.public_key
+vapid_key.private_key
+
+# Or you can save in PEM format if you prefer
+vapid_key.to_pem
+
+message = {
+  title: "Example",
+  body: "Hello, world!",
+  icon: "https://example.com/icon.png"
+}
+
+WebPush.payload_send(
+  endpoint: "https://fcm.googleapis.com/gcm/send/eah7hak....",
+  message: JSON.generate(message),
+  p256dh: "BO/aG9nYXNkZmFkc2ZmZHNmYWRzZmFl...",
+  auth: "aW1hcmthcmFpa3V6ZQ==",
+  ttl: 600, # optional, ttl in seconds, defaults to 2419200 (4 weeks)
+  urgency: 'normal' # optional, it can be very-low, low, normal, high, defaults to normal
+)

--- a/gems/web-push/3.0/web-push.rbs
+++ b/gems/web-push/3.0/web-push.rbs
@@ -1,0 +1,37 @@
+module WebPush
+  class Error < RuntimeError
+  end
+
+  class ConfigurationError < Error
+  end
+
+  class ResponseError < Error
+  end
+
+  class InvalidSubscription < ResponseError
+  end
+
+  class ExpiredSubscription < ResponseError
+  end
+
+  class Unauthorized < ResponseError
+  end
+
+  class PayloadTooLarge < ResponseError
+  end
+
+  class TooManyRequests < ResponseError
+  end
+
+  class PushServiceError < ResponseError
+  end
+
+  class VapidKey
+    def public_key: () -> String
+    def private_key: () -> String
+    def to_pem: () -> String
+  end
+
+  def self.generate_key: () -> VapidKey
+  def self.payload_send: (?message: String, endpoint: String, ?p256dh: String, ?auth: String, ?vapid: { subject: String, public_key: String, private_key: String }, **untyped) -> untyped
+end


### PR DESCRIPTION
This gem makes it possible to send push messages to web browsers from Ruby backends using the Web Push Protocol. It supports Message Encryption for Web Push and VAPID.

refs: https://github.com/pushpad/web-push