### PR TITLE
Export from steep

### DIFF
--- a/gems/parser/3.2/parser.rbs
+++ b/gems/parser/3.2/parser.rbs
@@ -39,10 +39,490 @@ module Parser
       attr_reader location: Source::Map
       alias loc location
     end
+
+    interface _BlockNode
+      def type: () -> :block
+
+      %a{pure} def loc: () -> (Source::Map & _BlockLocation)
+    end
+
+    interface _BlockLocation
+      %a{pure} def end: () -> Source::Range
+    end
+
+    interface _DefNode
+      def type: () -> :def
+
+      def children: () -> [Symbol, Node, Node?]
+
+      %a{pure} def loc: () -> (Source::Map & _DefLocation)
+    end
+
+    interface _DefLocation
+      def name: () -> Source::Range
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    interface _CaseNode
+      def type: () -> :case
+
+      %a{pure} def loc: () -> (Source::Map & _CaseLocation)
+    end
+
+    interface _CaseLocation
+      %a{pure} def else: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range
+    end
+
+    interface _NamedLocation
+      %a{pure} def name: () -> Source::Range
+    end
+
+    interface _SelectorLocation
+      %a{pure} def selector: () -> Source::Range
+    end
+
+    # ```ruby
+    # if foo then bar else baz end
+    # #^                              => keyword
+    # #      ^^^^                     => begin
+    # #               ^^^^            => else
+    # #                        ^^^    => end
+    # ```
+    #
+    interface _Condition
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def else: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    # ```ruby
+    # foo ? bar : baz
+    # #   ^               question
+    # #         ^         colon
+    # ```
+    interface _Ternary
+      %a{pure} def question: () -> Source::Range
+
+      %a{pure} def colon: () -> Source::Range
+    end
+
+    interface _Variable
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    # foo.bar(baz)
+    # #  ^             => dot
+    # #   ^^^          => selector
+    # #      ^         => begin
+    # #          ^     => end
+    #
+    # foo.bar += 1
+    # #  ^             => dot
+    # #   ^^^          => selector
+    # #       ^^       => operator
+    # ```
+    #
+    interface _Send
+      %a{pure} def dot: () -> Source::Range?
+
+      %a{pure} def selector: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    # ```ruby
+    # rescue Foo => x then
+    # #^^^^^                => keyword
+    # #          ^^         => assoc
+    # #               ^^^^  => begin
+    # ```
+    interface _RescueBody
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def assoc: () -> Source::Range?
+
+      %a{pure} def begin: () -> Source::Range?
+    end
+
+    # ```ruby
+    # +1
+    # ^         => operator
+    # ```
+    interface _Operator
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    # def self.foo(); end
+    # #^^                        => keyword
+    # #       ^                  => operator
+    # #        ^^^               => name
+    # #               ^^^        => end
+    #
+    # def foo = bar
+    # #^^                        => keyword
+    # #   ^^^                    => name
+    # #       ^                  => assignment
+    # ```
+    interface _MethodDefinition
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def end: () -> Source::Range?
+
+      %a{pure} def assignment: () -> Source::Range?
+    end
+
+    # ```ruby
+    # when foo then
+    # #^^^             => keyword
+    # #        ^^^^    => begin
+    # ```
+    interface _Keyword
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    # ```ruby
+    # foo[1] += 1
+    # #  ^             => begin
+    # #    ^           => end
+    # #      ^^        => operator
+    # ```
+    interface _Index
+      %a{pure} def begin: () -> Source::Range
+
+      %a{pure} def end: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    # <<FOO                   <= expression
+    #   foo                   <= heredoc_body
+    # FOO                     <= heredoc_end
+    # ```
+    #
+    interface _Heredoc
+      %a{pure} def heredoc_body: () -> Source::Range
+
+      %a{pure} def heredoc_end: () -> Source::Range
+    end
+
+    # ```ruby
+    # for x in [] then ... end
+    # #^^                       => keyword
+    # #     ^^                  => in
+    # #           ^^^^          => begin
+    # #                    ^^^  => end
+    # ```
+    interface _For
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def in: () -> Source::Range
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range
+    end
+
+    # ```ruby
+    # class Foo::Bar < Baz; end
+    # #^^^^                       => keyword
+    # #     ^^^^^^^^              => name
+    # #              ^            => operator
+    # #                     ^^^   => end
+    # ```
+    interface _Definition
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range
+    end
+
+    # ```ruby
+    # Foo::Bar += 1
+    # #  ^^                 => double_colon
+    # #    ^^^              => name
+    # #        ^^           => operator
+    # ```
+    #
+    interface _Constant
+      %a{pure} def double_colon: () -> Source::Range?
+
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    #   (1)
+    # # ^           => begin
+    # #   ^         => end
+    # ```
+    interface _Collection
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
   end
 
   module Source
