### PR TITLE
Allow multiple if/unless conditions in ActiveModel::Validations

### DIFF
--- a/gems/activemodel/6.0/_test/test.rb
+++ b/gems/activemodel/6.0/_test/test.rb
@@ -4,7 +4,9 @@ class Person
   attr_accessor :name, :age, :email
 
   validates :name, presence: true, length: { maximum: 100 }
-  validates :email, presence: true, if: -> { age >= 20 }
+  validates :email, presence: true, if: [:foo?, -> { age >= 20 }]
+
+  def foo? = true
 end
 
 Person.new.send(:valid?)

--- a/gems/activemodel/6.0/_test/test.rbs
+++ b/gems/activemodel/6.0/_test/test.rbs
@@ -5,4 +5,6 @@ class Person
   attr_accessor name: String
   attr_accessor age: Integer
   attr_accessor email: String
+
+  def foo?: () -> bool
 end

--- a/gems/activemodel/6.0/activemodel.rbs
+++ b/gems/activemodel/6.0/activemodel.rbs
@@ -47,6 +47,7 @@ module ActiveModel
 
     module ClassMethods
       type condition[T] = Symbol | ^(T) [self: T] -> boolish
+      type conditions[T] = condition[T] | Array[condition[T]]
 
       # Validates each attribute against a block.
       #
@@ -77,7 +78,7 @@ module ActiveModel
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc or string should return or evaluate to a +true+ or +false+
       #   value.
-      def validates_each: (*untyped attr_names, ?on: Symbol | Array[Symbol], ?allow_nil: boolish, ?allow_blank: boolish, ?if: condition[instance], ?unless: condition[instance]) { () [self: instance] -> void } -> void
+      def validates_each: (*untyped attr_names, ?on: Symbol | Array[Symbol], ?allow_nil: boolish, ?allow_blank: boolish, ?if: conditions[instance], ?unless: conditions[instance]) { () [self: instance] -> void } -> void
 
       VALID_OPTIONS_FOR_VALIDATE: untyped
 
@@ -142,7 +143,7 @@ module ActiveModel
       #
       # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.
       #
-      def validate: (*untyped args, ?on: Symbol | Array[Symbol], ?if: condition[instance], ?unless: condition[instance]) ?{ (instance) [self: instance] -> void } -> void
+      def validate: (*untyped args, ?on: Symbol | Array[Symbol], ?if: conditions[instance], ?unless: conditions[instance]) ?{ (instance) [self: instance] -> void } -> void
 
       # List all validators that are being used to validate the model using
       # +validates_with+ method.
@@ -465,7 +466,7 @@ module ActiveModel
       # and +:message+ can be given to one specific validator, as a hash:
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
-      def validates: (*untyped attributes, ?on: Symbol | Array[Symbol], ?if: condition[instance], ?unless: condition[instance], ?allow_nil: boolish, ?allow_blank: boolish, ?strict: boolish, **untyped) -> void
+      def validates: (*untyped attributes, ?on: Symbol | Array[Symbol], ?if: conditions[instance], ?unless: conditions[instance], ?allow_nil: boolish, ?allow_blank: boolish, ?strict: boolish, **untyped) -> void
 
       # This method is used to define validations that cannot be corrected by end
       # users and are considered exceptional. So each validator defined with bang
@@ -485,7 +486,7 @@ module ActiveModel
       #   person.name = ''
       #   person.valid?
       #   # => ActiveModel::StrictValidationFailed: Name can't be blank
-      def validates!: (*untyped attributes, ?on: Symbol | Array[Symbol], ?if: condition[instance], ?unless: condition[instance], ?allow_nil: boolish, ?allow_blank: boolish) -> void
+      def validates!: (*untyped attributes, ?on: Symbol | Array[Symbol], ?if: conditions[instance], ?unless: conditions[instance], ?allow_nil: boolish, ?allow_blank: boolish) -> void
 
       private
 


### PR DESCRIPTION
Allow multiple if/unless conditions in ActiveModel::Validations as described in the Rails guide.

Reference: https://github.com/yasslab/railsguides.jp/blob/3c243cf2a78ff99a58f4646d4794810599f38a9a/guides/source/active_record_validations.md?plain=1#L1042-L1054

```ruby
class Computer < ApplicationRecord
  validates :mouse, presence: true,
                    if: [Proc.new { |c| c.market.retail? }, :desktop?],
                    unless: Proc.new { |c| c.trackpad.present? }
end
```