### PR TITLE
Add types for minimagick

### DIFF
--- a/gems/mini_magick/4.13/_test/metadata.yaml
+++ b/gems/mini_magick/4.13/_test/metadata.yaml
@@ -1,0 +1,4 @@
+# If the test needs gem's RBS files, declare them here.
+#
+# additional_gems:
+#   - GEM_NAME

--- a/gems/mini_magick/4.13/_test/readme.rb
+++ b/gems/mini_magick/4.13/_test/readme.rb
@@ -1,0 +1,85 @@
+require "mini_magick"
+
+image = MiniMagick::Image.open("input.jpg")
+image.path #=> "/var/folders/k7/6zx6dx6x7ys3rv3srh0nyfj00000gn/T/magick20140921-75881-1yho3zc.jpg"
+image.resize "100x100"
+image.format "png"
+image.write "output.png"
+
+image = MiniMagick::Image.open("http://example.com/image.jpg")
+image.contrast
+image.write("from_internets.jpg")
+
+image = MiniMagick::Image.new("input.jpg")
+image.path #=> "input.jpg"
+image.resize "100x100"
+
+# Combine options
+image.combine_options do |b|
+  b.resize "250x200>"
+  b.rotate "-90"
+  b.flip
+end
+
+image = MiniMagick::Image.new("input.jpg") do |b|
+  b.resize "250x200>"
+  b.rotate "-90"
+  b.flip
+end
+
+# Attributes
+image.type        #=> "JPEG"
+image.width       #=> 250
+image.height      #=> 300
+image.dimensions  #=> [250, 300]
+image.size        #=> 3451 (in bytes)
+image.colorspace  #=> "DirectClass sRGB"
+image.exif        #=> {"DateTimeOriginal" => "2013:09:04 08:03:39", ...}
+image.resolution  #=> [75, 75]
+image.signature   #=> "60a7848c4ca6e36b8e2c5dea632ecdc29e9637791d2c59ebf7a54c0c6a74ef7e"
+
+image["%[gamma]"]
+
+# Pixels
+image = MiniMagick::Image.open("image.jpg")
+pixels = image.get_pixels
+# pixels[3][2][1] # Comment out for coverage
+
+image = MiniMagick::Image.open("image.jpg")
+image.crop "20x30+10+5"
+image.colorspace "Gray"
+pixels = image.get_pixels
+
+# Pixels To Image
+image = MiniMagick::Image.open('/Users/rabin/input.jpg')
+pixels = image.get_pixels
+depth = 8
+dimension = [image.width, image.height]
+map = 'rgb'
+image = MiniMagick::Image.get_image_from_pixels(pixels, dimension, map, depth ,'jpg')
+image.write('/Users/rabin/output.jpg')
+
+# Composite
+first_image  = MiniMagick::Image.new("first.jpg")
+second_image = MiniMagick::Image.new("second.jpg")
+result = first_image.composite(second_image) do |c|
+  c.compose "Over"    # OverCompositeOp
+  c.geometry "+20+20" # copy second_image onto first_image from (20, 20)
+end
+result.write "output.jpg"
+
+# Layers/Frames/Pages
+gif = MiniMagick::Image.open('/Users/rabin/input.gif')
+pdf = MiniMagick::Image.open('/Users/rabin/input.pdf')
+psd = MiniMagick::Image.open('/Users/rabin/input.psd')
+gif.frames #=> [...]
+pdf.pages  #=> [...]
+psd.layers #=> [...]
+
+gif.frames.each_with_index do |frame, idx|
+  frame.write("frame#{idx}.jpg")
+end
+
+# Image validation
+image.valid?
+image.validate!

--- a/gems/mini_magick/4.13/_test/test.rb
+++ b/gems/mini_magick/4.13/_test/test.rb
@@ -1,0 +1,13 @@
+require "mini_magick"
+
+image = MiniMagick::Image.open("input.jpg")
+
+# #resize returns self
+image.resize("100x100").resize("50x50")
+
+# #format returns self
+image.format("png").format("jpg")
+
+# Manually define dynamically generated methods
+image.type
+image.type("foo").resize("100x100")

--- a/gems/mini_magick/4.13/manifest.yaml
+++ b/gems/mini_magick/4.13/manifest.yaml
@@ -1,0 +1,9 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+dependencies:
+  - name: pathname
+  - name: tempfile
+  - name: uri

