### PR TITLE
globalid: Use `top` instead of `void` to avoid error on RBS v3.3

### DIFF
--- a/gems/globalid/1.1/globalid.rbs
+++ b/gems/globalid/1.1/globalid.rbs
@@ -33,7 +33,7 @@ class GlobalID
 
   def to_param: () -> String
 
-  def as_json: (*void) -> String
+  def as_json: (*top) -> String
 
   # Delegated methods
 
@@ -44,5 +44,5 @@ class GlobalID
 
   def to_s: () -> String
 
-  def deconstruct_keys: (void _keys) -> { app: String, model_name: String, model_id: String, params: Hash[untyped, untyped]? }
+  def deconstruct_keys: (top _keys) -> { app: String, model_name: String, model_id: String, params: Hash[untyped, untyped]? }
 end


### PR DESCRIPTION
The globalid RBS raises an error on `rbs validate` with RBS v3.3 because RBS v3.3 does not allow `void` as an argument.

```console
$ rbs _3.2.2_ -I gems/globalid/1.1/ validate --silent
$ rbs _3.3.0_ -I gems/globalid/1.1/ validate --silent
gems/globalid/1.1/globalid.rbs:36:15...36:32: `void` type is only allowed in return type or generics parameter
gems/globalid/1.1/globalid.rbs:47:24...47:126: `void` type is only allowed in return type or generics parameter
```

By this change, `rbs validate` does not display this error.

```console
$ rbs _3.2.2_ -I gems/globalid/1.1/ validate --silent
$ rbs _3.3.0_ -I gems/globalid/1.1/ validate --silent
```

Close #473