### PR TITLE
Add headers method to Request class on Faraday

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -11,6 +11,7 @@ conn.headers
 response = conn.get('/get', { param: '1' }, { 'Content-Type' => 'application/json' }) do |req|
   req.path = "/new_get"
   req.path = URI("https://example.com/new_get?abc=m")
+  req.headers["x-foo"] = "OK"
   req.url("/new_url")
   req.url("/new_url", { x_foo: "OK" })
   req.url(URI("https://example.com/new_url?abc=foo"))

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -186,7 +186,7 @@ module Faraday
     def headers=: (untyped) -> void
     def body=: (untyped) -> void
     def options=: (untyped) -> void
-    def headers: () -> Hash[untyped, untyped]
+    def headers: () -> Utils::Headers
     def url: (String | URI path, ?::Hash[untyped, untyped] params) -> void
     def []: (untyped key) -> void
     def []=: (untyped key, untyped value) -> void

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -186,6 +186,7 @@ module Faraday
     def headers=: (untyped) -> void
     def body=: (untyped) -> void
     def options=: (untyped) -> void
+    def headers: () -> Hash[untyped, untyped]
     def url: (String | URI path, ?::Hash[untyped, untyped] params) -> void
     def []: (untyped key) -> void
     def []=: (untyped key, untyped value) -> void


### PR DESCRIPTION
While attempting to add a header, I encountered the following error:

```
Type `::Faraday::Request` does not have method `headers`
│ Diagnostic ID: Ruby::NoMethod
```

To resolve this issue, I added a headers method to the ::Faraday::Request class.