### PR TITLE
Add MiniMagick v5.0

### DIFF
--- a/gems/mini_magick/5.0/_test/metadata.yaml
+++ b/gems/mini_magick/5.0/_test/metadata.yaml
@@ -1,0 +1,4 @@
+# If the test needs gem's RBS files, declare them here.
+#
+# additional_gems:
+#   - GEM_NAME

--- a/gems/mini_magick/5.0/_test/readme.rb
+++ b/gems/mini_magick/5.0/_test/readme.rb
@@ -1,0 +1,196 @@
+require "mini_magick"
+
+## Usage
+
+image = MiniMagick::Image.open("input.jpg")
+image.path # steep:ignore
+image.resize "100x100" # steep:ignore
+image.format "png" # steep:ignore
+image.write "output.png" # steep:ignore
+
+image = MiniMagick::Image.open("http://example.com/image.jpg")
+image.contrast # steep:ignore
+image.write("from_internets.jpg")
+
+image = MiniMagick::Image.new("input.jpg")
+image.path  #=> "input.jpg"
+image.resize "100x100" # steep:ignore
+
+### Combine options
+
+image.combine_options do |b|
+  b.resize "250x200>" # steep:ignore
+  b.rotate "-90" # steep:ignore
+  b.flip # steep:ignore
+end # the command gets executed
+
+image = MiniMagick::Image.new("input.jpg") do |b|
+  b.resize "250x200>" # steep:ignore
+  b.rotate "-90" # steep:ignore
+  b.flip # steep:ignore
+end # the command gets executed
+
+### Attributes
+
+image.type        #=> "JPEG"
+image.width       #=> 250
+image.height      #=> 300
+image.dimensions  #=> [250, 300]
+image.size        #=> 3451 (in bytes)
+image.colorspace  #=> "DirectClass sRGB"
+image.exif        #=> {"DateTimeOriginal" => "2013:09:04 08:03:39", ...}
+image.resolution  #=> [75, 75]
+image.signature   #=> "60a7848c4ca6e36b8e2c5dea632ecdc29e9637791d2c59ebf7a54c0c6a74ef7e"
+
+image["%[gamma]"] # "0.9"
+
+image.data
+
+### Pixels
+
+image = MiniMagick::Image.open("image.jpg")
+pixels = image.get_pixels
+# pixels[3][2][1] # the green channel value from the 4th-row, 3rd-column pixel
+
+image = MiniMagick::Image.open("image.jpg")
+image.crop "20x30+10+5" # steep:ignore
+image.colorspace "Gray" # steep:ignore
+pixels = image.get_pixels
+
+### Pixels To Image
+
+image = MiniMagick::Image.open('/Users/rabin/input.jpg')
+pixels = image.get_pixels
+depth = 8
+dimension = [image.width, image.height]
+map = 'rgb'
+image = MiniMagick::Image.get_image_from_pixels(pixels, dimension, map, depth ,'jpg')
+image.write('/Users/rabin/output.jpg')
+
+### Configuration
+
+MiniMagick.configure do |config|
+  config.timeout = nil # number of seconds IM commands may take
+  config.errors = true # raise errors non nonzero exit status
+  config.warnings = true # forward warnings to standard error
+  config.tmpdir = Dir.tmpdir # alternative directory for tempfiles
+  config.logger = Logger.new($stdout) # where to log IM commands
+  config.cli_prefix = nil # add prefix to all IM commands
+end
+
+### Composite
+
+first_image  = MiniMagick::Image.new("first.jpg")
+second_image = MiniMagick::Image.new("second.jpg")
+result = first_image.composite(second_image) do |c|
+  c.compose "Over" # steep:ignore
+  c.geometry "+20+20" # steep:ignore
+end
+result.write "output.jpg"
+
+### Layers/Frames/Pages
+
+gif = MiniMagick::Image.open('/Users/rabin/input.gif')
+pdf = MiniMagick::Image.open('/Users/rabin/input.pdf')
+psd = MiniMagick::Image.open('/Users/rabin/input.psd')
+gif.frames #=> [...]
+pdf.pages  #=> [...]
+psd.layers #=> [...]
+
+gif.frames.each_with_index do |frame, idx|
+  frame.write("frame#{idx}.jpg")
+end
+
+### Image validation
+
+image.valid?
+image.validate! # raises MiniMagick::Invalid if image is invalid
+
+### Logging
+
+MiniMagick.logger.level = Logger::DEBUG
+
+## Tools
+
+MiniMagick.convert do |convert|
+  convert << "input.jpg"
+  convert.resize("100x100") # steep:ignore
+  convert.negate # steep:ignore
+  convert << "output.jpg"
+end
+
+convert = MiniMagick.convert
+convert << "input.jpg"
+convert.resize("100x100") # steep:ignore
+convert.negate # steep:ignore
+convert << "output.jpg"
+convert.call
+
+### Appending
+
+MiniMagick.convert do |convert|
+  convert << "input.jpg"
+  convert.merge! ["-resize", "500x500", "-negate"]
+  convert << "output.jpg"
+end
+
+### "Plus" options
+
+MiniMagick.convert do |convert|
+  convert << "input.jpg"
+  convert.+
+  # convert.repage.+
+  # convert.distort.+("Perspective", "more args")
+end
+
+### Stacks
+
+MiniMagick.convert do |convert|
+  convert << "wand.gif"
+
+  convert.stack do |stack|
+    stack << "wand.gif"
+    stack.rotate(30) # steep:ignore
+    stack.foo("bar", "baz") # steep:ignore
+  end
+  # or
+  convert.stack("wand.gif", { rotate: 30, foo: ["bar", "baz"] })
+
+  convert << "images.gif"
+end
+
+### STDIN and STDOUT
+
+identify = MiniMagick.identify
+identify.stdin # alias for "-"
+identify.call(stdin: "")
+
+content = MiniMagick.convert do |convert|
+  convert << "input.jpg"
+  convert.auto_orient # steep:ignore
+  convert.stdout # alias for "-"
+end
+
+## Configuring
+
+### GraphicsMagick
+
+MiniMagick.configure do |config|
+  config.cli_prefix = "gm"
+end
+
+### Changing temporary directory
+
+MiniMagick.configure do |config|
+  config.tmpdir = File.join(Dir.tmpdir, "/my/new/tmp_dir")
+end
+
+### Avoiding raising errors
+
+MiniMagick.configure do |config|
+  config.errors = false
+end
+
+MiniMagick.identify(errors: false) do |b|
+  b.help # steep:ignore
+end

