### PR TITLE
Replace every `String | Symbol` to interned keyword

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -81,7 +81,7 @@ module ActiveRecord
     def self.columns: () -> Array[untyped]
     def self.reflect_on_all_associations: (?Symbol) -> Array[untyped]
 
-    def will_save_change_to_attribute?: (String | Symbol attr_name, ?from: untyped, ?to: untyped) -> bool
+    def will_save_change_to_attribute?: (interned attr_name, ?from: untyped, ?to: untyped) -> bool
 
     def save!: (?context: Symbol | Array[Symbol] context, ?validate: bool, ?touch: bool) -> void
     def save: (?context: Symbol | Array[Symbol] context, ?validate: bool, ?touch: bool) -> bool
@@ -295,22 +295,22 @@ module ActiveRecord
       def all: () -> self
       def ids: () -> Array[PrimaryKey]
       def none: () -> self
-      def pluck: (Symbol | String column) -> Array[untyped]
-              | (*Symbol | String columns) -> Array[Array[untyped]]
+      def pluck: (interned column) -> Array[untyped]
+              | (*interned columns) -> Array[Array[untyped]]
       def where: (*untyped) -> self
       def not: (*untyped) -> self
       def exists?: (*untyped) -> bool
       def order: (*untyped) -> self
-      def group: (*Symbol | String) -> untyped
+      def group: (*interned) -> untyped
       def distinct: () -> self
       def or: (self) -> self
       def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> self
-      def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def includes: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> self
-      def preload: (*String | Symbol | Hash[untyped, untyped]) -> self
+      def joins: (*interned | Hash[untyped, untyped]) -> self
+      def left_joins: (*interned | Hash[untyped, untyped]) -> self
+      def left_outer_joins: (*interned | Hash[untyped, untyped]) -> self
+      def includes: (*interned | Hash[untyped, untyped]) -> self
+      def eager_load: (*interned | Hash[untyped, untyped]) -> self
+      def preload: (*interned | Hash[untyped, untyped]) -> self
       def find_by: (*untyped) -> Model?
       def find_by!: (*untyped) -> Model
       def find: (PrimaryKey id) -> Model
@@ -362,17 +362,17 @@ module ActiveRecord
       def destroy_by: (*untyped) -> untyped
       def delete_by: (*untyped) -> untyped
       def each: () { (Model) -> void } -> self
-      def select: (*Symbol | String) -> self
+      def select: (*interned) -> self
                 | () { (Model) -> boolish } -> Array[Model]
-      def reselect: (*Symbol | String) -> self
+      def reselect: (*interned) -> self
     end
 
     module ClassMethods[Model, Relation, PrimaryKey]
       def all: () -> Relation
       def ids: () -> Array[PrimaryKey]
       def none: () -> Relation
-      def pluck: (Symbol | String column) -> Array[untyped]
-              | (*Symbol | String columns) -> Array[Array[untyped]]
+      def pluck: (interned column) -> Array[untyped]
+              | (*interned columns) -> Array[Array[untyped]]
       def where: (*untyped) -> Relation
       def exists?: (*untyped) -> bool
       def any?: () -> bool
@@ -384,16 +384,16 @@ module ActiveRecord
       def one?: () -> bool
               | () { (Model) -> boolish } -> bool
       def order: (*untyped) -> Relation
-      def group: (*Symbol | String) -> untyped
+      def group: (*interned) -> untyped
       def distinct: () -> Relation
       def or: (Relation) -> Relation
       def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> Relation
-      def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def includes: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-      def preload: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+      def joins: (*interned | Hash[untyped, untyped]) -> Relation
+      def left_joins: (*interned | Hash[untyped, untyped]) -> Relation
+      def left_outer_joins: (*interned | Hash[untyped, untyped]) -> Relation
+      def includes: (*interned | Hash[untyped, untyped]) -> Relation
+      def eager_load: (*interned | Hash[untyped, untyped]) -> Relation
+      def preload: (*interned | Hash[untyped, untyped]) -> Relation
       def find_by: (*untyped) -> Model?
       def find_by!: (*untyped) -> Model
       def find: (PrimaryKey id) -> Model
@@ -443,9 +443,9 @@ module ActiveRecord
       def touch_all: (*untyped, ?time: untyped) -> untyped
       def destroy_by: (*untyped) -> untyped
       def delete_by: (*untyped) -> untyped
-      def select: (*Symbol | String) -> Relation
+      def select: (*interned) -> Relation
                 | () { (Model) -> boolish } -> Array[Model]
-      def reselect: (*Symbol | String) -> Relation
+      def reselect: (*interned) -> Relation
     end
   end
 end
@@ -454,22 +454,22 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def all: () -> self
   def ids: () -> Array[PrimaryKey]
   def none: () -> self
-  def pluck: (Symbol | String column) -> Array[untyped]
-           | (*Symbol | String columns) -> Array[Array[untyped]]
+  def pluck: (interned column) -> Array[untyped]
+           | (*interned columns) -> Array[Array[untyped]]
   def where: (*untyped) -> self
   def not: (*untyped) -> self
   def exists?: (*untyped) -> bool
   def order: (*untyped) -> self
-  def group: (*Symbol | String) -> untyped
+  def group: (*interned) -> untyped
   def distinct: () -> self
   def or: (self) -> self
   def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> self
-  def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def includes: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> self
-  def preload: (*String | Symbol | Hash[untyped, untyped]) -> self
+  def joins: (*interned | Hash[untyped, untyped]) -> self
+  def left_joins: (*interned | Hash[untyped, untyped]) -> self
+  def left_outer_joins: (*interned | Hash[untyped, untyped]) -> self
+  def includes: (*interned | Hash[untyped, untyped]) -> self
+  def eager_load: (*interned | Hash[untyped, untyped]) -> self
+  def preload: (*interned | Hash[untyped, untyped]) -> self
   def find_by: (untyped, *untyped) -> Model?
   def find_by!: (untyped, *untyped) -> Model
   def find: (PrimaryKey id) -> Model
@@ -522,17 +522,17 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def destroy_by: (*untyped) -> untyped
   def delete_by: (*untyped) -> untyped
   def each: () { (Model) -> void } -> self
-  def select: (*Symbol | String) -> self
+  def select: (*interned) -> self
             | () { (Model) -> boolish } -> Array[Model]
-  def reselect: (*Symbol | String) -> self
+  def reselect: (*interned) -> self
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def all: () -> Relation
   def ids: () -> Array[PrimaryKey]
   def none: () -> Relation
-  def pluck: (Symbol | String column) -> Array[untyped]
-           | (*Symbol | String columns) -> Array[Array[untyped]]
+  def pluck: (interned column) -> Array[untyped]
+           | (*interned columns) -> Array[Array[untyped]]
   def where: (*untyped) -> Relation
   def exists?: (*untyped) -> bool
   def any?: () -> bool
@@ -544,16 +544,16 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def one?: () -> bool
           | () { (Model) -> boolish } -> bool
   def order: (*untyped) -> Relation
-  def group: (*Symbol | String) -> untyped
+  def group: (*interned) -> untyped
   def distinct: () -> Relation
   def or: (Relation) -> Relation
   def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> Relation
-  def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def left_outer_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def includes: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def eager_load: (*String | Symbol | Hash[untyped, untyped]) -> Relation
-  def preload: (*String | Symbol | Hash[untyped, untyped]) -> Relation
+  def joins: (*interned | Hash[untyped, untyped]) -> Relation
+  def left_joins: (*interned | Hash[untyped, untyped]) -> Relation
+  def left_outer_joins: (*interned | Hash[untyped, untyped]) -> Relation
+  def includes: (*interned | Hash[untyped, untyped]) -> Relation
+  def eager_load: (*interned | Hash[untyped, untyped]) -> Relation
+  def preload: (*interned | Hash[untyped, untyped]) -> Relation
   def find_by: (untyped) -> Model?
   def find_by!: (untyped) -> Model
   def find: (PrimaryKey id) -> Model
