### PR TITLE
activerecord: Fix signatures of AR::Base.includes, .preload and .eager_load

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -10,3 +10,7 @@ class User < ActiveRecord::Base
 end
 
 _user = User.new
+
+User.eager_load(:address, friends: [:address, :followers])
+User.includes(:address, :friends).to_a
+User.preload(:address, friends: [:address, :followers])

--- a/gems/activerecord/6.0/_test/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rbs
@@ -1,3 +1,8 @@
 class User < ActiveRecord::Base
+  class ActiveRecord_Relation < ActiveRecord::Relation
+  end
+
+  extend ActiveRecord::Relation::ClassMethods[User, ActiveRecord_Relation, Integer]
+
   def something: () -> untyped
 end

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -308,9 +308,9 @@ module ActiveRecord
       def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
       def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
       def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def includes: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def preload: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def includes: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
+      def eager_load: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
+      def preload: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
       def find_by: (*untyped) -> Model?
       def find_by!: (*untyped) -> Model
       def find: (PrimaryKey id) -> Model
@@ -391,9 +391,9 @@ module ActiveRecord
       def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
       def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
       def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def includes: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def preload: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def includes: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
+      def eager_load: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
+      def preload: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
       def find_by: (*untyped) -> Model?
       def find_by!: (*untyped) -> Model
       def find: (PrimaryKey id) -> Model
@@ -467,9 +467,9 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
   def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
   def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def includes: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def preload: (*String | Symbol | Hash[untyped, untyped]) -> self
+  def includes: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
+  def eager_load: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
+  def preload: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
   def find_by: (untyped, *untyped) -> Model?
   def find_by!: (untyped, *untyped) -> Model
   def find: (PrimaryKey id) -> Model
@@ -551,9 +551,9 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
   def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
   def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def includes: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def preload: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+  def includes: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
+  def eager_load: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
+  def preload: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
   def find_by: (untyped) -> Model?
   def find_by!: (untyped) -> Model
   def find: (PrimaryKey id) -> Model


### PR DESCRIPTION
`ActiveRecord::Base.includes`, `.preload` and `.eager_load` can take association names in several forms; Strings, Symbols, Arrays of Strings, Hashes, and keywoard arguments.

Actually, the API document mentions such usages:

```
User.eager_load(:address, friends: [:address, :followers])
```

refs: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-eager_load