+    #
+    # A range of characters in a particular source buffer.
+    #
+    # The range is always exclusive, i.e. a range with `begin_pos` of 3 and
+    # `end_pos` of 5 will contain the following characters:
+    #
+    #     example
+    #        ^^
+    #
+    # @!attribute [r] source_buffer
+    #  @return [Parser::Source::Buffer]
+    #
+    # @!attribute [r] begin_pos
+    #  @return [Integer] index of the first character in the range
+    #
+    # @!attribute [r] end_pos
+    #  @return [Integer] index of the character after the last character in the range
+    #
+    # @api public
+    #
     class Range
+      include Comparable
+
+      attr_reader source_buffer: untyped
+
+      attr_reader begin_pos: Integer
+
+      attr_reader end_pos: Integer
+
+      #
+      # @param [Buffer]  source_buffer
+      # @param [Integer] begin_pos
+      # @param [Integer] end_pos
+      #
+      def initialize: (untyped source_buffer, untyped begin_pos, untyped end_pos) -> void
+
+      #
+      # @return [Range] a zero-length range located just before the beginning
+      #   of this range.
+      #
+      def begin: () -> Range
+
+      #
+      # @return [Range] a zero-length range located just after the end
+      #   of this range.
+      #
+      def end: () -> Range
+
+      #
+      # @return [Integer] amount of characters included in this range.
+      #
+      def size: () -> Integer
+
+      alias length size
+
+      #
+      # Line number of the beginning of this range. By default, the first line
+      # of a buffer is 1; as such, line numbers are most commonly one-based.
+      #
+      # @see Buffer
+      # @return [Integer] line number of the beginning of this range.
+      #
+      def line: () -> Integer
+
+      alias first_line line
+
+      #
+      # @return [Integer] zero-based column number of the beginning of this range.
+      #
+      def column: () -> Integer
+
+      #
+      # @return [Integer] line number of the end of this range.
+      #
+      def last_line: () -> Integer
+
+      #
+      # @return [Integer] zero-based column number of the end of this range.
+      #
+      def last_column: () -> Integer
+
+      #
+      # @return [::Range] a range of columns spanned by this range.
+      # @raise RangeError
+      #
+      def column_range: () -> ::Range[Integer]
+
+      #
+      # @return [String] a line of source code containing the beginning of this range.
+      #
+      def source_line: () -> String
+
+      #
+      # @return [String] all source code covered by this range.
+      #
+      def source: () -> String
+
+      #
+      # `is?` provides a concise way to compare the source corresponding to this range.
+      # For example, `r.source == '(' || r.source == 'begin'` is equivalent to
+      # `r.is?('(', 'begin')`.
+      #
+      def is?: (*untyped what) -> untyped
+
+      #
+      # @return [Array<Integer>] a set of character indexes contained in this range.
+      #
+      def to_a: () -> Array[Integer]
+
+      #
+      # @return [Range] a Ruby range with the same `begin_pos` and `end_pos`
+      #
+      def to_range: () -> ::Range[Integer]
+
+      #
+      # Composes a GNU/Clang-style string representation of the beginning of this
+      # range.
+      #
+      # For example, for the following range in file `foo.rb`,
+      #
+      #     def foo
+      #         ^^^
+      #
+      # `to_s` will return `foo.rb:1:5`.
+      # Note that the column index is one-based.
+      #
+      # @return [String]
+      #
+      def to_s: () -> String
+
+      #
+      # @param [Hash] Endpoint(s) to change, any combination of :begin_pos or :end_pos
+      # @return [Range] the same range as this range but with the given end point(s) changed
+      # to the given value(s).
+      #
+      def with: (?begin_pos: untyped, ?end_pos: untyped) -> untyped
+
+      #
+      # @param [Hash] Endpoint(s) to change, any combination of :begin_pos or :end_pos
+      # @return [Range] the same range as this range but with the given end point(s) adjusted
+      # by the given amount(s)
+      #
+      def adjust: (?begin_pos: ::Integer, ?end_pos: ::Integer) -> untyped
+
+      #
+      # @param [Integer] new_size
+      # @return [Range] a range beginning at the same point as this range and length `new_size`.
+      #
+      def resize: (untyped new_size) -> untyped
+
+      #
+      # @param [Range] other
+      # @return [Range] smallest possible range spanning both this range and `other`.
+      #
+      def join: (untyped other) -> untyped
+
+      #
+      # @param [Range] other
+      # @return [Range] overlapping region of this range and `other`, or `nil`
+      #   if they do not overlap
+      #
+      def intersect: (untyped other) -> (untyped | nil)
+
+      #
+      # Return `true` iff this range and `other` are disjoint.
+      #
+      # Two ranges must be one and only one of ==, disjoint?, contains?, contained? or crossing?
+      #
+      # @param [Range] other
+      # @return [Boolean]
+      #
+      def disjoint?: (untyped other) -> untyped
+
+      #
+      # Return `true` iff this range is not disjoint from `other`.
+      #
+      # @param [Range] other
+      # @return [Boolean] `true` if this range and `other` overlap
+      #
+      def overlaps?: (untyped other) -> untyped
+
+      #
+      # Returns true iff this range contains (strictly) `other`.
+      #
+      # Two ranges must be one and only one of ==, disjoint?, contains?, contained? or crossing?
+      #
+      # @param [Range] other
+      # @return [Boolean]
+      #
+      def contains?: (untyped other) -> untyped
+
+      #
+      # Return `other.contains?(self)`
+      #
+      # Two ranges must be one and only one of ==, disjoint?, contains?, contained? or crossing?
+      #
+      # @param [Range] other
+      # @return [Boolean]
+      #
+      def contained?: (untyped other) -> untyped
+
+      #
+      # Returns true iff both ranges intersect and also have different elements from one another.
+      #
+      # Two ranges must be one and only one of ==, disjoint?, contains?, contained? or crossing?
+      #
+      # @param [Range] other
+      # @return [Boolean]
+      #
+      def crossing?: (untyped other) -> (false | untyped)
+
+      #
+      # Checks if a range is empty; if it contains no characters
+      # @return [Boolean]
+      def empty?: () -> untyped
+
+      #
+      # Compare ranges, first by begin_pos, then by end_pos.
+      #
+      def <=>: (untyped other) -> (nil | untyped)
+
+      alias eql? ==
+
+      #
+      # Support for Ranges be used in as Hash indices and in Sets.
+      #
+      def hash: () -> untyped
+
+      #
+      # @return [String] a human-readable representation of this range.
+      #
+      def inspect: () -> ::String
     end
 
     class Buffer
