### PR TITLE
Allow Array in `Sinatra::JSON#json` argument

### DIFF
--- a/gems/sinatra-contrib/4.0/json.rbs
+++ b/gems/sinatra-contrib/4.0/json.rbs
@@ -86,7 +86,8 @@ module Sinatra
   module JSON
     def self.encode: (untyped object) -> untyped
 
-    def json: (Hash[untyped, untyped] object, ?::Hash[untyped, untyped] options) -> untyped
+    def json: (Hash[untyped, untyped] object, ?::Hash[Symbol, untyped] options) -> void
+            | (Array[Hash[untyped, untyped]] object, ?::Hash[Symbol, untyped] options) -> void
 
     private
 

--- a/gems/sinatra/4.0/_test/test.rb
+++ b/gems/sinatra/4.0/_test/test.rb
@@ -52,4 +52,8 @@ class MyApp < Sinatra::Base
   patch '/' do
     raise HttpError.new(401)
   end
+
+  delete '/' do
+    json([{foo: 'bar'}])
+  end
 end


### PR DESCRIPTION
`Sinatra::JSON#json` was able to properly encode a list of objects as JSON, but was unable to represent them as types.

Fixed this so that Arrays are also accepted with type overloading.