### PR TITLE
Add types for flexirest

### DIFF
--- a/gems/flexirest/1.12/_test/test.rb
+++ b/gems/flexirest/1.12/_test/test.rb
@@ -1,0 +1,11 @@
+require "flexirest"
+
+class Person < Flexirest::Base
+  base_url "https://www.example.com/api/v1"
+
+  get :all, "/people"
+  get :find, "/people/:id"
+  put :save, "/people/:id"
+  post :create, "/people"
+  delete :remove, "/people/:id"
+end

--- a/gems/flexirest/1.12/_test/test.rbs
+++ b/gems/flexirest/1.12/_test/test.rbs
@@ -1,0 +1,3 @@
+class Person < Flexirest::Base
+end
+

--- a/gems/flexirest/1.12/base.rbs
+++ b/gems/flexirest/1.12/base.rbs
@@ -1,0 +1,4 @@
+module Flexirest
+  class Base < BaseWithoutValidation
+  end
+end

--- a/gems/flexirest/1.12/base_without_validation.rbs
+++ b/gems/flexirest/1.12/base_without_validation.rbs
@@ -1,0 +1,18 @@
+module Flexirest
+  class BaseWithoutValidation
+    include Mapping
+    extend Mapping::ClassMethods
+    include Configuration
+    extend Configuration::ClassMethods
+    include Callbacks
+    extend Callbacks::ClassMethods
+    include Caching
+    extend Caching::ClassMethods
+
+    def self._request: (String, Symbol, *untyped, **untyped) -> untyped
+    def self._plain_request: (String, Symbol, *untyped, **untyped) -> untyped
+    def _attributes: () -> Hash[Symbol, untyped]
+    def []: (String | Symbol key) -> untyped
+    def []=: (String | Symbol key, untyped value) -> untyped
+  end
+end

--- a/gems/flexirest/1.12/caching.rbs
+++ b/gems/flexirest/1.12/caching.rbs
@@ -1,0 +1,8 @@
+module Flexirest
+  module Caching
+    module ClassMethods
+      def perform_caching: (?bool value) -> bool
+      def perform_caching=: (bool value) -> bool
+    end
+  end
+end

--- a/gems/flexirest/1.12/callbacks.rbs
+++ b/gems/flexirest/1.12/callbacks.rbs
@@ -1,0 +1,10 @@
+module Flexirest
+  module Callbacks
+    module ClassMethods
+      def before_request: (Symbol method_name) -> void
+                        | () { (Symbol name, Request request) -> (false | :retry | untyped) } -> void
+      def after_request: (Symbol method_name) -> void
+                       | () { (Symbol name, Request request) -> (false | :retry | untyped) } -> void
+    end
+  end
+end

--- a/gems/flexirest/1.12/configuration.rbs
+++ b/gems/flexirest/1.12/configuration.rbs
@@ -1,0 +1,15 @@
+module Flexirest
+  module Configuration
+    module ClassMethods
+      def base_url: () -> (String | Array[String])
+                  | (String value) -> String
+                  | (Array[String] value) -> Array[String]
+      def base_url=: (String value) -> String
+      def request_body_type: (?Symbol value) -> Symbol
+      def request_body_type=: (Symbol value) -> Symbol
+      def whiny_missing: (?bool value) -> bool
+      def verbose!: () -> true
+      def verbose: (?bool value) -> bool
+    end
+  end
+end

--- a/gems/flexirest/1.12/connection.rbs
+++ b/gems/flexirest/1.12/connection.rbs
@@ -1,0 +1,10 @@
+module Flexirest
+  class BaseException < StandardError
+  end
+
+  class TimeoutException < BaseException
+  end
+
+  class ConnectionFailedException < BaseException
+  end
+end

--- a/gems/flexirest/1.12/flexirest.rbs
+++ b/gems/flexirest/1.12/flexirest.rbs
@@ -1,0 +1,13 @@
+module Flexirest
+  class NoAttributeException < StandardError
+  end
+
+  class ValidationFailedException < StandardError
+  end
+
+  class MissingOptionalLibraryError < StandardError
+  end
+
+  def self.name: () -> String
+  def self.name=: (String value) -> String
+end

