### PR TITLE
activerecord: `save` and `valid?` families should handle validation contexts

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-validation-contexts.rb
+++ b/gems/activerecord/6.0/_test/activerecord-validation-contexts.rb
@@ -1,0 +1,23 @@
+model = ActiveRecord::Base.new
+
+model.save
+model.save(context: :sample_context)
+model.save(context: [:update, :sample_context], touch: false)
+model.save(validate: false, touch: true)
+
+model.save!
+model.save!(context: :sample_context)
+model.save!(context: [:update, :sample_context], touch: false)
+model.save!(validate: false, touch: true)
+
+model.valid?
+model.valid?(:sample_context)
+model.valid?([:update, :sample_context])
+
+model.validate
+model.validate(:sample_context)
+model.validate([:update, :sample_context])
+
+model.invalid?
+model.invalid?(:sample_context)
+model.invalid?([:update, :sample_context])

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -83,14 +83,14 @@ module ActiveRecord
 
     def will_save_change_to_attribute?: (String | Symbol attr_name, ?from: untyped, ?to: untyped) -> bool
 
-    def save!: (?validate: bool, ?touch: bool) -> self
-    def save: () -> bool
+    def save!: (?context: Symbol | Array[Symbol] context, ?validate: bool, ?touch: bool) -> void
+    def save: (?context: Symbol | Array[Symbol] context, ?validate: bool, ?touch: bool) -> bool
     def update!: (*untyped) -> self
     def update: (*untyped) -> bool
     def destroy!: () -> self
     def destroy: () -> bool
-    def valid?: () -> bool
-    def invalid?: () -> bool
+    def valid?: (?Symbol | Array[Symbol] context) -> bool
+    def invalid?: (?Symbol | Array[Symbol] context) -> bool
     def errors: () -> untyped
     def []: (Symbol) -> untyped
     def []=: (Symbol, untyped) -> untyped


### PR DESCRIPTION
Ref: https://api.rubyonrails.org/v6.0.2.2/classes/ActiveRecord/Validations.html