### PR TITLE
globalid: Use untyped type for arguments

### DIFF
--- a/gems/globalid/1.1/globalid.rbs
+++ b/gems/globalid/1.1/globalid.rbs
@@ -33,7 +33,7 @@ class GlobalID
 
   def to_param: () -> String
 
-  def as_json: (*void) -> String
+  def as_json: (*untyped) -> String
 
   # Delegated methods
 
@@ -44,5 +44,5 @@ class GlobalID
 
   def to_s: () -> String
 
-  def deconstruct_keys: (void _keys) -> { app: String, model_name: String, model_id: String, params: Hash[untyped, untyped]? }
+  def deconstruct_keys: (untyped _keys) -> { app: String, model_name: String, model_id: String, params: Hash[untyped, untyped]? }
 end


### PR DESCRIPTION
Since RBS-3.3, void type is not allowed as an argument type.  This replaces them to untyped.