### PR TITLE
Fix type parameter mismatch on Concurrent::Map

### DIFF
--- a/gems/actionview/6.0/actionview-generated.rbs
+++ b/gems/actionview/6.0/actionview-generated.rbs
@@ -10169,7 +10169,7 @@ module ActionView
     class Cache
       # Threadsafe template cache
       # nodoc:
-      class SmallCache < Concurrent::Map
+      class SmallCache < Concurrent::Map[untyped, untyped]
         def initialize: (?::Hash[untyped, untyped] options) -> untyped
       end
 

--- a/gems/actionview/6.0/patch.rbs
+++ b/gems/actionview/6.0/patch.rbs
@@ -5,13 +5,6 @@ module ActionView
   end
 end
 
-# Remove the fake type for Concurrent::Map
-# if the real types are available.
-module Concurrent
-  class Map
-  end
-end
-
 # Remove the fake type for I18n::Config
 # if the real types are available.
 module I18n


### PR DESCRIPTION
ref: https://github.com/ruby/gem_rbs_collection/pull/500

It displayed the following error on actionpack's test.

```
 E, [2024-01-25T06:44:39.426559 #1943] ERROR -- rbs: /home/runner/work/gem_rbs_collection/gem_rbs_collection/gems/actioncable/7.1/_test/.gem_rbs_collection/concurrent-ruby/1.1/map.rbs:2:2...57:5: Generic parameters mismatch: ::Concurrent::Map (RBS::GenericParameterMismatchError)
```