### PR TITLE
Fix RBS syntax errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    abbrev (0.1.1)
+    abbrev (0.1.2)
     activesupport (7.1.1)
       base64
       bigdecimal
@@ -41,7 +41,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (3.3.0)
+    rbs (3.4.1)
       abbrev
     ruby2_keywords (0.0.5)
     securerandom (0.3.0)

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -444,7 +444,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def select: (*Symbol | String) -> Relation
             | () { (Model) -> boolish } -> Array[Model]
   def reselect: (*Symbol | String) -> Relation
-  def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void }) ?{ (Module extention) [self: Relation] -> void } -> void
+  def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void) ?{ (Module extention) [self: Relation] -> void } -> void
 end
 
 # https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/unary.rb

--- a/gems/mime-types/3.5/mime/types.rbs
+++ b/gems/mime-types/3.5/mime/types.rbs
@@ -70,7 +70,7 @@ module MIME
     def inspect: () -> String
 
     # Iterates through the type variants.
-    def each: () ?{ (MIME::Type]) -> void } -> Array[MIME::Type]
+    def each: () ?{ (MIME::Type) -> void } -> Array[MIME::Type]
 
     # Returns a list of MIME::Type objects, which may be empty. The optional
     # flag parameters are <tt>:complete</tt> (finds only complete MIME::Type

--- a/gems/mime-types/3.5/mime/types/registry.rbs
+++ b/gems/mime-types/3.5/mime/types/registry.rbs
@@ -9,7 +9,7 @@ module MIME
     def self.count: () -> Integer
 
     # MIME::Types#each against the default MIME::Types registry.
-    def self.each: () ?{ (MIME::Type]) -> void } -> Array[MIME::Type]
+    def self.each: () ?{ (MIME::Type) -> void } -> Array[MIME::Type]
 
     # MIME::Types#type_for against the default MIME::Types registry.
     def self.type_for: (untyped filename) -> Array[MIME::Type]


### PR DESCRIPTION
RBS 3.4 uncovers the syntax errors.

```
> ~/.rvm/gems/ruby-3.2.1/gems/rbs-3.4.1/lib/rbs/parser_aux.rb:17:in `_parse_signature': .../gem_rbs_collection/gems/mime-types/3.5/mime/types/registry.rbs:12:36...12:37: Syntax error: unexpected token for function parameter name, token=`]` (pRBRACKET) (RBS::ParsingError)
> 
>       def self.each: () ?{ (MIME::Type]) -> void } -> Array[MIME::Type]
>                                       ^
```