### PR TITLE
Fix Sidekiq::Job::Options::ClassMethods#sidekiq_retry_in

### DIFF
--- a/gems/sidekiq/7.0/_test/test_3.rb
+++ b/gems/sidekiq/7.0/_test/test_3.rb
@@ -61,8 +61,10 @@ class WorkerWithCustomRetry
   # of nil will use the default.
   sidekiq_retry_in do |count, exception|
     case exception
-    when Object
+    when StandardError
       10 * (count + 1) # (i.e. 10, 20, 30, 40, 50)
+    else
+      :kill
     end
   end
 

--- a/gems/sidekiq/7.0/job.rbs
+++ b/gems/sidekiq/7.0/job.rbs
@@ -48,7 +48,7 @@ module Sidekiq
 
         def sidekiq_retries_exhausted: () { (Hash[String, untyped] job, Exception ex) -> void } -> void
 
-        def sidekiq_retry_in: () { (Integer count, Exception ex) -> Integer } -> void
+        def sidekiq_retry_in: () { (Integer count, Exception ex) -> (Integer | :discard | :kill)? } -> void
 
         ACCESSOR_MUTEX: ::Thread::Mutex
       end


### PR DESCRIPTION
The block of Sidekiq::Job::Options::ClassMethods#sidekiq_retry_in returns `(Integer | :discard | :kill)?`.

https://github.com/sidekiq/sidekiq/blob/f2858e175efd57cffc3db50a19dd315e37b08668/lib/sidekiq/job_retry.rb#L221-L227