### PR TITLE
Disable /merge when non-gem files changed

### DIFF
--- a/.github/workflows/pr_bot/check_merge_ability.rb
+++ b/.github/workflows/pr_bot/check_merge_ability.rb
@@ -27,6 +27,7 @@ unless ability.approved?(PR_AUTHOR)
     `/merge` command failed.
 
     This PR is not approved yet by the reviewers. Please get approval from the reviewers.
+    #{'This PR includes non-gem files changes. `/merge` command does not work if the PR includes non-gem files. Please merge this PR manually.' if ability.admin_review_required?}
     See the Actions tab for detail.
   BODY
   comment_to_github(body, pr_number)

--- a/.github/workflows/pr_bot/review_result_comment_body.rb
+++ b/.github/workflows/pr_bot/review_result_comment_body.rb
@@ -23,9 +23,10 @@ else
       #{ability.not_approved_gems.map { "* `#{_1}`" }.join("\n")}
     MSG
   end
-  if ability.waiting_admin_approval?(PR_AUTHOR)
+  if ability.admin_review_required?
     msg << <<~MSG
       This PR still needs approval from the administrators.
+      The admin should review this PR and merge it manually.
     MSG
   end
 


### PR DESCRIPTION
It's to mitigate the impact when a malicious user try to attack the `/merge` command. 