### PR TITLE
Add types for ActionDispatch::RequestId

### DIFF
--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -1,0 +1,15 @@
+module ActionDispatch
+  class RequestId
+    X_REQUEST_ID: ::String
+
+    def initialize: (Rack::_Application app) -> void
+
+    def call: (Rack::env env) -> Rack::response
+
+    private
+
+    def make_request_id: (String? request_id) -> String
+
+    def internal_request_id: () -> String
+  end
+end

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -8140,32 +8140,6 @@ module ActionDispatch
 end
 
 module ActionDispatch
-  # Makes a unique request id available to the +action_dispatch.request_id+ env variable (which is then accessible
-  # through <tt>ActionDispatch::Request#request_id</tt> or the alias <tt>ActionDispatch::Request#uuid</tt>) and sends
-  # the same id to the client via the X-Request-Id header.
-  #
-  # The unique request id is either based on the X-Request-Id header in the request, which would typically be generated
-  # by a firewall, load balancer, or the web server, or, if this header is not available, a random uuid. If the
-  # header is accepted from the outside world, we sanitize it to a max of 255 chars and alphanumeric and dashes only.
-  #
-  # The unique request id can be used to trace a request end-to-end and would typically end up being part of log files
-  # from multiple pieces of the stack.
-  class RequestId
-    X_REQUEST_ID: ::String
-
-    def initialize: (untyped app) -> untyped
-
-    def call: (untyped env) -> untyped
-
-    private
-
-    def make_request_id: (untyped request_id) -> untyped
-
-    def internal_request_id: () -> untyped
-  end
-end
-
-module ActionDispatch
   module Session
     class SessionRestoreError < StandardError
       # nodoc:


### PR DESCRIPTION
This PR adds types for ActionDispatch::RequestId

ref: https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/middleware/request_id.rb