### PR TITLE
add: RBS signeture of ActiveRecord::Encryption::EncryptableRecord module

### DIFF
--- a/gems/activerecord/7.0/_test/test.rb
+++ b/gems/activerecord/7.0/_test/test.rb
@@ -13,5 +13,17 @@ module Test
     enum :role, { admin: 0, user: 1 }, _prefix: true
     enum :classify, %w[hoge fuga], _default: "hoge"
     enum :hoge, fuga: 0, piyo: 1
+
+    encrypts :secret, :key
+    encrypts :token, deterministic: true
+    encrypts :phrase, ignore_case: true
   end
+
+  User.deterministic_encrypted_attributes
+  User.source_attribute_from_preserved_attribute(:phrase)
+  user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
+  user.encrypt
+  user.encrypted_attribute?(:secret)
+  user.decrypt
+  user.ciphertext_for(:token)
 end

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -1,7 +1,7 @@
 module ActiveRecord
   class Base
     include Encryption::EncryptableRecord
-    extend ActiveRecord::Encryption::EncryptableRecord::ClassMethods
+    extend Encryption::EncryptableRecord::ClassMethods
   end
 
   module Inheritance

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -33,16 +33,16 @@ module ActiveRecord
 
         def deterministic_encrypted_attributes: () -> untyped
 
-        def source_attribute_from_preserved_attribute: (untyped attribute_name) -> (untyped | nil)
+        def source_attribute_from_preserved_attribute: (untyped attribute_name) -> untyped
       end
 
-      def encrypted_attribute?: (untyped attribute_name) -> (false | untyped)
+      def encrypted_attribute?: (untyped attribute_name) -> untyped
 
       def ciphertext_for: (untyped attribute_name) -> untyped
 
-      def encrypt: () -> (untyped | nil)
+      def encrypt: () -> untyped
 
-      def decrypt: () -> (untyped | nil)
+      def decrypt: () -> untyped
     end
   end
 end

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -1,4 +1,9 @@
 module ActiveRecord
+  class Base
+    include Encryption::EncryptableRecord
+    extend ActiveRecord::Encryption::EncryptableRecord::ClassMethods
+  end
+
   module Inheritance
     module ClassMethods
       def primary_abstract_class: () -> void
@@ -17,5 +22,27 @@ module ActiveRecord
     def sql_runtime=: (untyped runtime) -> untyped
 
     extend RuntimeRegistry
+  end
+
+  module Encryption
+    module EncryptableRecord
+      module ClassMethods
+        @deterministic_encrypted_attributes: untyped
+
+        def encrypts: (*untyped names, ?key_provider: untyped?, ?key: untyped?, ?deterministic: bool, ?support_unencrypted_data: untyped?, ?downcase: bool, ?ignore_case: bool, ?previous: untyped, **untyped context_properties) -> untyped
+
+        def deterministic_encrypted_attributes: () -> untyped
+
+        def source_attribute_from_preserved_attribute: (untyped attribute_name) -> (untyped | nil)
+      end
+
+      def encrypted_attribute?: (untyped attribute_name) -> (false | untyped)
+
+      def ciphertext_for: (untyped attribute_name) -> untyped
+
+      def encrypt: () -> (untyped | nil)
+
+      def decrypt: () -> (untyped | nil)
+    end
   end
 end


### PR DESCRIPTION
https://github.com/rails/rails/blob/v7.0.8.1/activerecord/lib/active_record/encryption/encryptable_record.rb

Generated automatically by typeprof.

The method definitions in the class_methods block of ActiveSupport::Concern have been rewritten to the ClassMethods module.