### PR TITLE
Fix rack `response` type

### DIFF
--- a/gems/rack/2.2/_test/string_body.rb
+++ b/gems/rack/2.2/_test/string_body.rb
@@ -1,0 +1,10 @@
+# @type var app: Rack::_Application
+app = _ = nil
+
+middleware = -> (env) do
+  # @type var env: Rack::env
+  # @type block: Rack::response
+  [404, { "FOO" => "BAR" }, "Not found"]
+end
+
+middleware #: Rack::_Application

--- a/gems/rack/2.2/rack.rbs
+++ b/gems/rack/2.2/rack.rbs
@@ -64,7 +64,16 @@ module Rack
   def self.release: -> String
 
   type env = Hash[String, untyped]
-  type response = [_ToI, _Each[[String, String]], _Each[String]]
+
+  type string_body = _ToStr
+
+  type enumerable_body = _Each[String]
+
+  interface _StreamingBody
+    def call: (untyped stream) -> void
+  end
+
+  type response = [_ToI, _Each[[String, String]], string_body | enumerable_body | _StreamingBody]
 
   interface _Application
     def call: (env) -> response


### PR DESCRIPTION
Allow a `String` to be the body of rack response.

The [SPEC](https://github.com/rack/rack/blob/main/SPEC.rdoc#label-The+Body) doesn't say `String` is permitted, but the [implementation](https://github.com/rack/rack/blob/main/lib/rack/response.rb#L37-L46) seems to accept `to_str` body.