### PR TITLE
Add types for marcel

### DIFF
--- a/gems/marcel/1.0/_test/test.rb
+++ b/gems/marcel/1.0/_test/test.rb
@@ -1,0 +1,28 @@
+require "marcel"
+require "pathname"
+require "stringio"
+
+# Magic bytes sniffing alone
+Marcel::MimeType.for Pathname.new("example.gif")
+#  => "image/gif"
+
+File.open "example.gif" do |file|
+  Marcel::MimeType.for file
+end
+#  => "image/gif"
+
+# Magic bytes with filename fallback
+Marcel::MimeType.for Pathname.new("unrecognisable-data"), name: "example.pdf"
+#  => "application/pdf"
+
+# File extension alone
+Marcel::MimeType.for extension: ".pdf"
+#  => "application/pdf"
+
+# Magic bytes, declared type, and filename together
+Marcel::MimeType.for Pathname.new("unrecognisable-data"), name: "example", declared_type: "image/png"
+#  => "image/png"
+
+# Safe fallback to application/octet-stream
+Marcel::MimeType.for StringIO.new(File.read "unrecognisable-data")
+#  => "application/octet-stream"

--- a/gems/marcel/1.0/manifest.yaml
+++ b/gems/marcel/1.0/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: pathname

--- a/gems/marcel/1.0/marcel.rbs
+++ b/gems/marcel/1.0/marcel.rbs
@@ -1,0 +1,13 @@
+module Marcel
+  class Magic
+    attr_reader type: String
+    attr_reader mediatype: String
+    attr_reader subtype: String
+
+    def self.by_magic: (IO | StringIO) -> instance
+  end
+
+  class MimeType
+    def self.for: (?Pathname | IO | StringIO pathname_or_io, ?name: String, ?extension: String, ?declared_type: String) -> String
+  end
+end


### PR DESCRIPTION
Marcel chooses the most appropriate content type for a file by inspecting its contents, the declared MIME type (perhaps passed as a Content-Type header), and the file extension.

refs: https://github.com/rails/marcel