### PR TITLE
add: ActiveRecord::QueryMethods::WhereChain#missing

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -18591,40 +18591,6 @@ module ActiveRecord
 
     include ActiveModel::ForbiddenAttributesProtection
 
-    # WhereChain objects act as placeholder for queries in which #where does not have any parameter.
-    # In this case, #where must be chained with #not to return a new relation.
-    class WhereChain
-      include ActiveModel::ForbiddenAttributesProtection
-
-      def initialize: (untyped scope) -> untyped
-
-      # Returns a new relation expressing WHERE + NOT condition according to
-      # the conditions in the arguments.
-      #
-      # #not accepts conditions as a string, array, or hash. See QueryMethods#where for
-      # more details on each format.
-      #
-      #    User.where.not("name = 'Jon'")
-      #    # SELECT * FROM users WHERE NOT (name = 'Jon')
-      #
-      #    User.where.not(["name = ?", "Jon"])
-      #    # SELECT * FROM users WHERE NOT (name = 'Jon')
-      #
-      #    User.where.not(name: "Jon")
-      #    # SELECT * FROM users WHERE name != 'Jon'
-      #
-      #    User.where.not(name: nil)
-      #    # SELECT * FROM users WHERE name IS NOT NULL
-      #
-      #    User.where.not(name: %w(Ko1 Nobu))
-      #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
-      def not: (untyped opts, *untyped rest) -> untyped
-
-      private
-
-      def not_behaves_as_nor?: (untyped opts) -> (::FalseClass | untyped)
-    end
-
     FROZEN_EMPTY_ARRAY: untyped
 
     FROZEN_EMPTY_HASH: untyped

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -298,7 +298,8 @@ module ActiveRecord
       def none: () -> self
       def pluck: (Symbol | String column) -> Array[untyped]
               | (*Symbol | String columns) -> Array[Array[untyped]]
-      def where: (*untyped) -> self
+      def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+               | (*untyped) -> self
       def not: (*untyped) -> self
       def exists?: (*untyped) -> bool
       def order: (*untyped) -> self
@@ -377,7 +378,8 @@ module ActiveRecord
       def none: () -> Relation
       def pluck: (Symbol | String column) -> Array[untyped]
               | (*Symbol | String columns) -> Array[Array[untyped]]
-      def where: (*untyped) -> Relation
+      def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+               | (*untyped) -> Relation
       def exists?: (*untyped) -> bool
       def any?: () -> bool
               | () { (Model) -> boolish } -> bool
@@ -461,7 +463,8 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def none: () -> self
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
-  def where: (*untyped) -> self
+  def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+           | (*untyped) -> self
   def not: (*untyped) -> self
   def exists?: (*untyped) -> bool
   def order: (*untyped) -> self
@@ -539,7 +542,8 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def none: () -> Relation
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
-  def where: (*untyped) -> Relation
+  def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+           | (*untyped) -> Relation
   def exists?: (*untyped) -> bool
   def any?: () -> bool
           | () { (Model) -> boolish } -> bool

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -288,6 +288,20 @@ module ActiveRecord
 
     def self.default_scope: (?untyped? scope) -> untyped | ...
   end
+
+  module QueryMethods
+    class WhereChain[Relation]
+      include ActiveModel::ForbiddenAttributesProtection
+
+      def initialize: (Relation scope) -> void
+                 
+      def not: (untyped opts, *untyped rest) -> Relation
+
+      private
+
+      def not_behaves_as_nor?: (untyped opts) -> (::FalseClass | untyped)
+    end
+  end
 end
 
 module ActiveRecord
@@ -298,7 +312,7 @@ module ActiveRecord
       def none: () -> self
       def pluck: (Symbol | String column) -> Array[untyped]
               | (*Symbol | String columns) -> Array[Array[untyped]]
-      def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+      def where: () -> ::ActiveRecord::QueryMethods::WhereChain[self]
                | (*untyped) -> self
       def not: (*untyped) -> self
       def exists?: (*untyped) -> bool
@@ -378,7 +392,7 @@ module ActiveRecord
       def none: () -> Relation
       def pluck: (Symbol | String column) -> Array[untyped]
               | (*Symbol | String columns) -> Array[Array[untyped]]
