### PR TITLE
Add sinatra gem type

### DIFF
--- a/gems/sinatra/4.0/_test/test.rb
+++ b/gems/sinatra/4.0/_test/test.rb
@@ -35,6 +35,16 @@ class MyApp < Sinatra::Base
     json(foo: foo, bar: bar)
   end
 
+  get '/test_params/:id' do
+    params[:id]
+    params['id']
+    json(status: 'ok')
+  end
+
+  get '/fail' do
+    halt 500
+  end
+
   post '/' do
     json(foo: foo, bar: bar)
   end

--- a/gems/sinatra/4.0/base.rbs
+++ b/gems/sinatra/4.0/base.rbs
@@ -461,12 +461,14 @@ module Sinatra
     attr_accessor app: untyped
 
     attr_accessor env: Hash[String, untyped]
+    def self.env: () -> Hash[String, untyped]
 
     attr_accessor request: untyped
 
     attr_accessor response: untyped
 
     attr_accessor params: IndifferentHash
+    def self.params: () -> IndifferentHash
 
     attr_reader template_cache: untyped
 
@@ -486,6 +488,7 @@ module Sinatra
     # Exit the current block, halts any further processing
     # of the request, and returns the specified response.
     def halt: (*untyped response) -> untyped
+    def self.halt: (*untyped response) -> untyped
 
     # Pass control to the next matching route.
     # If there are no more matching routes, Sinatra will


### PR DESCRIPTION
Method calls with HTTP verbs (`get`, `post`, etc.) are always evaluated as singleton methods, so a corresponding singleton method definition is required.