### PR TITLE
Stop recommending git submodule

### DIFF
--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -10,19 +10,6 @@ def help
   HELP
 end
 
-def normalize_github_url(str)
-  case str
-  when /\A\s*\z/
-    nil
-  when %r!\A[^/]+/[^/]+\z!
-    "https://github.com/#{str}.git"
-  when /\.git\z/
-    str
-  else
-    "#{str}.git"
-  end
-end
-
 def put(path, content)
   puts "create #{path}"
   path.dirname.mkpath unless path.dirname.directory?
@@ -51,10 +38,6 @@ begin
   puts "Gem version you want to add (MAJOR.MINOR is recommended. e.g. 4.2):"
   print '> '
 end while (version = $stdin.gets.chomp).empty?
-
-puts "GitHub Repository as USER/REPO (default: skip adding git submodule)"
-print '> '
-git_repo = normalize_github_url($stdin.gets.chomp)
 
 puts "Your GitHub account if you want to become the maintainer of RBS for this gem (default: skip adding you to the maintainer)"
 puts "See https://github.com/ruby/gem_rbs_collection/blob/main/docs/CONTRIBUTING.md#code-owners"
@@ -87,11 +70,6 @@ put base / 'manifest.yaml', <<~'YAML'
   # dependencies:
   #   - name: pathname
 YAML
-
-if git_repo
-  src_path = base.join('_src')
-  sh! 'git', 'submodule', 'add', '-f', '--name', src_path.to_s, git_repo, src_path.to_s
-end
 
 if github_account
   github_account = "@#{github_account}" unless github_account.start_with?('@')

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,8 +34,8 @@ This script generates an empty RBS to `gems/GEM_NAME/VERSION/GEM_NAME.rbs`, and 
 
 Specify the _major_ and _minor_ version you are using would be great for most cases.
 
-We recommend adding `_test` and `_src` directories.
-We assume `_test` directory contains files for testing, and `_src` is a git submodule for the source code of the version of the gem.
+We recommend adding `_test` directory.
+We assume `_test` directory contains files for testing.
 
 ### Write RBS files
 


### PR DESCRIPTION
This PR removes the `git submodule` suggestion from the boilerplate generator and the document.


This change is for #520.
In the new system, A PR author can merge the PR if it includes only files under `gems/GEM_NAME/`. But `.gitmodules` file is on the root directory.


I think the submodule is rarely utilized, and it introduces other difficulties (slow `git clone`, traps on renaming directories, and so on). Therefore, I'd like to stop adding a new submodule to this repository.


This PR does not remove existing submodules. They can still be available. (Perhaps I will remove them in the future if no one uses them)


BTW, the script, which will be introduced in #520, can turn on the submodule support if there is a demand. I'll decide whether it supports `git submodule` or not after a while. 