@@ -604,9 +604,9 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def touch_all: (*untyped, ?time: untyped) -> untyped
   def destroy_by: (*untyped) -> untyped
   def delete_by: (*untyped) -> untyped
-  def select: (*Symbol | String) -> Relation
+  def select: (*interned) -> Relation
             | () { (Model) -> boolish } -> Array[Model]
-  def reselect: (*Symbol | String) -> Relation
+  def reselect: (*interned) -> Relation
   def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void) ?{ (Module extention) [self: Relation] -> void } -> void
 end
 

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -7,8 +7,8 @@ module ActiveRecord
 
   module Enum
     def enum: (**untyped options) -> void
-            | ((String | Symbol) name, **untyped options) -> void
-            | ((String | Symbol) name, (Hash[(Symbol | String), untyped] | Array[Symbol | String]) values, **untyped options) -> void
+            | (interned name, **untyped options) -> void
+            | (interned name, (Hash[interned, untyped] | Array[interned]) values, **untyped options) -> void
   end
 
   module RuntimeRegistry

--- a/gems/activestorage/6.0/lib/reflection.rbs
+++ b/gems/activestorage/6.0/lib/reflection.rbs
@@ -25,7 +25,7 @@ module ActiveStorage
         #    User.reflect_on_attachment(:avatar)
         #    # => the avatar reflection
         #
-        def reflect_on_attachment: ((String | Symbol) attachment) -> (ActiveStorage::Reflection::HasOneAttachedReflection | ActiveStorage::Reflection::HasManyAttachedReflection | nil)
+        def reflect_on_attachment: ((interned) attachment) -> (ActiveStorage::Reflection::HasOneAttachedReflection | ActiveStorage::Reflection::HasManyAttachedReflection | nil)
       end
     end
   end

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -18,7 +18,7 @@ module ActiveSupport
       def compile_methods!: () -> void
 
       # Compiles reader methods so we don't have to go through method_missing.
-      def self.compile_methods!: (Array[Symbol | String] keys) -> void
+      def self.compile_methods!: (Array[interned] keys) -> void
     end
 
     module ClassMethods
@@ -28,8 +28,7 @@ module ActiveSupport
 
       private
 