--- a/gems/flexirest/1.12/headers_list.rbs
+++ b/gems/flexirest/1.12/headers_list.rbs
@@ -1,0 +1,9 @@
+module Flexirest
+  class HeadersList
+    def []=: (String key, untyped value) -> untyped
+    def []: (String key) -> untyped
+    def each: (?bool split_multiple_headers) { (String key, untyped value) -> void } -> void
+    def delete: (String key) -> untyped
+    def keys: () -> Array[String]
+  end
+end

--- a/gems/flexirest/1.12/mapping.rbs
+++ b/gems/flexirest/1.12/mapping.rbs
@@ -1,0 +1,11 @@
+module Flexirest
+  module Mapping
+    module ClassMethods
+      def get: (Symbol name, String url, ?Hash[untyped, untyped] options) -> untyped
+      def put: (Symbol name, String url, ?Hash[untyped, untyped] options) -> untyped
+      def post: (Symbol name, String url, ?Hash[untyped, untyped] options) -> untyped
+      def delete: (Symbol name, String url, ?Hash[untyped, untyped] options) -> untyped
+      def patch: (Symbol name, String url, ?Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end

--- a/gems/flexirest/1.12/request.rbs
+++ b/gems/flexirest/1.12/request.rbs
@@ -1,0 +1,85 @@
+module Flexirest
+  class Request
+    attr_accessor post_params: untyped
+    attr_accessor get_params: untyped
+    attr_accessor url: String
+    attr_accessor path: untyped
+    attr_accessor headers: HeadersList
+    attr_accessor method: Hash[untyped, untyped]
+    attr_accessor object: untyped
+    attr_accessor body: String
+    attr_accessor forced_url: String?
+    attr_accessor original_url: String
+    attr_accessor retrying: bool
+  end
+
+  class RequestException < StandardError
+  end
+
+  class InvalidArgumentsException < StandardError
+  end
+
+  class InvalidRequestException < RequestException
+  end
+
+  class MissingParametersException < RequestException
+  end
+
+  class ResponseParseException < RequestException
+  end
+
+  class HTTPException < RequestException
+    attr_reader status: Integer
+    attr_reader result: untyped
+    attr_reader request_url: String
+    attr_reader body: String?
+  end
+
+  class HTTPClientException < HTTPException
+  end
+
+  class HTTPUnauthorisedClientException < HTTPClientException
+  end
+
+  class HTTPBadRequestClientException < HTTPClientException
+  end
+
+  class HTTPForbiddenClientException < HTTPClientException
+  end
+
+  class HTTPMethodNotAllowedClientException < HTTPClientException
+  end
+
+  class HTTPNotAcceptableClientException < HTTPClientException
+  end
+
+  class HTTPTimeoutClientException < HTTPClientException
+  end
+
+  class HTTPConflictClientException < HTTPClientException
+  end
+
+  class HTTPNotFoundClientException < HTTPClientException
+  end
+
+  class HTTPTooManyRequestsClientException < HTTPClientException
+  end
+
+  class HTTPServerException < HTTPException
+  end
+
+  class HTTPInternalServerException < HTTPServerException
+  end
+
+  class HTTPNotImplementedServerException < HTTPServerException
+  end
+
+  class HTTPBadGatewayServerException < HTTPServerException
+  end
+
+  class HTTPServiceUnavailableServerException < HTTPServerException
+  end
+
+  class HTTPGatewayTimeoutServerException < HTTPServerException
+  end
+end


### PR DESCRIPTION
Access your REST APIs in a flexible way.

Write your API classes in an ActiveRecord-style; like ActiveResource but Flexirest works where the resource naming doesn't follow Rails conventions, it has built-in caching and is much more flexible.

refs: https://github.com/flexirest/flexirest