### PR TITLE
set sidekiq redis direct dependency

### DIFF
--- a/gems/sidekiq/6.3/manifest.yaml
+++ b/gems/sidekiq/6.3/manifest.yaml
@@ -1,3 +1,4 @@
 dependencies:
   - name: logger
   - name: monitor
+  - name: redis


### PR DESCRIPTION
After `rbs collection` on a project with sidekiq, I'm getting " Cannot find type `::Redis`" running steep. gems should be declaring their direct dependencies as well.

This is probably not the only "direct dependency" issue around, but it's enough to get the conversation started.