### PR TITLE
Run comment on review workflow only when the PR is still opened

### DIFF
--- a/.github/workflows/comment_on_review.yml
+++ b/.github/workflows/comment_on_review.yml
@@ -25,5 +25,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run:
-          gh pr comment "$(cat PR_NUMBER)" --body "$(cat COMMENT_BODY.txt)" --repo "$GH_REPO"
+          state="$(gh pr view "$(cat PR_NUMBER)" --json state --jq .state --repo "$GH_REPO")"
+          if [ "$state" = "OPEN"]; then
+            gh pr comment "$(cat PR_NUMBER)" --body "$(cat COMMENT_BODY.txt)" --repo "$GH_REPO"
+          fi
 


### PR DESCRIPTION
Problem
---

Currently, this workflow comments to a PR if the PR has been already merged. Sometimes it's noisy. For example: https://github.com/ruby/gem_rbs_collection/pull/577#issuecomment-2144441234

Solution
---

Check the merge state before the comment to avoid unnecessary comments.

This patch uses `gh pr view` command instead of the event payload of GHA. We can easily imagine that a PR is merged while this workflow is running. Therefore it should check the PR state right before the comment.