### PR TITLE
Improve Time.find_zone

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -69,3 +69,4 @@ itself if Object.new.blank? \
 
 "Matz".presence_in("Matzuyama")&.in?(%w[Yukihiro Matz Matsumoto])
 ActiveSupport::TimeZone['Asia/Tokyo'].to_s
+Time.find_zone(Object.name)

--- a/gems/activesupport/6.0/activesupport-6.0.rbs
+++ b/gems/activesupport/6.0/activesupport-6.0.rbs
@@ -23,3 +23,26 @@ module ActiveSupport
     def self.[]: (String | real | Duration) -> instance?
   end
 end
+
+# activesupport/lib/active_support/core_ext/time/zones.rb
+class Time
+  # Returns a TimeZone instance matching the time zone provided.
+  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
+  # Raises an +ArgumentError+ for invalid time zones.
+  #
+  #   Time.find_zone! "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
+  #   Time.find_zone! "EST"              # => #<ActiveSupport::TimeZone @name="EST" ...>
+  #   Time.find_zone! -5.hours           # => #<ActiveSupport::TimeZone @name="Bogota" ...>
+  #   Time.find_zone! nil                # => nil
+  #   Time.find_zone! false              # => false
+  #   Time.find_zone! "NOT-A-TIMEZONE"   # => ArgumentError: Invalid Timezone: NOT-A-TIMEZONE
+  def self.find_zone!: (String | real | ActiveSupport::Duration) -> ActiveSupport::TimeZone
+
+  # Returns a TimeZone instance matching the time zone provided.
+  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
+  # Returns +nil+ for invalid time zones.
+  #
+  #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
+  #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
+  def self.find_zone: (String | real | ActiveSupport::Duration | nil) -> ActiveSupport::TimeZone?
+end

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -5658,26 +5658,6 @@ class Time
   # attributes that have been read before the block will remain in
   # the application's default timezone.
   def self.use_zone: (untyped time_zone) { () -> untyped } -> untyped
-
-  # Returns a TimeZone instance matching the time zone provided.
-  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
-  # Raises an +ArgumentError+ for invalid time zones.
-  #
-  #   Time.find_zone! "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
-  #   Time.find_zone! "EST"              # => #<ActiveSupport::TimeZone @name="EST" ...>
-  #   Time.find_zone! -5.hours           # => #<ActiveSupport::TimeZone @name="Bogota" ...>
-  #   Time.find_zone! nil                # => nil
-  #   Time.find_zone! false              # => false
-  #   Time.find_zone! "NOT-A-TIMEZONE"   # => ArgumentError: Invalid Timezone: NOT-A-TIMEZONE
-  def self.find_zone!: (untyped time_zone) -> untyped
-
-  # Returns a TimeZone instance matching the time zone provided.
-  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
-  # Returns +nil+ for invalid time zones.
-  #
-  #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
-  #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
-  def self.find_zone: (untyped time_zone) -> untyped
 end
 
 module URI

--- a/gems/activesupport/7.0/_test/test.rb
+++ b/gems/activesupport/7.0/_test/test.rb
@@ -20,3 +20,4 @@ nil.try { |n| p n }
 
 "Id".downcase_first
 ActiveSupport::TimeZone['Asia/Tokyo'].to_s
+Time.find_zone(Object.name)

--- a/gems/activesupport/7.0/activesupport-7.0.rbs
+++ b/gems/activesupport/7.0/activesupport-7.0.rbs
@@ -59,6 +59,29 @@ module ActiveSupport
   end
 end
 
+# activesupport/lib/active_support/core_ext/time/zones.rb
+class Time
+  # Returns a TimeZone instance matching the time zone provided.
+  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
+  # Raises an +ArgumentError+ for invalid time zones.
+  #
+  #   Time.find_zone! "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
+  #   Time.find_zone! "EST"              # => #<ActiveSupport::TimeZone @name="EST" ...>
+  #   Time.find_zone! -5.hours           # => #<ActiveSupport::TimeZone @name="Bogota" ...>
+  #   Time.find_zone! nil                # => nil
+  #   Time.find_zone! false              # => false
+  #   Time.find_zone! "NOT-A-TIMEZONE"   # => ArgumentError: Invalid Timezone: NOT-A-TIMEZONE
+  def self.find_zone!: (ActiveSupport::TimeZone | TZInfo::Timezone | String | real | ActiveSupport::Duration) -> ActiveSupport::TimeZone
+
+  # Returns a TimeZone instance matching the time zone provided.
+  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
+  # Returns +nil+ for invalid time zones.
+  #
+  #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
+  #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
+  def self.find_zone: (ActiveSupport::TimeZone | TZInfo::Timezone | String | real | ActiveSupport::Duration | nil) -> ActiveSupport::TimeZone?
+end
+
 module Enumerable[unchecked out Elem]
   # Returns a new +Array+ without the blank items.
   # Uses Object#blank? for determining if an item is blank.


### PR DESCRIPTION
This change emphasizes typical use cases.

```rb
Time.find_zone(user.timezone)
```

In this case it is more practical to consider `user.timezone` as a valid type even if it is a `String?`.
This is the reason for `| nil`.

Also, cases like `(false) -> false` are not useful in most cases.
This case has been intentionally cut as it is not the intended practical code.