### PR TITLE
Add `is_password?` method type to `BCrypt::Password` class

### DIFF
--- a/gems/bcrypt/3.1/_test/test.rb
+++ b/gems/bcrypt/3.1/_test/test.rb
@@ -12,6 +12,7 @@ BCrypt::Password.new(hashed_password.to_s)
 
 hashed_password == raw_password
 hashed_password == raw_password.to_s
+hashed_password.is_password?(raw_password)
 
 # BCrypt::Engine
 BCrypt::Engine.cost = 5

--- a/gems/bcrypt/3.1/bcrypt.rbs
+++ b/gems/bcrypt/3.1/bcrypt.rbs
@@ -8,6 +8,7 @@ module BCrypt
     def self.valid_hash?: (String h) -> bool
     def initialize: (String raw_hash) -> void
     def ==: (_ToS secret) -> bool
+    alias is_password? ==
   end
 
   class Engine


### PR DESCRIPTION
The corresponding implementation is as follows:
https://github.com/bcrypt-ruby/bcrypt-ruby/blob/58f8afd33d8813e84706b938815bb1aa08d0b470/lib/bcrypt/password.rb#L79