-      def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+      def where: () -> ::ActiveRecord::QueryMethods::WhereChain[Relation]
                | (*untyped) -> Relation
       def exists?: (*untyped) -> bool
       def any?: () -> bool
@@ -463,7 +477,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def none: () -> self
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
-  def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+  def where: () -> ::ActiveRecord::QueryMethods::WhereChain[self]
            | (*untyped) -> self
   def not: (*untyped) -> self
   def exists?: (*untyped) -> bool
@@ -542,7 +556,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def none: () -> Relation
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
-  def where: () -> ::ActiveRecord::QueryMethods::WhereChain
+  def where: () -> ::ActiveRecord::QueryMethods::WhereChain[Relation]
            | (*untyped) -> Relation
   def exists?: (*untyped) -> bool
   def any?: () -> bool

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -31,4 +31,10 @@ module ActiveRecord
   class MismatchedForeignKey < StatementInvalid
     def initialize: (?primary_key_column: untyped? primary_key_column, ?primary_key: untyped? primary_key, ?target_table: untyped? target_table, ?foreign_key: untyped? foreign_key, ?table: untyped? table, ?binds: untyped? binds, ?sql: untyped? sql, ?message: untyped? message) -> untyped
   end
+
+  module QueryMethods
+    class WhereChain
+      def missing: (*Symbol associations) -> Relation
+    end
+  end
 end

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -33,7 +33,7 @@ module ActiveRecord
   end
 
   module QueryMethods
-    class WhereChain
+    class WhereChain[Relation]
       def missing: (*Symbol associations) -> Relation
     end
   end

--- a/gems/activerecord/7.0/_test/test.rb
+++ b/gems/activerecord/7.0/_test/test.rb
@@ -17,8 +17,15 @@ module Test
     encrypts :secret, :key
     encrypts :token, deterministic: true
     encrypts :phrase, ignore_case: true
+
+    has_many :posts
   end
 
+  class Post < ApplicationRecord
+    belongs_to :user
+  end
+
+  User.where.missing(:posts)
   User.deterministic_encrypted_attributes
   User.source_attribute_from_preserved_attribute(:phrase)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')

--- a/gems/activerecord/7.0/_test/test.rb
+++ b/gems/activerecord/7.0/_test/test.rb
@@ -17,15 +17,9 @@ module Test
     encrypts :secret, :key
     encrypts :token, deterministic: true
     encrypts :phrase, ignore_case: true
-
-    has_many :posts
   end
 
-  class Post < ApplicationRecord
-    belongs_to :user
-  end
-
-  User.where.missing(:posts)
+  User.where.missing.to_sql
   User.deterministic_encrypted_attributes
   User.source_attribute_from_preserved_attribute(:phrase)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')

--- a/gems/activerecord/7.0/_test/test.rbs
+++ b/gems/activerecord/7.0/_test/test.rbs
@@ -6,25 +6,6 @@ module Test
     extend ::ActiveRecord::Base::ClassMethods[User, ActiveRecord_Relation, Integer]
 
     class ActiveRecord_Relation < ::ActiveRecord::Relation
-      include ::ActiveRecord::Relation::Methods[User, Integer]
-      include Enumerable[User]
-    end
-
-    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-      include ::ActiveRecord::Relation::Methods[User, Integer]
-    end
-  end
-
-  class Post < ApplicationRecord
-    extend ::ActiveRecord::Base::ClassMethods[Post, ActiveRecord_Relation, Integer]
-
-    class ActiveRecord_Relation < ::ActiveRecord::Relation
-      include ::ActiveRecord::Relation::Methods[Post, Integer]
-      include Enumerable[Post]
-    end
-
-    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-      include ::ActiveRecord::Relation::Methods[Post, Integer]
     end
   end
 end

--- a/gems/activerecord/7.0/_test/test.rbs
+++ b/gems/activerecord/7.0/_test/test.rbs
@@ -2,6 +2,29 @@ module Test
   class ApplicationRecord < ActiveRecord::Base
   end
 