@@ -52,18 +532,179 @@ module Parser
       def replace: (untyped range, String content) -> self
     end
 
+    #
+    # {Map} relates AST nodes to the source code they were parsed from.
+    # More specifically, a {Map} or its subclass contains a set of ranges:
+    #
+    #  * `expression`: smallest range which includes all source corresponding
+    #    to the node and all `expression` ranges of its children.
+    #  * other ranges (`begin`, `end`, `operator`, ...): node-specific ranges
+    #    pointing to various interesting tokens corresponding to the node.
+    #
+    # Note that the {Map::Heredoc} map is the only one whose `expression` does
+    # not include other ranges. It only covers the heredoc marker (`<<HERE`),
+    # not the here document itself.
+    #
+    # All ranges except `expression` are defined by {Map} subclasses.
+    #
+    # Ranges (except `expression`) can be `nil` if the corresponding token is
+    # not present in source. For example, a hash may not have opening/closing
+    # braces, and so would its source map.
+    #
+    #     p Parser::CurrentRuby.parse('[1 => 2]').children[0].loc
+    #     # => <Parser::Source::Map::Collection:0x007f5492b547d8
+    #     #  @end=nil, @begin=nil,
+    #     #  @expression=#<Source::Range (string) 1...7>>
+    #
+    # The {file:doc/AST_FORMAT.md} document describes how ranges associated to source
+    # code tokens. For example, the entry
+    #
+    #     (array (int 1) (int 2))
+    #
+    #     "[1, 2]"
+    #      ^ begin
+    #           ^ end
+    #      ~~~~~~ expression
+    #
+    # means that if `node` is an {Parser::AST::Node} `(array (int 1) (int 2))`,
+    # then `node.loc` responds to `begin`, `end` and `expression`, and
+    # `node.loc.begin` returns a range pointing at the opening bracket, and so on.
+    #
+    # If you want to write code polymorphic by the source map (i.e. accepting
+    # several subclasses of {Map}), use `respond_to?` instead of `is_a?` to
+    # check whether the map features the range you need. Concrete {Map}
+    # subclasses may not be preserved between versions, but their interfaces
+    # will be kept compatible.
+    #
+    # You can visualize the source maps with `ruby-parse -E` command-line tool.
+    #
+    # @example
+    #  require 'parser/current'
+    #
+    #  p Parser::CurrentRuby.parse('[1, 2]').loc
+    #  # => #<Parser::Source::Map::Collection:0x007f14b80eccd8
+    #  #  @end=#<Source::Range (string) 5...6>,
+    #  #  @begin=#<Source::Range (string) 0...1>,
+    #  #  @expression=#<Source::Range (string) 0...6>>
+    #
+    # @!attribute [r] node
+    #  The node that is described by this map. Nodes and maps have 1:1 correspondence.
+    #  @return [Parser::AST::Node]
+    #
+    # @!attribute [r] expression
+    #  @return [Range]
+    #
+    # @api public
+    #
     class Map
