### PR TITLE
activerecord: if/unless proc params can take an instance as an argument

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   enum role: { admin: 0, user: 1 }, _prefix: :user_role
 
   validates :name, presence: true, if: -> { something }
+  validates :age, presence: true, if: ->(user) { user.something }
 
   before_save -> (obj) { obj.something; self.something }
   around_save -> (obj, block) { block.call; obj.something }

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -1,6 +1,6 @@
 module ActiveRecord
   class Base
-    type condition[T] = Symbol | ^() [self: T] -> boolish
+    type condition[T] = Symbol | ^(T) [self: T] -> boolish
 
     # puts ActiveRecord::Base.singleton_class.ancestors.map(&:to_s).select { |s| /ClassMethods$/.match?(s) }.map{ |s| "extend ::#{s}" }.sort
     extend ::ActiveModel::AttributeMethods::ClassMethods


### PR DESCRIPTION
Proc objects for if/unless params to the validation and hook methods can
take an instance of the AR model as an argument.