### PR TITLE
Remove Faraday::Utils::Headers#initialize_copy

### DIFF
--- a/gems/faraday/2.5/_test/test_utils_headers.rb
+++ b/gems/faraday/2.5/_test/test_utils_headers.rb
@@ -2,7 +2,6 @@ Faraday::Utils::Headers.from({}).instance_variable_get(:@names)
 Faraday::Utils::Headers.allocate.instance_variable_get(:@names)
 h = Faraday::Utils::Headers.new
 h.initialize_names
-h.initialize_copy(Faraday::Utils::Headers.new).instance_variable_get(:@names)
 h[:test] = 2134
 h[:test] = :df
 h[:test] = nil

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -231,7 +231,6 @@ module Faraday
       def self.allocate: () -> Headers
       def initialize: (?::Hash[Symbol | String, untyped]? hash) -> void
       def initialize_names: () -> void
-      def initialize_copy: (self other) -> self
 
       KeyMap: ::Hash[Symbol, String]
 


### PR DESCRIPTION
`Faraday::Utils::Headers` inherits `Hash` and override `#initialize_copy`.

Previously, `#initialize_copy` was called in the test file for Faraday to check the type signature, but I noticed the use of this method is marked as an error by Steep. I'm not sure why the current version of Steep reports it, but I decided to remove the declaration from the type signature because `#initialize_copy` is in the first place a private method originally.  In my opinion, it doesn't make sense to expose the signature of `#initialize_copy` since it cannot be used without `#send`.

Here is an example code to confirm the method is private.

```console
$ ruby --version
ruby 3.4.0preview1 (2024-05-16 master 9d69619623) [arm64-darwin23]
$
$ ruby <<RUBY

class A < Hash
  def initialize_copy(*)
    super
  end
end

A.new.initialize_copy(A.new)
RUBY
-:8:in '<main>': private method 'initialize_copy' called for an instance of A (NoMethodError)
```