### PR TITLE
remove: ActiveRecord::Relation::Methods#not

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -299,7 +299,6 @@ module ActiveRecord
       def pluck: (Symbol | String column) -> Array[untyped]
               | (*Symbol | String columns) -> Array[Array[untyped]]
       def where: (*untyped) -> self
-      def not: (*untyped) -> self
       def exists?: (*untyped) -> bool
       def order: (*untyped) -> self
       def group: (*Symbol | String) -> untyped

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -461,7 +461,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def pluck: (Symbol | String column) -> Array[untyped]
            | (*Symbol | String columns) -> Array[Array[untyped]]
   def where: (*untyped) -> self
-  def not: (*untyped) -> self
   def exists?: (*untyped) -> bool
   def order: (*untyped) -> self
   def group: (*Symbol | String) -> untyped


### PR DESCRIPTION
This method does not exist.