### PR TITLE
Specify the gem version with `.0` suffix

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -96,7 +96,7 @@ class Runner
   end
 
   def generate_gemfile_lock
-    v = "~> #{version}"
+    v = "~> #{version}.0"
     gemfile.write(<<~RUBY)
       source 'https://rubygems.org'
       gem #{gem_name.dump}, #{v.dump}


### PR DESCRIPTION
gem_rbs_collection usually assumes the directory name contains the *major* and *minor* version numbers. Generating the constraints with `~> #{version}` results in `~> 7.0`, which means testing `activerecord/7.0/_test` scripts with `activerecord/7.1` definition.

Adding `.0` generates `~> 7.0.0`, which ensures running test in `activerecord/7.0` with `activerecord/7.1` definitions.

💡  You may want to do something smarter so that directory names with patch number works correctly.