### PR TITLE
Add types for rest-client resource class

### DIFF
--- a/gems/rest-client/2.1/_test/test.rb
+++ b/gems/rest-client/2.1/_test/test.rb
@@ -33,3 +33,24 @@ RestClient.get('http://example.com/resource') { |response, request, result, &blo
     response.return!(&block)
   end
 }
+
+resource = RestClient::Resource.new("http://example.com/resource")
+resource.get
+resource.get(params: {id: 50, 'foo' => 'bar'})
+resource.get(accept: :json)
+resource.post(params: 'one', nested: {param2: 'two'})
+resource.post({'x' => 1}.to_json, {content_type: :json, accept: :json})
+resource.delete
+
+resource['nested'] { |response, request, result, &block|
+  case response.code
+  when 200
+    p "It worked !"
+    response
+  when 423
+    raise SomeCustomExceptionIfYouWant
+  else
+    response.return!(&block)
+  end
+}
+

--- a/gems/rest-client/2.1/rest-client.rbs
+++ b/gems/rest-client/2.1/rest-client.rbs
@@ -29,6 +29,44 @@ module RestClient
     def description: () -> String
   end
 
+  class Resource
+    attr_reader url: String
+    attr_reader options: Hash[untyped, untyped]?
+    attr_reader block: Proc
+
+    def initialize: (String url, ?Hash[untyped, untyped] options, ?String backwards_compatability) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> void
+
+    def get: (?Hash[untyped, untyped] additional_headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
+
+    def head: (?Hash[untyped, untyped] additional_headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
+
+    def post: (untyped payload, ?Hash[untyped, untyped] additional_headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
+
+    def put: (untyped payload, ?Hash[untyped, untyped] additional_headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
+
+    def patch: (untyped payload, ?Hash[untyped, untyped] additional_headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
+
+    def delete: (?Hash[untyped, untyped] additional_headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
+
+    def to_s: -> String
+
+    def user: -> untyped
+
+    def password: -> untyped
+
+    def headers: -> Hash[untyped, untyped]
+
+    def read_timeout: -> Integer
+
+    def open_timeout: -> Integer
+
+    def log: -> untyped
+
+    def []: (String suburl) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> self
+
+    def concat_urls: (untyped url, untyped suburl) -> String
+  end
+
   def self.get: (String url, ?Hash[untyped, untyped] headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
   def self.post: (String url, untyped payload, ?Hash[untyped, untyped] headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response
   def self.patch: (String url, untyped payload, ?Hash[untyped, untyped] headers) ?{ (Response, Request, Net::HTTPResponse, callback) -> void } -> Response


### PR DESCRIPTION
rest-client has a "Resource" class which allows you to save resources to request in different ways. This adds support for this class.