### PR TITLE
Make `ActiveRecord::Associations::ClassMethods#has_many` block optional

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -3558,7 +3558,7 @@ module ActiveRecord
       #   has_many :tags, as: :taggable
       #   has_many :reports, -> { readonly }
       #   has_many :subscribers, through: :subscriptions, source: :user
-      def has_many: (untyped name, ?untyped? scope, **untyped options) { () -> untyped } -> untyped
+      def has_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped
 
       # Specifies a one-to-one association with another class. This method should only be used
       # if the other class contains the foreign key. If the current class contains the foreign key,
@@ -4005,7 +4005,7 @@ module ActiveRecord
       #   has_and_belongs_to_many :nations, class_name: "Country"
       #   has_and_belongs_to_many :categories, join_table: "prods_cats"
       #   has_and_belongs_to_many :categories, -> { readonly }
-      def has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) { () -> untyped } -> untyped
+      def has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped
     end
   end
 end


### PR DESCRIPTION
Also `has_many_and_belongs_to`