-      # TODO: Fix to use `interned` in names params after releasing ruby/rbs#1499
-      def config_accessor: (*(String | Symbol) names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> void
+      def config_accessor: (*interned names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> void
     end
 
     def config: () -> InheritableOptions
@@ -265,11 +264,9 @@ module ActiveSupport
   class OrderedOptions < Hash[Symbol, untyped]
     alias _get []
 
-    # TODO: Fix to use `interned` in key params after releasing ruby/rbs#1499
-    def []=: ((String | Symbol) key, untyped value) -> untyped
+    def []=: (interned key, untyped value) -> untyped
 
-    # TODO: Fix to use `interned` in key params after releasing ruby/rbs#1499
-    def []: ((String | Symbol) key) -> untyped
+    def []: (interned key) -> untyped
 
     def method_missing: (Symbol name, *untyped args) -> untyped
 
@@ -279,8 +276,7 @@ module ActiveSupport
   end
 
   class InheritableOptions < OrderedOptions
-    # TODO: Fix to use `interned` in parent params after releasing ruby/rbs#1499
-    def initialize: (?Hash[(String | Symbol), untyped]? parent) -> void
+    def initialize: (?Hash[interned, untyped]? parent) -> void
 
     def inheritable_copy: () -> instance
   end
@@ -327,14 +323,11 @@ class Module
   def mattr_accessor: (*untyped syms, ?default: untyped? default, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) ?{ () -> untyped } -> untyped
                     | ...
 
-  # TODO: Fix to use `interned` in attrs params after releasing ruby/rbs#1499
-  def attr_internal_reader: (*(Symbol | String) attrs) -> void
+  def attr_internal_reader: (*interned attrs) -> void
 
-  # TODO: Fix to use `interned` in attrs params after releasing ruby/rbs#1499
-  def attr_internal_writer: (*(Symbol | String) attrs) -> void
+  def attr_internal_writer: (*interned attrs) -> void
 
-  # TODO: Fix to use `interned` in attrs params after releasing ruby/rbs#1499
-  def attr_internal_accessor: (*(Symbol | String) attrs) -> void
+  def attr_internal_accessor: (*interned attrs) -> void
 
   alias attr_internal attr_internal_accessor
 
@@ -342,12 +335,10 @@ class Module
 
   private
 
-  # TODO: Fix to use `interned` in attr params after releasing ruby/rbs#1499
-  def attr_internal_ivar_name: ((Symbol | String) attr) -> String
+  def attr_internal_ivar_name: (interned attr) -> String
 
   type access_type = :reader | :writer
-  # TODO: Fix to use `interned` in attr params after releasing ruby/rbs#1499
-  def attr_internal_define: ((Symbol | String) attr_name, access_type `type`) -> void
+  def attr_internal_define: (interned attr_name, access_type `type`) -> void
 end
 
 class Integer

--- a/gems/carrierwave/3.0/carrierwave.rbs
+++ b/gems/carrierwave/3.0/carrierwave.rbs
@@ -44,12 +44,12 @@ module CarrierWave
 
     module Versions
       module ClassMethods
-        def version: (String | Symbol name, **untyped) ? { () -> void } -> void
+        def version: (interned name, **untyped) ? { () -> void } -> void
       end
 
       def versions: () -> Hash[Symbol, CarrierWave::Uploader::Base]
       def version_name: () -> String
-      def version_exists?: (String | Symbol) -> bool
+      def version_exists?: (interned) -> bool
       def cache: (*untyped) -> void
       def url: (*Symbol) -> String
              | (Hash[untyped, untyped]) -> String

--- a/gems/chunky_png/1.4.0/chunky_png.rbs
+++ b/gems/chunky_png/1.4.0/chunky_png.rbs
@@ -517,7 +517,7 @@ module ChunkyPNG
     extend DataUrlImporting
 
     module PNGEncoding
-      type constraints = Hash[Symbol | String, untyped] | Symbol
+      type constraints = Hash[interned, untyped] | Symbol
 
       def write: (IO io, ?constraints constraints) -> void
 

--- a/gems/chunky_png/1.4.0/color.rbs
+++ b/gems/chunky_png/1.4.0/color.rbs
@@ -427,7 +427,7 @@ module ChunkyPNG
     #   255. Overrides any opacity value given in the color name.
     # @return [Integer] The color value.
     # @raise [ChunkyPNG::Exception] If the color name was not recognized.
-    def html_color: (Symbol | String color_name, ?Integer? opacity) -> Integer
+    def html_color: (interned color_name, ?Integer? opacity) -> Integer
 
     # @return [Integer] Black pixel/color
     BLACK: Integer

--- a/gems/circuitbox/2.0/circuitbox.rbs
+++ b/gems/circuitbox/2.0/circuitbox.rbs
@@ -45,7 +45,7 @@ class Circuitbox
 
   extend Configuration
 
-  # def self.circuit: [T] (String | Symbol service_name, Hash[untyped, untyped] options) ?{ () -> T } -> (CircuitBreaker | T)
-  def self.circuit: (String | Symbol service_name, Hash[untyped, untyped] options) -> CircuitBreaker
-                  | [T] (String | Symbol service_name, Hash[untyped, untyped] options) ?{ () -> T } -> T
+  # def self.circuit: [T] (interned service_name, Hash[untyped, untyped] options) ?{ () -> T } -> (CircuitBreaker | T)
+  def self.circuit: (interned service_name, Hash[untyped, untyped] options) -> CircuitBreaker
+                  | [T] (interned service_name, Hash[untyped, untyped] options) ?{ () -> T } -> T
 end

--- a/gems/faker/2.23/faker.rbs
+++ b/gems/faker/2.23/faker.rbs
@@ -13,7 +13,7 @@ module Faker
 
   class Config
     def self.random=: (Random | nil) -> Random
-    def self.locale=: (Symbol | String) -> (Symbol | String)
+    def self.locale=: (interned) -> interned
   end
 
   class Name < Base

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -49,19 +49,19 @@ module Faraday
         def initialize: (?strict_mode: bool) ?{ (self) -> void } -> void
         def empty?: () -> bool
         def match: (untyped env) -> ((false | nil) | [Stub, meta]) # TODO: `env` should be Faraday::Env
-        def get: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def head: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def post: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def put: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def patch: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def delete: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def options: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def get: (String | URI | Regexp path, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def head: (String | URI | Regexp path, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def post: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def put: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def patch: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def delete: (String | URI | Regexp path, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def options: (String | URI | Regexp path, ?::Hash[interned, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void # TODO: `env` should be Faraday::Env
         def verify_stubbed_calls: () -> void
         def strict_mode=: (boolish value) -> void
 
         private # protected is not yet supported. See https://github.com/ruby/rbs/issues/579
 
-        def new_stub: (:get | :head | :post | :put | :patch | :delete | :options request_method, String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers, ?(^(String) -> bool | _ToS)? body) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def new_stub: (:get | :head | :post | :put | :patch | :delete | :options request_method, String | URI | Regexp path, ?::Hash[interned, untyped] headers, ?(^(String) -> bool | _ToS)? body) { (untyped env, meta) -> [Integer, ::Hash[interned, untyped], String] } -> void
         def matches?: (::Hash[Symbol, untyped] stack, untyped env) -> ([Stub, meta] | nil) # TODO: `env` should be Faraday::Env
       end
 
@@ -78,7 +78,7 @@ module Faraday
         def matches?: (untyped env) -> [bool, meta] # TODO: `env` should be Faraday::Env
         def path_match?: (String request_path, meta) -> bool
         def params_match?: (untyped env) -> bool # TODO: `env` should be Faraday::Env
-        def headers_match?: (::Hash[String | Symbol, untyped] request_headers) -> bool
+        def headers_match?: (::Hash[interned, untyped] request_headers) -> bool
         def body_match?: (String request_body) -> bool
         def to_s: () -> ::String
       end
@@ -95,7 +95,7 @@ module Faraday
     @constants: Hash[String, untyped]
 
     def initialize: () -> void
-    def get: (Symbol | String name) -> untyped
+    def get: (interned name) -> untyped
     def set: (untyped klass, ?_ToS? name) -> void
   end
 
@@ -224,32 +224,32 @@ module Faraday
   end
 
   module Utils
-    class Headers < ::Hash[Symbol | String, untyped]
+    class Headers < ::Hash[interned, untyped]
       @names: ::Hash[String, String]
 
       def self.from: (untyped value) -> Headers
       def self.allocate: () -> Headers
-      def initialize: (?::Hash[Symbol | String, untyped]? hash) -> void
+      def initialize: (?::Hash[interned, untyped]? hash) -> void
       def initialize_names: () -> void
       def initialize_copy: (self other) -> self
 
       KeyMap: ::Hash[Symbol, String]
 
-      def []: (String | Symbol key) -> untyped?
-      def []=: (String | Symbol key, untyped val) -> untyped
-      def fetch: (String | Symbol key, *untyped args) ?{ () -> untyped } -> untyped
-      def delete: (String | Symbol key) -> untyped?
-      def include?: (String | Symbol key) -> bool
+      def []: (interned key) -> untyped?
+      def []=: (interned key, untyped val) -> untyped
+      def fetch: (interned key, *untyped args) ?{ () -> untyped } -> untyped
+      def delete: (interned key) -> untyped?
+      def include?: (interned key) -> bool
 
       alias has_key? include?
       alias member? include?
       alias key? include?
 
-      def merge!: (::Hash[Symbol | String, untyped] other) -> self
+      def merge!: (::Hash[interned, untyped] other) -> self
       alias update merge!
 
-      def merge: (::Hash[Symbol | String, untyped] other) -> Headers
-      def replace: (::Hash[Symbol | String, untyped] other) -> self
+      def merge: (::Hash[interned, untyped] other) -> Headers
+      def replace: (::Hash[interned, untyped] other) -> self
       def to_hash: () -> Headers
       def parse: (String? header_string) -> Array[untyped]?
 
@@ -257,7 +257,7 @@ module Faraday
 
       private
 
-      def add_parsed: (Symbol | String key, String value) -> untyped
+      def add_parsed: (interned key, String value) -> untyped
     end
   end
 end

--- a/gems/flipper/0.28/flipper.rbs
+++ b/gems/flipper/0.28/flipper.rbs
@@ -1,5 +1,5 @@
 module Flipper
-  type name_type = String | Symbol
+  type name_type = interned
 
   extend ::Flipper
 
@@ -34,7 +34,7 @@ module Flipper
   #
   # Returns Flipper::DSL instance.
   def instance: () -> untyped
-  
+
   include DSL::_DelegateMethods
 
   # Public: Set the flipper instance. It is most common to use the

--- a/gems/http/5.1/http.rbs
+++ b/gems/http/5.1/http.rbs
@@ -1,6 +1,6 @@
 module HTTP
   interface _Callable
-    def call: () -> (Symbol | String)
+    def call: () -> interned
   end
 
   def self.auth: (_ToS) -> HTTP::Client
@@ -21,7 +21,7 @@ module HTTP
       extend Forwardable
       attr_reader headers: Headers
       def []: (_ToS name) -> (nil | String | Array[String])
-      def []=: (String | Symbol name, Array[_ToS] | _ToS value) -> void
+      def []=: (interned name, Array[_ToS] | _ToS value) -> void
     end
 
     extend Forwardable
@@ -57,10 +57,10 @@ module HTTP
     def initialize: () -> void
     def initialize_copy: (instance other) -> void
 
-    def set: (String | Symbol name, Array[_ToS] | _ToS value) -> void
+    def set: (interned name, Array[_ToS] | _ToS value) -> void
     alias []= set
     def delete: (_ToS name) -> void
-    def add: (String | Symbol name, Array[_ToS] | _ToS value) -> void
+    def add: (interned name, Array[_ToS] | _ToS value) -> void
     def get: (_ToS name) -> Array[String]
     def []: (_ToS name) -> (nil | String | Array[String])
 
@@ -118,7 +118,7 @@ module HTTP
 
   class Response
     class Status < ::Delegator
-      def self.coerce: (String | Symbol | Numeric & _ToI object) -> instance
+      def self.coerce: (interned | Numeric & _ToI object) -> instance
       alias self.[] self.coerce
       private
       def self.symbolize: (_ToS str) -> Symbol

--- a/gems/httparty/0.18/httparty.rbs
+++ b/gems/httparty/0.18/httparty.rbs
@@ -151,7 +151,7 @@ module HTTParty
     #     include HTTParty
     #     format :json
     #   end
-    def format: (?String | Symbol? f) -> void
+    def format: (?interned? f) -> void
 
     # Declare whether or not to follow redirects.  When true, an
     # {HTTParty::RedirectionTooDeep} error will raise upon encountering a
@@ -231,7 +231,7 @@ module HTTParty
     #     include HTTParty
     #     ssl_version :SSLv3
     #   end
-    def ssl_version: (String | Symbol version) -> void
+    def ssl_version: (interned version) -> void
 
     # Allows setting of SSL ciphers to use.  This only works in Ruby 1.9+.
     # You can get a list of valid specific ciphers from OpenSSL::Cipher.ciphers.
@@ -576,7 +576,7 @@ module HTTParty
 
     private
 
-    def from_ruby_version: (String ruby_version, ?option: (Symbol | String)? option, ?warn: bool warn) { () -> untyped } -> void
+    def from_ruby_version: (String ruby_version, ?option: interned? option, ?warn: bool warn) { () -> untyped } -> void
 
     def add_timeout?: (Integer | Float timeout) -> bool
 

--- a/gems/i18n/1.10/i18n.rbs
+++ b/gems/i18n/1.10/i18n.rbs
@@ -16,7 +16,7 @@ module I18n
     def backend=: (untyped value) -> untyped
     def default_locale: -> Symbol
     def default_locale=: (untyped value) -> untyped
-    def available_locales: -> Array[String | Symbol]
+    def available_locales: -> Array[interned]
     def available_locales=: (untyped value) -> untyped
     def default_separator: -> String
     def default_separator=: (String value) -> String
@@ -29,7 +29,7 @@ module I18n
 
     def reload!: -> void
     def eager_load!: -> void
-    def translate: (String | Symbol | Array[untyped] key, ?throw: bool throw, ?raise: bool raise, ?locale: untyped? locale, **untyped options) -> String
+    def translate: (interned | Array[untyped] key, ?throw: bool throw, ?raise: bool raise, ?locale: untyped? locale, **untyped options) -> String
     alias t translate
     def translate!: (untyped key, **untyped options) -> String
     alias t! translate!
@@ -39,7 +39,7 @@ module I18n
     alias l localize
     def with_locale: (?untyped? tmp_locale) { () -> untyped } -> untyped
     def normalize_keys: (untyped locale, untyped key, untyped scope, ?untyped separator) -> Array[Symbol]
-    def locale_available?: (Symbol | String locale) -> bool
+    def locale_available?: (interned locale) -> bool
     def enforce_available_locales!: (untyped locale) -> nil
     def available_locales_initialized?: -> bool
   end
@@ -51,7 +51,7 @@ module I18n
     def backend=: (untyped backend) -> untyped
     def default_locale: -> Symbol
     def default_locale=: (untyped locale) -> untyped
-    def available_locales: -> Array[String | Symbol]
+    def available_locales: -> Array[interned]
     def available_locales_set: -> untyped
     def available_locales=: (untyped locales) -> void
     def available_locales_initialized?: -> bool

--- a/gems/json-jwt/1.16/json-jwt.rbs
+++ b/gems/json-jwt/1.16/json-jwt.rbs
@@ -25,7 +25,7 @@ module JSON
 
     def initialize: (OpenSSL::PKey::RSA | OpenSSL::PKey::EC | OpenSSL::PKey::PKey | String | Hash[untyped, untyped] params, Hash[untyped, untyped] ex_params) -> void
     def content_type: () -> String
-    def thumbprint: (OpenSSL::Digest | String | Symbol digest) -> String
+    def thumbprint: (OpenSSL::Digest | interned digest) -> String
     def to_key: () -> OpenSSL::PKey::PKey
     def rsa?: () -> bool
     def ec?: () -> bool

--- a/gems/kaminari-core/1.2/kaminari-core.rbs
+++ b/gems/kaminari-core/1.2/kaminari-core.rbs
@@ -9,13 +9,13 @@ module Kaminari
     attr_accessor outer_window: Integer
     attr_accessor left: Integer
     attr_accessor right: Integer
-    attr_accessor page_method_name: Symbol | String
+    attr_accessor page_method_name: interned
     attr_accessor max_pages: Integer?
     attr_accessor params_on_first_page: bool
 
-    attr_writer param_name: Symbol | String | _Callable
+    attr_writer param_name: interned | _Callable
 
-    def param_name: () -> (Symbol | String)
+    def param_name: () -> interned
   end
 
   module PageScopeMethods : _Model_Relation
@@ -35,7 +35,7 @@ module Kaminari
   end
 
   interface _Callable
-    def call: () -> (Symbol | String)
+    def call: () -> interned
   end
 
   module ConfigurationMethods

--- a/gems/launchdarkly-server-sdk/6.4/ldclient-rb/in_memory_store.rbs
+++ b/gems/launchdarkly-server-sdk/6.4/ldclient-rb/in_memory_store.rbs
@@ -24,11 +24,11 @@ module LaunchDarkly
 
     def initialize: () -> void
 
-    def get: (kind, String | Symbol key) -> Hash[Symbol, untyped]?
+    def get: (kind, interned key) -> Hash[Symbol, untyped]?
 
     def all: (kind) -> Hash[Symbol, Hash[Symbol, untyped]]
 
-    def delete: (kind, String | Symbol key, Integer version) -> void
+    def delete: (kind, interned key, Integer version) -> void
 
     def init: (Hash[kind, Hash[Symbol, Hash[Symbol, untyped]]] all_data) -> void
 

--- a/gems/launchdarkly-server-sdk/6.4/ldclient-rb/redis_store.rbs
+++ b/gems/launchdarkly-server-sdk/6.4/ldclient-rb/redis_store.rbs
@@ -42,11 +42,11 @@ module LaunchDarkly
     #
     def self.default_prefix: () -> String
 
-    def get: (kind, String | Symbol key) -> Hash[Symbol, untyped]?
+    def get: (kind, interned key) -> Hash[Symbol, untyped]?
 
     def all: (kind) -> Hash[Symbol, Hash[Symbol, untyped]]
 
-    def delete: (kind, String | Symbol key, Integer version) -> void
+    def delete: (kind, interned key, Integer version) -> void
 
     def init: (Hash[kind, Hash[Symbol, untyped]] all_data) -> void
 

--- a/gems/launchdarkly-server-sdk/7.2/ldclient-rb/context.rbs
+++ b/gems/launchdarkly-server-sdk/7.2/ldclient-rb/context.rbs
@@ -124,7 +124,7 @@ module LaunchDarkly
     # @param attribute [String, Symbol]
     # @return [any]
     #
-    def get_value: (String | Symbol attribute) -> untyped
+    def get_value: (interned attribute) -> untyped
 
     #
     # get_value_for_reference looks up the value of any attribute of the

--- a/gems/launchdarkly-server-sdk/7.2/ldclient-rb/impl/integrations/redis_impl.rbs
+++ b/gems/launchdarkly-server-sdk/7.2/ldclient-rb/impl/integrations/redis_impl.rbs
@@ -46,11 +46,11 @@ module LaunchDarkly
           #
           def self.default_prefix: () -> String
 
-          def get: (kind, String | Symbol key) -> Hash[Symbol, untyped]?
+          def get: (kind, interned key) -> Hash[Symbol, untyped]?
 
           def all: (kind) -> Hash[Symbol, Hash[Symbol, untyped]]
 
-          def delete: (kind, String | Symbol key, Integer version) -> void
+          def delete: (kind, interned key, Integer version) -> void
 
           def init: (Hash[kind, Hash[Symbol, untyped]] all_data) -> void
 

--- a/gems/protobuf/3.10.3/enum.rbs
+++ b/gems/protobuf/3.10.3/enum.rbs
@@ -83,7 +83,7 @@ module Protobuf
     #
     # Returns the Enum object with the given name or nil.
     #
-    def self.enum_for_name: (Symbol | String name) -> instance?
+    def self.enum_for_name: (interned name) -> instance?
 
     # Public: Get the Enum object corresponding to the given tag.
     #
@@ -116,7 +116,7 @@ module Protobuf
     #
     # Returns an Enum object or nil.
     #
-    def self.fetch: (instance | String | Symbol | Integer candidate) -> instance?
+    def self.fetch: (instance | interned | Integer candidate) -> instance?
 
     # Public: Get the Symbol name associated with the given number.
     #

--- a/gems/redis/4.2/redis.rbs
+++ b/gems/redis/4.2/redis.rbs
@@ -66,7 +66,7 @@ class Redis
   #   - `:xx => true`: Only set the key if it already exist.
   #   - `:keepttl => true`: Retain the time to live associated with the key.
   # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
-  def set: ((String | Symbol) key, top value, ?ex: Integer?, ?px: Integer?, ?nx: boolish, ?xx: boolish, ?keepttl: boolish) -> (String | bool)
+  def set: (interned key, top value, ?ex: Integer?, ?px: Integer?, ?nx: boolish, ?xx: boolish, ?keepttl: boolish) -> (String | bool)
 
   # Set the time to live in seconds of a key.
   #
@@ -80,7 +80,7 @@ class Redis
   #
   # @param [String] key
   # @return [String]
-  def get: ((String | Symbol) key) -> String?
+  def get: (interned key) -> String?
 
   # Delete one or more keys.
   #

--- a/gems/rolify/6.0/rolify.rbs
+++ b/gems/rolify/6.0/rolify.rbs
@@ -14,7 +14,7 @@ module Rolify
   end
   extend Configure
 
-  type role_name = (Symbol | String)
+  type role_name = interned
 
   module Role
     # should be overwrite to return record object

--- a/gems/sidekiq/6.2/redis_connection.rbs
+++ b/gems/sidekiq/6.2/redis_connection.rbs
@@ -1,5 +1,5 @@
 module Sidekiq
   module RedisConnection
-    def self.create: (?Hash[Symbol | String, untyped]) -> ConnectionPool[Redis]
+    def self.create: (?Hash[interned, untyped]) -> ConnectionPool[Redis]
   end
 end

--- a/gems/sidekiq/6.2/sidekiq.rbs
+++ b/gems/sidekiq/6.2/sidekiq.rbs
@@ -11,9 +11,9 @@ module Sidekiq
 
   def self.`❨╯°□°❩╯︵┻━┻`: () -> nil
 
-  def self.options: () -> Hash[(Symbol | String), untyped]
+  def self.options: () -> Hash[interned, untyped]
 
-  def self.options=: (Hash[(Symbol | String), untyped] opts) -> void
+  def self.options=: (Hash[interned, untyped] opts) -> void
 
   #
   # Configuration for Sidekiq server, use like:
@@ -50,7 +50,7 @@ module Sidekiq
 
   def self.default_server_middleware: () -> Sidekiq::Middleware::Chain
 
-  def self.default_worker_options=: (Hash[(String | Symbol), untyped] hash) -> void
+  def self.default_worker_options=: (Hash[interned, untyped] hash) -> void
 
   def self.default_worker_options: () -> Hash[String, untyped]
 
@@ -211,12 +211,12 @@ module Sidekiq
     # Example usage:
     #   Sidekiq::Client.enqueue_to(:queue_name, MyWorker, 'foo', 1, :bat => 'bar')
     #
-    def self.enqueue_to: ((Symbol | String) queue, Class klass, *untyped args) -> String
+    def self.enqueue_to: (interned queue, Class klass, *untyped args) -> String
 
     # Example usage:
     #   Sidekiq::Client.enqueue_to_in(:queue_name, 3.minutes, MyWorker, 'foo', 1, :bat => 'bar')
     #
-    def self.enqueue_to_in: ((Symbol | String) queue, (Time | untyped) interval, Class klass, *untyped args) -> String
+    def self.enqueue_to_in: (interned queue, (Time | untyped) interval, Class klass, *untyped args) -> String
 
     # Example usage:
     #   Sidekiq::Client.enqueue_in(3.minutes, MyWorker, 'foo', 1, :bat => 'bar')
@@ -237,11 +237,11 @@ module Sidekiq
     end
 
     module ActionMailer
-      def sidekiq_delay: (?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay: (?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_until: (untyped timestamp, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_until: (untyped timestamp, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
       alias delay sidekiq_delay
       alias delay_for sidekiq_delay_for
@@ -255,11 +255,11 @@ module Sidekiq
     end
 
     module ActiveRecord
-      def sidekiq_delay: (?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay: (?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_until: (untyped timestamp, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_until: (untyped timestamp, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
       alias delay sidekiq_delay
       alias delay_for sidekiq_delay_for
@@ -273,11 +273,11 @@ module Sidekiq
     end
 
     module Klass
-      def sidekiq_delay: (?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay: (?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_until: (untyped timestamp, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_until: (untyped timestamp, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
       alias delay sidekiq_delay
       alias delay_for sidekiq_delay_for
@@ -285,7 +285,7 @@ module Sidekiq
     end
 
     class Proxy < BasicObject
-      def initialize: (untyped performable, untyped target, ?Hash[(String | Symbol), untyped] options) -> void
+      def initialize: (untyped performable, untyped target, ?Hash[interned, untyped] options) -> void
 
       def method_missing: (String name, *untyped args) -> String
     end
@@ -697,7 +697,7 @@ module Sidekiq
         #
         # In practice, any option is allowed.  This is the main mechanism to configure the
         # options for a specific job.
-        def sidekiq_options: (?Hash[Symbol | String, untyped] opts) -> untyped
+        def sidekiq_options: (?Hash[interned, untyped] opts) -> untyped
                            | (?queue: String, ?retry: (bool | Integer), ?dead: bool, ?backtrace: (bool | Integer), ?pool: untyped, ?tags: Array[String]) -> Hash[String, untyped]
 
         def sidekiq_retry_in: () { (Integer count, Exception exception) -> Integer? } -> void
@@ -758,9 +758,9 @@ module Sidekiq
       #
       # In practice, any option is allowed.  This is the main mechanism to configure the
       # options for a specific job.
-      def sidekiq_options: (?Hash[Symbol | String, untyped] opts) -> Hash[String, untyped]
+      def sidekiq_options: (?Hash[interned, untyped] opts) -> Hash[String, untyped]
 
-      def client_push: (Hash[(Symbol | String), untyped] item) -> String
+      def client_push: (Hash[interned, untyped] item) -> String
     end
   end
 
@@ -780,7 +780,7 @@ module Sidekiq
     def local_level: () -> Integer
 
     def local_level=: (Integer? level) -> void
-                    | ((Symbol | String) level) -> void
+                    | (interned level) -> void
 
     def level: () -> Integer
   end

--- a/gems/sidekiq/6.3/redis_connection.rbs
+++ b/gems/sidekiq/6.3/redis_connection.rbs
@@ -1,5 +1,5 @@
 module Sidekiq
   module RedisConnection
-    def self.create: (?Hash[Symbol | String, untyped]) -> ConnectionPool[Redis]
+    def self.create: (?Hash[interned, untyped]) -> ConnectionPool[Redis]
   end
 end

--- a/gems/sidekiq/6.3/sidekiq.rbs
+++ b/gems/sidekiq/6.3/sidekiq.rbs
@@ -11,9 +11,9 @@ module Sidekiq
 
   def self.`❨╯°□°❩╯︵┻━┻`: () -> nil
 
-  def self.options: () -> Hash[(Symbol | String), untyped]
+  def self.options: () -> Hash[interned, untyped]
 
-  def self.options=: (Hash[(Symbol | String), untyped] opts) -> void
+  def self.options=: (Hash[interned, untyped] opts) -> void
 
   #
   # Configuration for Sidekiq server, use like:
@@ -50,7 +50,7 @@ module Sidekiq
 
   def self.default_server_middleware: () -> Sidekiq::Middleware::Chain
 
-  def self.default_worker_options=: (Hash[(String | Symbol), untyped] hash) -> void
+  def self.default_worker_options=: (Hash[interned, untyped] hash) -> void
 
   def self.default_worker_options: () -> Hash[String, untyped]
 
@@ -211,12 +211,12 @@ module Sidekiq
     # Example usage:
     #   Sidekiq::Client.enqueue_to(:queue_name, MyWorker, 'foo', 1, :bat => 'bar')
     #
-    def self.enqueue_to: ((Symbol | String) queue, Class klass, *untyped args) -> String
+    def self.enqueue_to: (interned queue, Class klass, *untyped args) -> String
 
     # Example usage:
     #   Sidekiq::Client.enqueue_to_in(:queue_name, 3.minutes, MyWorker, 'foo', 1, :bat => 'bar')
     #
-    def self.enqueue_to_in: ((Symbol | String) queue, (Time | untyped) interval, Class klass, *untyped args) -> String
+    def self.enqueue_to_in: (interned queue, (Time | untyped) interval, Class klass, *untyped args) -> String
 
     # Example usage:
     #   Sidekiq::Client.enqueue_in(3.minutes, MyWorker, 'foo', 1, :bat => 'bar')
@@ -237,11 +237,11 @@ module Sidekiq
     end
 
     module ActionMailer
-      def sidekiq_delay: (?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay: (?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_until: (untyped timestamp, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_until: (untyped timestamp, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
       alias delay sidekiq_delay
       alias delay_for sidekiq_delay_for
@@ -255,11 +255,11 @@ module Sidekiq
     end
 
     module ActiveRecord
-      def sidekiq_delay: (?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay: (?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_until: (untyped timestamp, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_until: (untyped timestamp, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
       alias delay sidekiq_delay
       alias delay_for sidekiq_delay_for
@@ -273,11 +273,11 @@ module Sidekiq
     end
 
     module Klass
-      def sidekiq_delay: (?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay: (?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_for: ((Time | untyped) interval, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
-      def sidekiq_delay_until: (untyped timestamp, ?Hash[(String | Symbol), untyped]? options) -> Sidekiq::Extensions::Proxy
+      def sidekiq_delay_until: (untyped timestamp, ?Hash[interned, untyped]? options) -> Sidekiq::Extensions::Proxy
 
       alias delay sidekiq_delay
       alias delay_for sidekiq_delay_for
@@ -285,7 +285,7 @@ module Sidekiq
     end
 
     class Proxy < BasicObject
-      def initialize: (untyped performable, untyped target, ?Hash[(String | Symbol), untyped] options) -> void
+      def initialize: (untyped performable, untyped target, ?Hash[interned, untyped] options) -> void
 
       def method_missing: (String name, *untyped args) -> String
     end
@@ -407,7 +407,7 @@ module Sidekiq
         #
         # In practice, any option is allowed.  This is the main mechanism to configure the
         # options for a specific job.
-        def sidekiq_options: (?Hash[Symbol | String, untyped] opts) -> untyped
+        def sidekiq_options: (?Hash[interned, untyped] opts) -> untyped
                            | (?queue: String, ?retry: (bool | Integer), ?dead: bool, ?backtrace: (bool | Integer), ?pool: untyped, ?tags: Array[String]) -> Hash[String, untyped]
 
         def sidekiq_retry_in: () { (Integer count, Exception exception) -> Integer? } -> void
@@ -468,9 +468,9 @@ module Sidekiq
       #
       # In practice, any option is allowed.  This is the main mechanism to configure the
       # options for a specific job.
-      def sidekiq_options: (?Hash[Symbol | String, untyped] opts) -> Hash[String, untyped]
+      def sidekiq_options: (?Hash[interned, untyped] opts) -> Hash[String, untyped]
 
-      def client_push: (Hash[(Symbol | String), untyped] item) -> String
+      def client_push: (Hash[interned, untyped] item) -> String
     end
   end
 
@@ -784,7 +784,7 @@ module Sidekiq
         #
         # In practice, any option is allowed.  This is the main mechanism to configure the
         # options for a specific job.
-        def sidekiq_options: (?Hash[Symbol | String, untyped] opts) -> untyped
+        def sidekiq_options: (?Hash[interned, untyped] opts) -> untyped
                            | (?queue: String, ?retry: (bool | Integer), ?dead: bool, ?backtrace: (bool | Integer), ?pool: untyped, ?tags: Array[String]) -> Hash[String, untyped]
 
         def sidekiq_retry_in: () { (Integer count, Exception exception) -> Integer? } -> void
@@ -845,9 +845,9 @@ module Sidekiq
       #
       # In practice, any option is allowed.  This is the main mechanism to configure the
       # options for a specific job.
-      def sidekiq_options: (?Hash[Symbol | String, untyped] opts) -> Hash[String, untyped]
+      def sidekiq_options: (?Hash[interned, untyped] opts) -> Hash[String, untyped]
 
-      def client_push: (Hash[(Symbol | String), untyped] item) -> String
+      def client_push: (Hash[interned, untyped] item) -> String
     end
   end
 
@@ -867,7 +867,7 @@ module Sidekiq
     def local_level: () -> Integer
 
     def local_level=: (Integer? level) -> void
-                    | ((Symbol | String) level) -> void
+                    | (interned level) -> void
 
     def level: () -> Integer
   end

--- a/gems/sidekiq/7.0/client.rbs
+++ b/gems/sidekiq/7.0/client.rbs
@@ -2,8 +2,6 @@ module Sidekiq
   class Client
     type interval = Time | Numeric
 
-    type queue_name = Symbol | String
-
     include Sidekiq::JobUtil
 
     attr_accessor redis_pool: ConnectionPool[RedisClientAdapter]
@@ -12,13 +10,13 @@ module Sidekiq
 
     def self.enqueue_in: (interval interval, Class klass, *untyped args) -> void
 
-    def self.enqueue_to: (queue_name queue, Class klass, *untyped args) -> void
+    def self.enqueue_to: (interned queue, Class klass, *untyped args) -> void
 
-    def self.enqueue_to_in: (queue_name queue, interval interval, Class klass, *untyped args) -> void
+    def self.enqueue_to_in: (interned queue, interval interval, Class klass, *untyped args) -> void
 
     def self.push: (Hash[String, untyped] item) -> String
 
-    def self.push_bulk: (Hash[Symbol | String, untyped] items) -> Array[String?]
+    def self.push_bulk: (Hash[interned, untyped] items) -> Array[String?]
 
     def self.via: (ConnectionPool[RedisClientAdapter] pool) { () -> void } -> void
 
@@ -26,7 +24,7 @@ module Sidekiq
 
     def push: (Hash[String, untyped] item) -> String
 
-    def push_bulk: (Hash[Symbol | String, untyped] items) -> Array[String?]
+    def push_bulk: (Hash[interned, untyped] items) -> Array[String?]
 
     private
 

--- a/gems/sidekiq/7.0/config.rbs
+++ b/gems/sidekiq/7.0/config.rbs
@@ -53,7 +53,7 @@ module Sidekiq
 
     def redis: () { (RedisClientAdapter conn) -> void } -> Hash[String, untyped]
 
-    def redis=: (Hash[Symbol | String, untyped] hash) -> void
+    def redis=: (Hash[interned, untyped] hash) -> void
 
     def redis_info: () -> Hash[String, String]
 

--- a/gems/sidekiq/7.0/job.rbs
+++ b/gems/sidekiq/7.0/job.rbs
@@ -31,9 +31,9 @@ module Sidekiq
 
       def queue_as: (string q) -> void
 
-      def set: (Hash[Symbol | string, untyped] options) -> Setter
+      def set: (Hash[interned, untyped] options) -> Setter
 
-      def sidekiq_options: (?Hash[Symbol | string, untyped] opts) -> void
+      def sidekiq_options: (?Hash[interned, untyped] opts) -> void
     end
 
     module Options
@@ -44,7 +44,7 @@ module Sidekiq
 
         def sidekiq_class_attribute: (*string attrs) ->void
 
-        def sidekiq_options: (?Hash[Symbol | string, untyped] opts) -> void
+        def sidekiq_options: (?Hash[interned, untyped] opts) -> void
 
         def sidekiq_retries_exhausted: () { (Hash[String, untyped] job, Exception ex) -> void } -> void
 
@@ -69,13 +69,13 @@ module Sidekiq
 
       alias perform_sync perform_inline
 
-      def set: (Hash[Symbol | string, untyped] options) -> self
+      def set: (Hash[interned, untyped] options) -> self
 
       private
 
       def at: (float interval) -> self
 
-      def initialize: (singleton(Client) klass, Hash[Symbol | string, untyped] opts) -> void
+      def initialize: (singleton(Client) klass, Hash[interned, untyped] opts) -> void
     end
   end
 end

--- a/gems/sidekiq/7.0/logger.rbs
+++ b/gems/sidekiq/7.0/logger.rbs
@@ -43,9 +43,9 @@ module Sidekiq
     def local_level: () -> Integer
 
     def local_level=: (Integer? level) -> void
-                    | ((Symbol | String) level) -> void
+                    | (interned level) -> void
 
-    def log_at: ((Symbol | String | Integer) level) { () -> void } -> void
+    def log_at: ((interned | Integer) level) { () -> void } -> void
 
     LEVELS: ::Hash[String, Integer]
   end

--- a/gems/simplecov/0.22/simplecov.rbs
+++ b/gems/simplecov/0.22/simplecov.rbs
@@ -5,7 +5,7 @@ module SimpleCov
 
   def self.collate: (Array[String] result_filenames) -> void
 
-  def self.start: (?(String | Symbol | nil) profile) ?{ [self: Configuration] -> void } -> void
+  def self.start: (?(interned | nil) profile) ?{ [self: Configuration] -> void } -> void
 
   module Configuration
     type filter = String

--- a/gems/slack-notifier/2.4/slack-notifier.rbs
+++ b/gems/slack-notifier/2.4/slack-notifier.rbs
@@ -30,7 +30,7 @@ module Slack
       class Base
         attr_reader options: Hash[Symbol, untyped]
 
-        def self.middleware_name: (String | Symbol) -> self
+        def self.middleware_name: (interned) -> self
         def self.options: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
         def call: (?Hash[Symbol, untyped] payload) -> Hash[Symbol, untyped]
       end

--- a/gems/sorcery/0.16/sorcery.rbs
+++ b/gems/sorcery/0.16/sorcery.rbs
@@ -18,7 +18,7 @@ module Sorcery
       def current_user: () -> (T | nil)
       def logout: () -> void
       def auto_login: (T, ?bool should_remember) -> void
-      def redirect_back_or_to: (String url, ?Hash[(String | Symbol), String] flash_hash) -> void
+      def redirect_back_or_to: (String url, ?Hash[interned, String] flash_hash) -> void
     end
   end
 end

--- a/gems/woothee/1.11/woothee.rbs
+++ b/gems/woothee/1.11/woothee.rbs
@@ -1,5 +1,5 @@
 # Classes
 module Woothee
-  def self.parse: (String useragent) -> { name: String, category: Symbol | String, os: String, os_version: String, version: String, vendor: String }
+  def self.parse: (String useragent) -> { name: String, category: interned, os: String, os_version: String, version: String, vendor: String }
   def self.is_crawler: (String useragent) -> bool
 end

--- a/gems/yard/0.9/yard/code_objects.rbs
+++ b/gems/yard/0.9/yard/code_objects.rbs
@@ -209,7 +209,7 @@ class YARD::CodeObjects::Base
   # @yield [self] a block to perform any extra initialization on the object
   # @yieldparam [Base] self the newly initialized code object
   # @return [Base] the newly created object
-  def initialize: (YARD::CodeObjects::NamespaceObject namespace, Symbol | String name, *untyped) { (YARD::CodeObjects::Base self) -> untyped } -> void
+  def initialize: (YARD::CodeObjects::NamespaceObject namespace, interned name, *untyped) { (YARD::CodeObjects::Base self) -> untyped } -> void
   # Copies all data in this object to another code object, except for
   # uniquely identifying information (path, namespace, name, scope).
   #
@@ -223,7 +223,7 @@ class YARD::CodeObjects::Base
   # @return [Symbol] if prefix is false, the symbolized name
   # @return [String] if prefix is true, prefix + the name as a String.
   #   This must be implemented by the subclass.
-  def name: (?bool prefix) -> (Symbol | String)
+  def name: (?bool prefix) -> interned
   # Associates a file with a code object, optionally adding the line where it was defined.
   # By convention, '<stdin>' should be used to associate code that comes form standard input.
   #
@@ -709,7 +709,7 @@ class YARD::CodeObjects::MethodObject < ::YARD::CodeObjects::Base
   # @param [NamespaceObject] namespace the namespace
   # @param [String, Symbol] name the method name
   # @param [Symbol] scope +:instance+, +:class+, or +:module+
-  def initialize: (YARD::CodeObjects::NamespaceObject namespace, String | Symbol name, ?Symbol scope) -> void
+  def initialize: (YARD::CodeObjects::NamespaceObject namespace, interned name, ?Symbol scope) -> void
   # @return whether or not the method is the #initialize constructor method
   def constructor?: () -> bool
   # @return [Boolean] whether or not this method was created as a module
@@ -758,7 +758,7 @@ class YARD::CodeObjects::MethodObject < ::YARD::CodeObjects::Base
   # @return [String] returns {#sep} + +name+ for an instance method if
   #   prefix is true
   # @return [Symbol] the name without {#sep} if prefix is set to false
-  def name: (?bool prefix) -> (String | Symbol)
+  def name: (?bool prefix) -> interned
   # Override separator to differentiate between class and instance
   # methods.
   # @return [String] "#" for an instance method, "." for class
@@ -993,7 +993,7 @@ class YARD::CodeObjects::Proxy
   # @return [String] if prefix is true, prefix + the name as a String.
   #   This must be implemented by the subclass.
   #
-  def name: (?bool prefix) -> (Symbol | String)
+  def name: (?bool prefix) -> interned
   # Returns a text representation of the Proxy
   # @return [String] the object's #inspect method or P(OBJECTPATH)
   def inspect: () -> String
@@ -1029,7 +1029,7 @@ class YARD::CodeObjects::Proxy
   def <=>: (untyped other) -> bool
   # @return [Boolean]
   def equal?: (untyped other) -> bool
-  # @return [Boolean] 
+  # @return [Boolean]
   #
   def ==: (untyped other) -> bool
   # @return [Integer] the object's hash value (for equality checking)

--- a/gems/yard/0.9/yard/handlers.rbs
+++ b/gems/yard/0.9/yard/handlers.rbs
@@ -180,7 +180,7 @@ class YARD::Handlers::Base
   #   token matches match only the first token of the
   #   statement.
   #
-  def self.handles: (*YARD::Parser::Ruby::Legacy::RubyToken | Symbol | String | Regexp matches) -> untyped
+  def self.handles: (*YARD::Parser::Ruby::Legacy::RubyToken | interned | Regexp matches) -> untyped
   # This class is implemented by {Ruby::Base} and {Ruby::Legacy::Base}.
   # To implement a base handler class for another language, implement
   # this method to return true if the handler should process the given

--- a/gems/yard/0.9/yard/options.rbs
+++ b/gems/yard/0.9/yard/options.rbs
@@ -85,7 +85,7 @@ class YARD::Options
   #   options[:format] # equivalent to: options.format
   # @param [Symbol, String] key the option name to access
   # @return the value of the option named +key+
-  def []: (Symbol | String key) -> untyped
+  def []: (interned key) -> untyped
   # Delegates setter calls with Hash syntax to the attribute setter with the key name
   #
   # @example Setting an option with Hash syntax
@@ -93,7 +93,7 @@ class YARD::Options
   # @param [Symbol, String] key the option to set
   # @param [Object] value the value to set for the option
   # @return [Object] the value being set
-  def []=: (Symbol | String key, untyped value) -> untyped
+  def []=: (interned key, untyped value) -> untyped
   # Updates values from an options hash or options object on this object.
   # All keys passed should be key names defined by attributes on the class.
   #
@@ -140,7 +140,7 @@ class YARD::Options
   #
   # @param [Symbol, String] key the key to delete a value for
   # @return [Object] the value that was deleted
-  def delete: (Symbol | String key) -> untyped
+  def delete: (interned key) -> untyped
   # only for 1.8.6
   def tap: () { (YARD::Options _self) -> untyped } -> untyped
 end

--- a/gems/yard/0.9/yard/rake.rbs
+++ b/gems/yard/0.9/yard/rake.rbs
@@ -41,7 +41,7 @@ class YARD::Rake::YardocTask < ::Rake::TaskLib
   # @yield a block to allow any options to be modified on the task
   # @yieldparam [YardocTask] _self the task object to allow any parameters
   #   to be changed.
-  def initialize: (?String | Symbol name) { (YARD::Rake::YardocTask _self) -> untyped } -> void
+  def initialize: (?interned name) { (YARD::Rake::YardocTask _self) -> untyped } -> void
   # Defines the rake task
   # @return [void]
   def define: () -> void

--- a/gems/yard/0.9/yard/registry.rbs
+++ b/gems/yard/0.9/yard/registry.rbs
@@ -215,7 +215,7 @@ module YARD::Registry
   #   +proxy_fallback+ is +true+.
   # @return [nil] if +proxy_fallback+ is +false+ and no object was found.
   # @see P
-  def self.resolve: (YARD::CodeObjects::NamespaceObject? namespace, String | Symbol name, ?bool inheritance, ?bool proxy_fallback, ?Symbol? type) -> (YARD::CodeObjects::Base | YARD::CodeObjects::Proxy)?
+  def self.resolve: (YARD::CodeObjects::NamespaceObject? namespace, interned name, ?bool inheritance, ?bool proxy_fallback, ?Symbol? type) -> (YARD::CodeObjects::Base | YARD::CodeObjects::Proxy)?
 
   # @return [Hash{String => String}] a set of checksums for files
   def self.checksums: () -> Hash[String, String]

--- a/gems/yard/0.9/yard/registry_store.rbs
+++ b/gems/yard/0.9/yard/registry_store.rbs
@@ -18,19 +18,19 @@ class YARD::RegistryStore
   # @param [String, Symbol] key the path name of the object to look for.
   #   If it is empty or :root, returns the {#root} object.
   # @return [CodeObjects::Base, nil] a code object or nil if none is found
-  def get: (String | Symbol key) -> YARD::CodeObjects::Base?
+  def get: (interned key) -> YARD::CodeObjects::Base?
   # Associates an object with a path
   # @param [String, Symbol] key the path name (:root or '' for root object)
   # @param [CodeObjects::Base] value the object to store
   # @return [CodeObjects::Base] returns +value+
-  def put: (String | Symbol key, YARD::CodeObjects::Base value) -> YARD::CodeObjects::Base
+  def put: (interned key, YARD::CodeObjects::Base value) -> YARD::CodeObjects::Base
   # Gets a {CodeObjects::Base} from the store
   # @param [String, Symbol] key
   #   the path name of the object to look for.
   #   If it is empty or :root, returns the {#root} object.
   # @return [CodeObjects::Base, nil] a code object or nil if none is found
   #
-  def []: (String | Symbol key) -> YARD::CodeObjects::Base?
+  def []: (interned key) -> YARD::CodeObjects::Base?
   # Associates an object with a path
   # @param [String, Symbol] key
   #   the path name (:root or '' for root object)
@@ -38,7 +38,7 @@ class YARD::RegistryStore
   #   the object to store
   # @return [CodeObjects::Base] returns +value+
   #
-  def []=: (String | Symbol key, YARD::CodeObjects::Base value) -> YARD::CodeObjects::Base
+  def []=: (interned key, YARD::CodeObjects::Base value) -> YARD::CodeObjects::Base
   # Deletes an object at a given path
   # @param [#to_sym] key the key to delete
   # @return [void]

--- a/gems/yard/0.9/yard/server.rbs
+++ b/gems/yard/0.9/yard/server.rbs
@@ -228,7 +228,7 @@ class YARD::Server::Commands::DisplayObjectCommand < ::YARD::Server::Commands::L
   # based on the list prefix instead of a HTML filename.
   # @param (see Templates::Helpers::HtmlHelper#url_for_list)
   # @return (see Templates::Helpers::HtmlHelper#url_for_list)
-  def url_for_list: (String | Symbol type) -> String
+  def url_for_list: (interned type) -> String
   # Returns the frames URL for the page
   # @return (see Templates::Helpers::HtmlHelper#url_for_frameset)
   def url_for_frameset: () -> String
@@ -525,7 +525,7 @@ class YARD::Server::Commands::SearchCommand < ::YARD::Server::Commands::LibraryC
   # based on the list prefix instead of a HTML filename.
   # @param (see Templates::Helpers::HtmlHelper#url_for_list)
   # @return (see Templates::Helpers::HtmlHelper#url_for_list)
-  def url_for_list: (String | Symbol type) -> String
+  def url_for_list: (interned type) -> String
   # Returns the frames URL for the page
   # @return (see Templates::Helpers::HtmlHelper#url_for_frameset)
   def url_for_frameset: () -> String
@@ -854,7 +854,7 @@ module YARD::Server::DocServerHelper
   # based on the list prefix instead of a HTML filename.
   # @param (see Templates::Helpers::HtmlHelper#url_for_list)
   # @return (see Templates::Helpers::HtmlHelper#url_for_list)
-  def url_for_list: (String | Symbol type) -> String
+  def url_for_list: (interned type) -> String
 
   # Returns the frames URL for the page
   # @return (see Templates::Helpers::HtmlHelper#url_for_frameset)

--- a/gems/yard/0.9/yard/templates.rbs
+++ b/gems/yard/0.9/yard/templates.rbs
@@ -31,7 +31,7 @@ module YARD::Templates::Engine
   # @raise [ArgumentError] if the path does not exist within one of the
   #   {template_paths} on disk.
   # @return [Template] the module representing the template
-  def self.template: (*Array[String | Symbol] path) -> YARD::Templates::Template
+  def self.template: (*Array[interned] path) -> YARD::Templates::Template
 
   # Forces creation of a template at +path+ within a +full_path+.
   #
@@ -353,7 +353,7 @@ module YARD::Templates::Helpers::HtmlHelper
   # @param [Symbol, String] type the language type (:ruby, :plain, etc). Use
   #   :plain for no syntax highlighting.
   # @return [String] the highlighted source
-  def html_syntax_highlight: (String source, ?Symbol | String type) -> String
+  def html_syntax_highlight: (String source, ?interned type) -> String
 
   # @return [String] unhighlighted source
   def html_syntax_highlight_plain: (untyped source) -> String
@@ -450,7 +450,7 @@ module YARD::Templates::Helpers::HtmlHelper
   # @param [String, Symbol] type the list type to generate a URL for
   # @return [String] the URL pointing to the list
   # @since 0.8.0
-  def url_for_list: (String | Symbol type) -> String
+  def url_for_list: (interned type) -> String
 
   # Returns the URL for the frameset page
   #
@@ -920,7 +920,7 @@ module YARD::Templates::Template
   #   from the file "name.erb" where name is the section name. For
   #   templates, they will have {Template::ClassMethods#run} called on them.
   #   Any subsections can be yielded to using yield or {#yieldall}
-  def sections: (*Array[Array[untyped] | Symbol | String | YARD::Templates::Template] args) -> untyped
+  def sections: (*Array[Array[untyped] | interned | YARD::Templates::Template] args) -> untyped
 
   # Initialization called on the template. Override this in a 'setup.rb'
   # file in the template's path to implement a template
@@ -942,7 +942,7 @@ module YARD::Templates::Template
   # @param [String, Symbol] section the section name
   # @yield calls subsections to be rendered
   # @return [String] the contents of the ERB rendered section
-  def erb: (String | Symbol section) -> String
+  def erb: (interned section) -> String
 
   # Returns the contents of a file. If +allow_inherited+ is set to +true+,
   # use +{{{__super__}}}+ inside the file contents to insert the contents
@@ -971,7 +971,7 @@ module YARD::Templates::Template
   # @param [Symbol, String] sect if provided, uses a specific section name
   # @return [String] the rendered ERB file in any of the inherited template
   #   paths.
-  def superb: (?Symbol | String sect) -> String
+  def superb: (?interned sect) -> String
 
   def inspect: () -> untyped
 


### PR DESCRIPTION
`interned` is defined as alias for `Symbol | string` in RBS 3.3. 
ref: https://github.com/ruby/rbs/pull/1469

This PR replaced every `Symbol | string` to `interned`.
I found them by regexp: `symbol\s?\|\s?string|string\s?\|\s?symbol`.