+      attr_reader node: AST::Node
+
+      attr_reader expression: Range
+
+      #
+      # @param [Range] expression
+      def initialize: (untyped expression) -> void
+
+      #
+      # @api private
+      def initialize_copy: (untyped other) -> untyped
+
+      #
+      # @api private
+      def node=: (untyped node) -> untyped
+
+      #
+      # A shortcut for `self.expression.line`.
+      # @return [Integer]
+      #
       def line: () -> Integer
-      def first_line: () -> Integer
-      def last_line: () -> Integer
+
+      alias first_line line
+
+      #
+      # A shortcut for `self.expression.column`.
+      # @return [Integer]
+      #
       def column: () -> Integer
-      def first_column: () -> Integer
+
+      #
+      # A shortcut for `self.expression.last_line`.
+      # @return [Integer]
+      #
+      def last_line: () -> Integer
+
+      #
+      # A shortcut for `self.expression.last_column`.
+      # @return [Integer]
+      #
       def last_column: () -> Integer
+
+      #
+      # @api private
+      #
+      def with_expression: (untyped expression_l) -> untyped
+
+      #
+      # Compares source maps.
+      # @return [Boolean]
+      #
+      def ==: (untyped other) -> bool
+
+      #
+      # Converts this source map to a hash with keys corresponding to
+      # ranges. For example, if called on an instance of {Collection},
+      # which adds the `begin` and `end` ranges, the resulting hash
+      # will contain keys `:expression`, `:begin` and `:end`.
+      #
+      # @example
+      #  require 'parser/current'
+      #
+      #  p Parser::CurrentRuby.parse('[1, 2]').loc.to_hash
+      #  # => {
+      #  #   :begin => #<Source::Range (string) 0...1>,
+      #  #   :end => #<Source::Range (string) 5...6>,
+      #  #   :expression => #<Source::Range (string) 0...6>
+      #  # }
+      #
+      # @return [Hash<Symbol, Parser::Source::Range>]
+      #
+      def to_hash: () -> Hash[Symbol, Range]
+
+      def with: () ?{ () -> untyped } -> untyped
+
+      def update_expression: (untyped expression_l) -> untyped
+
+      def first_column: () -> Integer
     end
 
     class Comment
-      def location: () -> Map
+      def self.associate: (untyped ast, untyped comments) -> untyped
+
+      def self.associate_by_identity: (untyped ast, untyped comments) -> untyped
+
+      def self.associate_locations: (untyped ast, untyped comments) -> untyped
+
+      public
+
+      def ==: (untyped other) -> bool
+
+      def document?: () -> bool
+
+      def inline?: () -> bool
+
+      def inspect: () -> String
+
       alias loc location
+
+      def location: () -> Map
+
+      def text: () -> String
+
+      def type: () -> (:inline | :document)
+
+      private
+
+      def initialize: (untyped range) -> void
     end
   end
 end


### PR DESCRIPTION
Steep has definitions for the parser, https://github.com/soutaro/steep/tree/55c58d0f8aa1fc65a8add95a5fde43f6b4375164/sig/shims
but they conflict with those in gem_rbs_collection, so only one can be used.

I believe the best approach for the community is to support and develop the ones in gem_rbs_collection.

Here are the steps I propose:

1. Stop distributing the sig directory from Steep.
2. Merge the parser definitions from Steep into gem_rbs_collection.

@soutaro @pocke 
How about you all?