-  class User < ActiveRecord::Base
+  class User < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[User, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ::ActiveRecord::Relation
+      include ::ActiveRecord::Relation::Methods[User, Integer]
+      include Enumerable[User]
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[User, Integer]
+    end
+  end
+
+  class Post < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[Post, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ::ActiveRecord::Relation
+      include ::ActiveRecord::Relation::Methods[Post, Integer]
+      include Enumerable[Post]
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[Post, Integer]
+    end
   end
 end

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -24,6 +24,12 @@ module ActiveRecord
     extend RuntimeRegistry
   end
 
+  module QueryMethods
+    class WhereChain
+      def missing: (*Symbol associations) -> Relation
+    end
+  end
+
   module Encryption
     module EncryptableRecord
       module ClassMethods

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -25,7 +25,7 @@ module ActiveRecord
   end
 
   module QueryMethods
-    class WhereChain
+    class WhereChain[Relation]
       def missing: (*Symbol associations) -> Relation
     end
   end

--- a/gems/activerecord/7.1/_test/test.rb
+++ b/gems/activerecord/7.1/_test/test.rb
@@ -22,8 +22,15 @@ module Test
       # @type var email: String
       email.strip.downcase
     }
+
+    has_many :posts
   end
 
+  class Post < ApplicationRecord
+    belongs_to :user
+  end
+
+  User.where.missing(:posts)
   User.deterministic_encrypted_attributes
   User.source_attribute_from_preserved_attribute(:phrase)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')

--- a/gems/activerecord/7.1/_test/test.rb
+++ b/gems/activerecord/7.1/_test/test.rb
@@ -22,15 +22,9 @@ module Test
       # @type var email: String
       email.strip.downcase
     }
-
-    has_many :posts
   end
 
-  class Post < ApplicationRecord
-    belongs_to :user
-  end
-
-  User.where.missing(:posts)
+  User.where.missing.to_sql
   User.deterministic_encrypted_attributes
   User.source_attribute_from_preserved_attribute(:phrase)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')

--- a/gems/activerecord/7.1/_test/test.rbs
+++ b/gems/activerecord/7.1/_test/test.rbs
@@ -6,25 +6,6 @@ module Test
     extend ::ActiveRecord::Base::ClassMethods[User, ActiveRecord_Relation, Integer]
 
     class ActiveRecord_Relation < ::ActiveRecord::Relation
-      include ::ActiveRecord::Relation::Methods[User, Integer]
-      include Enumerable[User]
-    end
-
-    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-      include ::ActiveRecord::Relation::Methods[User, Integer]
-    end
-  end
-
-  class Post < ApplicationRecord
-    extend ::ActiveRecord::Base::ClassMethods[Post, ActiveRecord_Relation, Integer]
-
-    class ActiveRecord_Relation < ::ActiveRecord::Relation
-      include ::ActiveRecord::Relation::Methods[Post, Integer]
-      include Enumerable[Post]
-    end
-
-    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-      include ::ActiveRecord::Relation::Methods[Post, Integer]
     end
   end
 end

--- a/gems/activerecord/7.1/_test/test.rbs
+++ b/gems/activerecord/7.1/_test/test.rbs
@@ -2,6 +2,29 @@ module Test
   class ApplicationRecord < ActiveRecord::Base
   end
 
-  class User < ActiveRecord::Base
+  class User < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[User, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ::ActiveRecord::Relation
+      include ::ActiveRecord::Relation::Methods[User, Integer]
+      include Enumerable[User]
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[User, Integer]
+    end
+  end
+
+  class Post < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[Post, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ::ActiveRecord::Relation
+      include ::ActiveRecord::Relation::Methods[Post, Integer]
+      include Enumerable[Post]
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[Post, Integer]
+    end
   end
 end

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -27,7 +27,7 @@ module ActiveRecord
   end
 
   module QueryMethods
-    class WhereChain
+    class WhereChain[Relation]
       def missing: (*Symbol associations) -> Relation
     end
   end

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -26,6 +26,12 @@ module ActiveRecord
     extend RuntimeRegistry
   end
 
+  module QueryMethods
+    class WhereChain
+      def missing: (*Symbol associations) -> Relation
+    end
+  end
+
   module Encryption
     module EncryptableRecord
       module ClassMethods


### PR DESCRIPTION
Added `ActiveRecord::QueryMethods::WhereChain#missing` in version 6.1 or later.

Fixed to return `::ActiveRecord::QueryMethods::WhereChain` when the `where` method has no argument.

I confirmed that no errors occurred when used with [rbs-rails](https://github.com/pocke/rbs_rails).