### PR TITLE
activerecord: Rename AR::Relation::ClassMethods to AR::Base::ClassMethods

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rbs
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   class ActiveRecord_Relation < ActiveRecord::Relation
   end
 
-  extend ActiveRecord::Relation::ClassMethods[User, ActiveRecord_Relation, Integer]
+  extend ActiveRecord::Base::ClassMethods[User, ActiveRecord_Relation, Integer]
 
   def something: () -> untyped
 end

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -367,7 +367,9 @@ module ActiveRecord
                 | () { (Model) -> boolish } -> Array[Model]
       def reselect: (*Symbol | String) -> self
     end
+  end
 
+  class Base
     module ClassMethods[Model, Relation, PrimaryKey]
       def all: () -> Relation
       def ids: () -> Array[PrimaryKey]


### PR DESCRIPTION
In #413, we added `ActiveRecord::Relation::ClassMethods` as a new styled component of `_ActiveRecord_Relation_ClassMethods`.  But this name is not good because it is used to enhance the subclasses of `ActiveRecord::Base`, not the subclasses of `ActiveRecord::Relation`.

It should be renamed to `ActiveRecord::Base::ClassMethods`.

refs:

* https://github.com/pocke/rbs_rails/blob/v0.12.0/lib/rbs_rails/active_record.rb#L33
* https://github.com/ruby/gem_rbs_collection/pull/413