### PR TITLE
actionpack: Fix signature of ActionController::Base.*_action

### DIFF
--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -142,15 +142,15 @@ module AbstractController::Callbacks::ClassMethods
   type around_action_callback[T] = Symbol | ^(T controller, ^() -> void) [self: T] -> void | _AroundActionCallback
   type after_action_callback[T] = Symbol | ^(T controller) [self: T] -> void | _AfterActionCallback
 
-  def before_action: (*before_action_callback[instance]) ?{ (instance controller) [self: instance] -> void } -> void
-  def around_action: (*around_action_callback[instance]) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
-  def after_action: (*after_action_callback[instance]) ?{ (instance controller) [self: instance] -> void } -> void
-  def skip_before_action: (*before_action_callback[instance]) ?{ (instance controller) [self: instance] -> void } -> void
-  def skip_around_action: (*around_action_callback[instance]) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
-  def skip_after_action: (*after_action_callback[instance]) ?{ (instance controller) [self: instance] -> void } -> void
-  def prepend_before_action: (*before_action_callback[instance]) ?{ (instance controller) [self: instance] -> void } -> void
-  def prepend_around_action: (*around_action_callback[instance]) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
-  def prepend_after_action: (*after_action_callback[instance]) ?{ (instance controller) [self: instance] -> void } -> void
+  def before_action: (*before_action_callback[instance], ?if: before_action_callback[instance], ?unless: before_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
+  def around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
+  def after_action: (*after_action_callback[instance], ?if: after_action_callback[instance], ?unless: after_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
+  def skip_before_action: (*before_action_callback[instance], ?if: before_action_callback[instance], ?unless: before_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
+  def skip_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
+  def skip_after_action: (*after_action_callback[instance], ?if: after_action_callback[instance], ?unless: after_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
+  def prepend_before_action: (*before_action_callback[instance], ?if: before_action_callback[instance], ?unless: before_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
+  def prepend_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
+  def prepend_after_action: (*after_action_callback[instance], ?if: after_action_callback[instance], ?unless: after_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
 
   alias append_before_action before_action
   alias append_around_action around_action


### PR DESCRIPTION
`ActionController::Base.*_action` can take `if` and `unless`, and other keyword arguments.