### PR TITLE
fix type definition on RuboCop

### DIFF
--- a/gems/parser/3.2/parser.rbs
+++ b/gems/parser/3.2/parser.rbs
@@ -48,6 +48,10 @@ module Parser
     class Buffer
     end
 
+    class TreeRewriter
+      def replace: (untyped range, String content) -> self
+    end
+
     class Map
       def line: () -> Integer
       def first_line: () -> Integer

--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -12,13 +12,17 @@ module RuboCop
     class Base
       extend AST::NodePattern::Macros
 
-      def add_offense: (untyped node, ?message: String) -> void
+      def add_offense: (untyped node, ?message: String) -> void |
+                       (untyped node, ?message: String) {(Corrector) -> void} -> void
       def cop_config: () -> Hash[String, untyped]
       def processed_source: () -> AST::ProcessedSource
     end
 
+    class Corrector < Parser::Source::TreeRewriter
+    end
+
     module RangeHelp
-      def source_range: (Parser::Source::Buffer source_buffer, Integer line_number, Integer column, ?Integer length) -> Parser::Source::Range 
+      def source_range: (Parser::Source::Buffer source_buffer, Integer line_number, Integer column, ?Integer length) -> Parser::Source::Range
     end
   end
 


### PR DESCRIPTION
- can receive block on `add_offense`
- add necessary types