--- a/gems/mini_magick/5.0/_test/test.rb
+++ b/gems/mini_magick/5.0/_test/test.rb
@@ -1,0 +1,29 @@
+require "mini_magick"
+
+MiniMagick::Error
+MiniMagick::Invalid
+MiniMagick::TimeoutError
+
+MiniMagick.imagemagick7?
+MiniMagick.cli_version
+
+MiniMagick.version == "5.0"
+
+MiniMagick::Tool.new("mogrify", foo: "FOO") do |mogrify|
+  mogrify.resize "100x100" # steep:ignore
+  mogrify << 1
+  mogrify.merge!(["-foo", 1, nil])
+  mogrify.+("Perspective", "0,0,4,5 89,0,45,46")
+  mogrify.stack do |stack|
+    stack << "wand.gif"
+  end
+  mogrify.stdin
+  mogrify.stdout
+  mogrify.xc
+  mogrify.canvas("khaki")
+  mogrify.executable
+  mogrify.call
+end
+
+mogrify = MiniMagick::Tool.new("mogrify", foo: "FOO")
+mogrify.call

--- a/gems/mini_magick/5.0/manifest.yaml
+++ b/gems/mini_magick/5.0/manifest.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  - name: logger
+  - name: pathname
+  - name: tempfile
+  - name: tmpdir
+  - name: uri

