### PR TITLE
activestorage: Attached::Many should support methods of ActiveRerord

### DIFF
--- a/gems/activestorage/6.0/lib/attached/many.rbs
+++ b/gems/activestorage/6.0/lib/attached/many.rbs
@@ -1,6 +1,8 @@
 module ActiveStorage
   # Decorated proxy object representing of multiple attachments to a model.
   class Attached::Many < Attached
+    include _ActiveRecord_Relation[ActiveStorage::Attachment, Integer]
+
     # Returns all the associated attachment records.
     #
     # All methods called on this proxy object that aren't listed here will automatically be delegated to +attachments+.


### PR DESCRIPTION
`ActiveStorage::Attached::Many` delegates missing method calls to the ActiveRecord::Relation object; `#attachments`.  Therefore it should support methods of AR::Relation.

refs:
* https://github.com/rails/rails/blob/v7.1.0/activestorage/lib/active_storage/attached/many.rb#L27
* https://github.com/rails/rails/blob/v7.1.0/activestorage/lib/active_storage/attached/model.rb#L201