### PR TITLE
Add a devcontainer.json file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "gem_rbs_collection--dev",
+  "image": "ruby:latest",
+  "workspaceFolder": "/workspaces/gem_rbs_collection",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "soutaro.rbs-syntax",
+        "Shopify.ruby-extensions-pack"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I want to add a very basic `devcontainer.json` file since I think it's handy to get started for those who use containers for development. With this, developers can quickly start to work on something on this repo with their containers on local machines, Codespaces, etc.