### PR TITLE
sorcery: Do not use void? type

### DIFF
--- a/gems/sorcery/0.16/sorcery.rbs
+++ b/gems/sorcery/0.16/sorcery.rbs
@@ -16,7 +16,7 @@ module Sorcery
 
       def logged_in?: () -> bool
       def current_user: () -> (T | nil)
-      def logout: () -> (nil | void)
+      def logout: () -> void
       def auto_login: (T, ?bool should_remember) -> void
       def redirect_back_or_to: (String url, ?Hash[(String | Symbol), String] flash_hash) -> void
     end


### PR DESCRIPTION
Since RBS-3.3, void? type is not allowed.