### PR TITLE
Display example message on bin test command

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -8,11 +8,28 @@ require 'yaml'
 @verbose = false
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: bin/test [options] <gem...>"
+  opts.banner = <<~BANNER
+    Usage: bin/test [options] <gem...>
+
+    Examples:
+        # Test a gem
+        $ bin/test gems/rack/2.2
+
+        # Test a gem with verbose messages
+        $ bin/test gems/rack/2.2 -v
+
+        # Test all the gems
+        $ bin/test -a
+
+    Options:
+  BANNER
 
   opts.on("-a", "--all", "Test all gems") do @all = true end
   opts.on("-v", "--verbose", "Print more messages") do @verbose = true end
-end.parse!(ARGV)
+
+  opts.parse!(ARGV)
+  abort opts.help if ARGV.empty? && !@all
+end
 
 dirs =
   if @all

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This script generates an empty RBS to `gems/GEM_NAME/VERSION/GEM_NAME.rbs`, and 
 
 Specify the _major_ and _minor_ version you are using would be great for most cases.
 
-We recommend adding `_test`, and `_src` directories.
+We recommend adding `_test` and `_src` directories.
 We assume `_test` directory contains files for testing, and `_src` is a git submodule for the source code of the version of the gem.
 
 ### Write RBS files
@@ -82,9 +82,8 @@ It is important that the testing is to confirm the relationship between RBS and 
 
 You can test your code with the following steps.
 
-1. Write a Ruby program which uses the gem code
-2. Execute `bin/test gems/GEM_NAME/VERSION` to run test test suites.
-   * It executes `rbs validate` and `steep check`.
+1. Write a Ruby program which uses the gem code.
+2. Execute `bin/test gems/GEM_NAME/VERSION` to run the test suites, including `rbs validate` and `steep check`.
 
 See existing gems for examples, like [redis/4.2](https://github.com/ruby/gem_rbs_collection/tree/main/gems/redis/4.2/_test) or [listen/3.2](https://github.com/ruby/gem_rbs_collection/tree/main/gems/listen/3.2/_test).
 


### PR DESCRIPTION
ref: https://github.com/ruby/gem_rbs_collection/pull/502


I applied @ybiquitous's changes with small modifications.

* Use `banner` instead of the `examples` lvar
* Explicit `--help` option is unnecessary because optparse defines `--help` automatically.
* `tap` is unnecessary to call `abort`. We can write the logic in the `OptionParser.new`'s block. 
