### PR TITLE
Add types for ActiveRecord missing method

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -17,3 +17,4 @@ User.eager_load(:address, friends: [:address, :followers])
 User.includes(:address, :friends).to_a
 User.preload(:address, friends: [:address, :followers])
 User.in_order_of(:id, [1, 5, 3])
+User.where.missing(:address, :friends)

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -300,6 +300,7 @@ module ActiveRecord
               | (*Symbol | String columns) -> Array[Array[untyped]]
       def where: (*untyped) -> self
       def not: (*untyped) -> self
+      def missing: (*Symbol) -> self
       def exists?: (*untyped) -> bool
       def order: (*untyped) -> self
       def group: (*Symbol | String) -> untyped
@@ -463,6 +464,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
            | (*Symbol | String columns) -> Array[Array[untyped]]
   def where: (*untyped) -> self
   def not: (*untyped) -> self
+  def missing: (*Symbol) -> self
   def exists?: (*untyped) -> bool
   def order: (*untyped) -> self
   def group: (*Symbol | String) -> untyped


### PR DESCRIPTION
ref: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-missing