### PR TITLE
activerecord: Fix AR::Relation#or can take other kinds of relation

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -304,7 +304,7 @@ module ActiveRecord
       def order: (*untyped) -> self
       def group: (*Symbol | String) -> untyped
       def distinct: () -> self
-      def or: (self) -> self
+      def or: (::ActiveRecord::Relation) -> self
       def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> self
       def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
       def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
@@ -387,7 +387,7 @@ module ActiveRecord
       def order: (*untyped) -> Relation
       def group: (*Symbol | String) -> untyped
       def distinct: () -> Relation
-      def or: (Relation) -> Relation
+      def or: (::ActiveRecord::Relation) -> Relation
       def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> Relation
       def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
       def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
@@ -463,7 +463,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def order: (*untyped) -> self
   def group: (*Symbol | String) -> untyped
   def distinct: () -> self
-  def or: (self) -> self
+  def or: (::ActiveRecord::Relation) -> self
   def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> self
   def joins: (*String | Symbol | Hash[untyped, untyped]) -> self
   def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> self
@@ -547,7 +547,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def order: (*untyped) -> Relation
   def group: (*Symbol | String) -> untyped
   def distinct: () -> Relation
-  def or: (Relation) -> Relation
+  def or: (::ActiveRecord::Relation) -> Relation
   def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> Relation
   def joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation
   def left_joins: (*String | Symbol | Hash[untyped, untyped]) -> Relation


### PR DESCRIPTION
`ActiveRecord::Relation#or` can take not only the its own kind of relation but also other kinds of relation.

Example:

    Blog.joins(:articles).merge(Blog.where(id: 1).or(Article.where(id: 1)))