### PR TITLE
Suppress review comment action on not approval comment

### DIFF
--- a/.github/workflows/generate_comment_body_on_review.yml
+++ b/.github/workflows/generate_comment_body_on_review.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   create_comment:
-    if: github.event.review.state != 'CHANGES_REQUESTED'
+    if: github.event.review.state != 'CHANGES_REQUESTED' && ( github.event.review.state == 'APPROVED' || contains(github.event.review.body, 'APPROVE') )
     runs-on: 'ubuntu-latest'
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
Previously, the comment on a review is triggered by all kinds of review comments, even if the comment is for a line comment or a non-approval comment.

example: https://github.com/ruby/gem_rbs_collection/pull/544#issuecomment-2044050993


This workflow intends to introduce what the reviewer or PR author should do after PR approval. So it should not be triggered by a non-approval comment.


This PR suppresses such events. 