--- a/gems/mini_magick/5.0/mini_magick.rbs
+++ b/gems/mini_magick/5.0/mini_magick.rbs
@@ -1,0 +1,226 @@
+module MiniMagick
+  class Error < RuntimeError
+  end
+
+  class Invalid < StandardError
+  end
+
+  class TimeoutError < Error
+  end
+
+  extend Configuration
+
+  def self.imagemagick7?: () -> bool
+
+  def self.cli_version: () -> String
+
+  # Define methods for dynamically generated
+
+  def self.animate: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.compare: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.composite: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                    | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.conjure: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.convert: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.display: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.identify: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                   | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.import: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                 | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.mogrify: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.montage: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                  | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+  def self.stream: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) -> Tool
+                 | (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) { (Tool) -> void } -> String
+end
+
+module MiniMagick
+  def self.version: () -> Gem::Version
+end
+
+module MiniMagick
+  module Configuration
+    attr_accessor cli_prefix: (String | Array[String])?
+
+    attr_accessor timeout: Integer?
+
+    attr_accessor logger: Logger
+
+    attr_accessor tmpdir: String
+
+    attr_accessor errors: bool
+
+    attr_accessor warnings: bool
+
+    def configure: () { (self) -> void } -> void
+  end
+end
+
+module MiniMagick
+  class Tool
+    CREATION_OPERATORS: ::Array["xc" | "canvas" | "logo" | "rose" | "gradient" | "radial-gradient" | "plasma" | "pattern" | "text" | "pango"]
+
+    def self.new: (String name, *untyped args) -> instance
+                | (String name, *untyped args) { (instance) -> void } -> String
+
+    def initialize: (String name, **untyped options) -> void
+
+    def call: (?errors: bool, ?warnings: bool, ?stdin: _ToS, ?timeout: Integer?, **untyped options) ?{ (String, String, Process::Status) -> void } -> String
+
+    def command: () -> Array[String]
+
+    def executable: () -> Array[String]
+
+    def <<: (_ToS arg) -> self
+
+    def merge!: (Array[_ToS] new_args) -> self
+
+    def +: (*_ToS values) -> self
+
+    def stack: (*untyped args) ?{ (self) -> void } -> self
+
+    def stdin: () -> self
+
+    def stdout: () -> self
+
+    # Define methods for dynamically generated
+
+    def xc: (?_ToS value) -> self
+    def canvas: (?_ToS value) -> self
+    def logo: (?_ToS value) -> self
+    def rose: (?_ToS value) -> self
+    def gradient: (?_ToS value) -> self
+    def radial_gradient: (?_ToS value) -> self
+    def plasma: (?_ToS value) -> self
+    def pattern: (?_ToS value) -> self
+    def text: (?_ToS value) -> self
+    def pango: (?_ToS value) -> self
+
+    # Define deprecated tool subclasses for dynamically generated
+
+    class Animate < Tool
+    end
+    class Compare < Tool
+    end
+    class Composite < Tool
+    end
+    class Conjure < Tool
+    end
+    class Convert < Tool
+    end
+    class Display < Tool
+    end
+    class Identify < Tool
+    end
+    class Import < Tool
+    end
+    class Magick < Tool
+    end
+    class Mogrify < Tool
+    end
+    class Montage < Tool
+    end
+    class Stream < Tool
+    end
+  end
+end
+
+module MiniMagick
+  class Image
+    def self.read: (String | _Reader stream, ?String? ext) -> instance
+
+    def self.import_pixels: (String | _Reader blob, Integer columns, Integer rows, Integer depth, String map, ?::String format) -> instance
+
+    def self.open: (_ToS | URI::Generic path_or_url, ?String? ext, **untyped options) -> instance
+
+    def self.create: (?String? ext) { (Tempfile) -> void } -> instance
+
+   attr_reader path: String
+
+   attr_reader tempfile: Tempfile
+
+   def initialize: (_ToS input_path, ?Tempfile? tempfile) ?{ (Tool) -> void } -> void
+
+   def to_blob: () -> String
+
+   def valid?: () -> bool
+
+   def validate!: () -> void
+
+   def []: (_ToS value) -> String
+
+   alias info []
+
+   def layers: () -> Array[instance]
+
+   alias pages layers
+
+   alias frames layers
+
+   def get_pixels: (?::String map) -> Array[untyped]
+
+   def self.get_image_from_pixels: (Array[untyped] pixels, Array[Integer] dimension, String map, Integer depth, String format) -> instance
+
+   def format: (String format, ?::Integer page, ?::Hash[untyped, untyped] read_opts, **untyped) ?{ (Tool) -> void } -> self
+
+   def combine_options: () { (Tool) -> void } -> self
+
+   def write: (String | Pathname | _Writer output_to) -> untyped
+
+   def composite: (instance other_image, ?String output_extension, ?untyped? mask) ?{ (Tool) -> void } -> instance
+
+   def collapse!: (?::Integer frame) -> self
+
+   def destroy!: () -> void
+
+   def identify: () ?{ (Tool) -> void } -> String
+
+   def mogrify: (?Integer? page) ?{ (Tool) -> void } -> self
+
+   def layer?: () -> bool
+
+   def landscape?: () -> bool
+
+   def portrait?: () -> bool
+
+   # Define dynamically methods
+
+   def type: () -> String
+            | (*untyped) -> instance
+
+   def width: () -> Integer
+            | (*untyped) -> instance
+
+   def height: () -> Integer
+             | (*untyped) -> instance
+
+   def dimensions: () -> Array[Integer]
+                  | (*untyped) -> instance
+
+   def size: () -> Integer
+           | (*untyped) -> instance
+
+   def human_size: () -> String
+                 | (*untyped) -> instance
+
+   def colorspace: () -> String
+                 | (*untyped) -> instance
+
+   def exif: () -> Hash[untyped, untyped]
+           | (*untyped) -> instance
+
+   def resolution: (*untyped) -> Array[Integer]
+
+   def signature: () -> String
+                | (*untyped) -> instance
+
+   def data: () -> Hash[untyped, untyped]
+           | (*untyped) -> instance
+  end
+end

--- a/gems/mini_magick/_reviewers.yaml
+++ b/gems/mini_magick/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - aki19035vc


### PR DESCRIPTION
Since MiniMagick v5.0 has been released, add types.

https://github.com/minimagick/minimagick/tree/v5.0.1

The README includes the following usage example,
but methods such as resize and format do not exist and there are hacked by method_missing.

```ruby
image = MiniMagick::Image.open("input.jpg")
image.path
image.resize "100x100"
image.format "png"
image.write "output.png"
```

Since it is not possible to determine whether a method can be used or not depending on the version of ImageMagick being used, methods that are hacked with method_missing are not defined in the collection.