--- a/gems/mini_magick/4.13/mini_magick.rbs
+++ b/gems/mini_magick/4.13/mini_magick.rbs
@@ -1,0 +1,225 @@
+module MiniMagick
+  class Error < RuntimeError
+  end
+
+  class Invalid < StandardError
+  end
+end
+
+module MiniMagick
+  class Image
+    def self.read: (String | _Reader stream, ?String? ext) -> instance
+
+    def self.create: (?String? ext, ?bool validate) ?{ (Tempfile) -> void } -> instance
+
+    def self.open: (string | URI::Generic path_or_url, ?String? ext, ?::Hash[untyped, untyped] options, **untyped) -> instance
+
+    attr_reader path: String
+
+    attr_reader tempfile: Tempfile
+
+    def initialize: (string input_path, ?Tempfile? tempfile) ?{ (MiniMagick::Tool::MogrifyRestricted) -> void } -> void
+
+    def to_blob: () -> String
+
+    def valid?: () -> bool
+
+    def validate!: () -> void
+
+    # Manually define dynamically generated methods with MiniMagick::Image.attribute
+
+    def type: () -> String
+            | (*untyped) -> instance
+
+    def width: () -> Integer
+             | (*untyped) -> instance
+
+    def height: () -> Integer
+              | (*untyped) -> instance
+
+    def dimensions: () -> Array[Integer]
+                  | (*untyped) -> instance
+
+    def size: () -> Integer
+            | (*untyped) -> instance
+
+    def human_size: () -> String
+                  | (*untyped) -> instance
+
+    def colorspace: () -> String
+                  | (*untyped) -> instance
+
+    def exif: () -> Hash[untyped, untyped]
+            | (*untyped) -> instance
+
+    def resolution: (*untyped) -> Array[Integer]
+
+    def signature: () -> String
+                 | (*untyped) -> instance
+
+    def data: () -> Hash[untyped, untyped]
+            | (*untyped) -> instance
+
+    def details: () -> Hash[untyped, untyped]
+               | (*untyped) -> instance
+
+    def []: (string value) -> String
+
+    alias info []
+
+    def layers: () -> Array[instance]
+
+    alias pages layers
+
+    alias frames layers
+
+    def get_pixels: (?::String map) -> Array[untyped]
+
+    def self.get_image_from_pixels: (Array[untyped] pixels, Array[Integer] dimension, String map, Integer depth, String format) -> instance
+
+    def format: (String format, ?::Integer page, ?::Hash[untyped, untyped] read_opts, **untyped) ?{ (MiniMagick::Tool::Convert) -> void } -> instance
+
+    def combine_options: () { (MiniMagick::Tool::MogrifyRestricted) -> void } -> instance
+
+    def write: (String | Pathname | _Writer output_to) -> void
+
+    def composite: (instance other_image, ?String output_extension, ?untyped? mask) ?{ (MiniMagick::Tool::Composite) -> void } -> instance
+
+    def collapse!: (?::Integer frame) -> instance
+
+    def destroy!: () -> void
+
+    def identify: () ?{ (MiniMagick::Tool::Identify) -> void } -> String
+
+    def mogrify: (?Integer? page) ?{ (MiniMagick::Tool::MogrifyRestricted) -> void } -> instance
+
+    def layer?: () -> bool
+
+    def landscape?: () -> bool
+
+    def portrait?: () -> bool
+
+    # If method is not found, the method of Mogrify is called.
+    include MiniMagick::Tool::Mogrify::_InstanceMethods[instance]
+  end
+end
+
+module MiniMagick
+  class Tool
+    def command: () -> Array[String]
+
+    def executable: () -> Array[String]
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Animate < Tool
+    end
+  end
+end
+
+module MiniMagickp
+  class Tool
+    class Compare < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    # see: https://imagemagick.org/script/composite.php
+    class Composite < Tool
+      def compose: (String operator) -> instance
+
+      def geometry: (String geometry) -> instance
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Conjure < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Convert < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Display < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Identify < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Import < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Magick < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    # see: http://www.imagemagick.org/script/mogrify.php
+    class Mogrify < Tool
+      # MiniMagick::Image uses the methods of MiniMagick::Tool::Mogrify when the method is not found,
+      # so it is defined as an interface to be common.
+      # Other Tool methods need not be defined as interfaces.
+      interface _InstanceMethods[T]
+        def contrast: () -> T
+
+        def crop: (String geometry) -> T
+
+        def flip: () -> T
+
+        def resize: (String geometry) -> T
+
+        def rotate: (String degrees) -> T
+      end
+
+      include _InstanceMethods[instance]
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class MogrifyRestricted < Mogrify
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Montage < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Tool
+    class Stream < Tool
+    end
+  end
+end


### PR DESCRIPTION
Adds types that follows the basic use case described in the README.

https://github.com/minimagick/minimagick/tree/v4.13.1

The following types will be added after this PR merge.

- MiniMagick.configure
- Methods hacked with method_missing
  - mogrify, identify, etc...