### PR TITLE
Duplicated keyword argument

### DIFF
--- a/gems/rolify/6.0/rolify.rbs
+++ b/gems/rolify/6.0/rolify.rbs
@@ -55,7 +55,7 @@ module Rolify
 
   def rolify: (?role_cname: String, ?role_join_table_name: String, ?before_add: untyped, ?after_add: untyped, ?before_remove: untyped, ?after_remove: untyped, ?inverse_of: untyped, ?strict: bool) -> void
   def adapter: () -> untyped
-  def resourcify: (Symbol association_name, role_cname: String, ?role_cname: String, ?dependent: :Symbol) -> void
+  def resourcify: (Symbol association_name, ?role_cname: String, ?dependent: :Symbol) -> void
   def resource_adapter: () -> untyped
   def scopify: () -> void
   def role_class: () -> untyped


### PR DESCRIPTION
rbs v3.6 will raise syntax error.

https://github.com/ruby/rbs/pull/1883