### PR TITLE
Add types for actioncable

### DIFF
--- a/gems/actioncable/7.1/_scripts/test
+++ b/gems/actioncable/7.1/_scripts/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit command with non-zero status code, Output logs of every command executed, Treat unset variables as an error when substituting.
+set -eou pipefail
+# Internal Field Separator - Linux shell variable
+IFS=$'\n\t'
+# Print shell input lines
+set -v
+
+# Set RBS_DIR variable to change directory to execute type checks using `steep check`
+RBS_DIR=$(cd $(dirname $0)/..; pwd)
+# Set REPO_DIR variable to validate RBS files added to the corresponding folder
+REPO_DIR=$(cd $(dirname $0)/../../..; pwd)
+# Validate RBS files, using the bundler environment present
+bundle exec rbs --repo $REPO_DIR -r actioncable:7.1 validate --silent
+
+cd ${RBS_DIR}/_test
+# Run type checks
+bundle exec steep check
+
+$(git rev-parse --show-toplevel)/bin/check-untyped-call.rb
+$(git rev-parse --show-toplevel)/bin/check-manifest-yaml.rb

--- a/gems/actioncable/7.1/_test/Steepfile
+++ b/gems/actioncable/7.1/_test/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :test do
+  check "."
+  signature "."
+
+  repo_path "../../../"
+  library "actioncable"
+
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/gems/actioncable/7.1/_test/test.rb
+++ b/gems/actioncable/7.1/_test/test.rb
@@ -1,0 +1,4 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "actioncable"

--- a/gems/actioncable/7.1/actioncable.rbs
+++ b/gems/actioncable/7.1/actioncable.rbs
@@ -1,0 +1,11 @@
+module ActionCable
+  module Connection
+    class Base
+    end
+  end
+
+  module Channel
+    class Base
+    end
+  end
+end


### PR DESCRIPTION
This only adds empty class definitions.  But these classes are very important because `rails new` generates a new application having subclasses of them.  I saw it in the Rails tutorial.