### PR TITLE
Add types for shrine

### DIFF
--- a/gems/shrine/3.6/_test/metadata.yaml
+++ b/gems/shrine/3.6/_test/metadata.yaml
@@ -1,0 +1,2 @@
+additional_gems:
+  - activerecord

--- a/gems/shrine/3.6/_test/test.rb
+++ b/gems/shrine/3.6/_test/test.rb
@@ -1,0 +1,19 @@
+require "shrine"
+require "shrine/storage/file_system"
+
+Shrine.storages = {
+  cache: Shrine::Storage::FileSystem.new("public", prefix: "uploads/cache"), # temporary
+  store: Shrine::Storage::FileSystem.new("public", prefix: "uploads"),       # permanent
+}
+
+Shrine.plugin :activerecord           # loads Active Record integration
+Shrine.plugin :cached_attachment_data # enables retaining cached file across form redisplays
+Shrine.plugin :restore_cached_data    # extracts metadata for assigned cached files
+
+class ImageUploader < Shrine
+  # plugins and uploading logic
+end
+
+class Photo < ActiveRecord::Base
+  include ImageUploader::Attachment(:image) # adds an `image` virtual attribute
+end

--- a/gems/shrine/3.6/_test/test.rbs
+++ b/gems/shrine/3.6/_test/test.rbs
@@ -1,0 +1,5 @@
+class ImageUploader < Shrine
+end
+
+class Photo < ActiveRecord::Base
+end

--- a/gems/shrine/3.6/manifest.yaml
+++ b/gems/shrine/3.6/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: tempfile

--- a/gems/shrine/3.6/shrine.rbs
+++ b/gems/shrine/3.6/shrine.rbs
@@ -1,0 +1,43 @@
+class Shrine
+  class Error < StandardError
+  end
+
+  class InvalidFile < Error
+    def initialize: (untyped io, untyped missing_methods) -> void
+  end
+
+  class FileNotFound < Error
+  end
+
+  module ClassMethods
+    attr_reader opts: untyped
+    attr_accessor storages: Hash[Symbol, Shrine::Storage::t]
+    attr_accessor logger: untyped
+
+    def inherited: (untyped subclass) -> void
+    def plugin: (untyped plugin, *untyped args, **untyped kwargs) ?{ () -> untyped } -> untyped
+    def find_storage: (Symbol | String name) -> Shrine::Storage::t
+    def Attachment: (Symbol) -> Shrine::Attachment
+    alias attachment Attachment
+    alias [] Attachment
+    def upload: (untyped io, Shrine::Storage::t storage, **untyped options) -> Shrine::UploadedFile
+    def uploaded_file: (String | Hash[untyped, untyped] | Shrine::UploadedFile object) -> Shrine::UploadedFile
+    def with_file: [T](untyped io) { (untyped) -> T } -> T
+    def warn: (String message) -> void
+    def deprecation: (String message) -> void
+  end
+
+  module InstanceMethods
+    attr_reader storage_key: Symbol
+
+    def initialize: (Symbol storage_key) -> void
+    def storage: () -> Shrine::Storage::t
+    def upload: (untyped io, **untyped options) -> Shrine::UploadedFile
+    def generate_location: (untyped io, ?metadata: Hash[untyped, untyped], **untyped options) -> String
+    def extract_metadata: (untyped io, **untyped options) -> Hash[String, untyped]
+    def opt: () -> untyped
+  end
+
+  extend ClassMethods
+  include InstanceMethods
+end

--- a/gems/shrine/3.6/shrine/attachment.rbs
+++ b/gems/shrine/3.6/shrine/attachment.rbs
@@ -1,0 +1,18 @@
+class Shrine
+  class Attachment < Module
+    module ClassMethods
+      attr_accessor shrine_class: Shrine
+      def []: (*untyped args, **untyped options) -> instance
+    end
+
+    module InstanceMethods
+      def initialize: (Symbol name, **untyped) -> void
+      def attachment_name: () -> Symbol
+      def options: () -> Hash[untyped, untyped]
+      def shrine_class: () -> Shrine
+    end
+
+    extend ClassMethods
+    include InstanceMethods
+  end
+end

--- a/gems/shrine/3.6/shrine/storage.rbs
+++ b/gems/shrine/3.6/shrine/storage.rbs
@@ -1,0 +1,18 @@
+class Shrine
+  module Storage
+    type t = FileSystem | Linter | Memory | S3
+
+    class FileSystem
+      def initialize: (String directory, ?prefix: String, ?clean: bool, ?permissions: Integer, ?directory_permissions: Integer) -> void
+    end
+
+    class Linter
+    end
+
+    class Memory
+    end
+
+    class S3
+    end
+  end
+end

--- a/gems/shrine/3.6/shrine/uploaded_file.rbs
+++ b/gems/shrine/3.6/shrine/uploaded_file.rbs
@@ -1,0 +1,46 @@
+class Shrine
+  class UploadedFile
+    module ClassMethods
+      attr_accessor shrine_class: Shrine
+    end
+
+    module InstanceMethods
+      attr_reader id: untyped
+      attr_reader storage_key: untyped
+      attr_reader metadata: Hash[String, untyped]
+
+      def initialize: (Hash[Symbol, untyped] data) -> void
+      def original_filename: () -> String?
+      def extension: () -> String?
+      def size: () -> Integer
+      def mime_type: () -> String?
+      alias content_type mime_type
+      def []: (String key) -> untyped
+      def open: (**untyped options) -> IO
+              | [T](**untyped options) { (IO) -> T } -> T
+      def download: (**untyped options) -> Tempfile
+                  | [T](**untyped options) { (Tempfile) -> T } -> T
+      def stream: (String | IO destination, **untyped options) -> void
+      def read: (**untyped args) -> String
+      def eof?: () -> bool
+      def rewind: () -> void
+      def close: () -> void
+      def opened?: () -> bool
+      def url: (**untyped options) -> String
+      def exists?: () -> bool
+      def replace: (IO io, **untyped options) -> void
+      def to_io: () -> IO
+      def to_json: (**untyped args) -> String
+      def as_json: (**untyped args) -> String
+      def data: () -> { "id" => untyped, "storage" => String, "metadata" => Hash[String, untyped] }
+      def ==: (untyped other) -> bool
+      alias eql? ==
+      def uploader: () -> Shrine
+      def storage: () -> Shrine::Storage::t
+      def shrine_class: () -> Shrine
+    end
+
+    extend ClassMethods
+    include InstanceMethods
+  end
+end


### PR DESCRIPTION
Shrine is a toolkit for handling file attachments in Ruby applications.

refs: https://github.com/shrinerb/shrine