### PR TITLE
fix: Correct RBS for ActionController::Parameters#fetch method

### DIFF
--- a/gems/actionpack/6.0/_test/test.rb
+++ b/gems/actionpack/6.0/_test/test.rb
@@ -20,4 +20,12 @@ class ApplicationController < ActionController::Base
       ActiveSupport::SecurityUtils.secure_compare(token, 'secret')
     end
   end
+
+  def fetch
+    params = ActionController::Parameters.new(person: { name: 'Francesco' })
+    # fetch with block
+    params.fetch(:person) { { name: 'Default Name' } }
+    # fetch without block
+    params.fetch(:person)
+  end
 end

--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -170,5 +170,6 @@ module ActionController
     def to_s: () -> String
     def each_key: () { (untyped) -> untyped} -> Hash[untyped, untyped]
                 | () -> Enumerator[untyped, self]
+    def fetch: (untyped key, *untyped args) ?{ () -> untyped } -> untyped
   end
 end

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -3664,21 +3664,6 @@ module ActionController
     # when +permit+ is called.
     def []=: (untyped key, untyped value) -> untyped
 
-    # Returns a parameter for the given +key+. If the +key+
-    # can't be found, there are several options: With no other arguments,
-    # it will raise an <tt>ActionController::ParameterMissing</tt> error;
-    # if a second argument is given, then that is returned (converted to an
-    # instance of ActionController::Parameters if possible); if a block
-    # is given, then that will be run and its result returned.
-    #
-    #   params = ActionController::Parameters.new(person: { name: "Francesco" })
-    #   params.fetch(:person)               # => <ActionController::Parameters {"name"=>"Francesco"} permitted: false>
-    #   params.fetch(:none)                 # => ActionController::ParameterMissing: param is missing or the value is empty: none
-    #   params.fetch(:none, {})             # => <ActionController::Parameters {} permitted: false>
-    #   params.fetch(:none, "Francesco")    # => "Francesco"
-    #   params.fetch(:none) { "Francesco" } # => "Francesco"
-    def fetch: (untyped key, *untyped args) { () -> untyped } -> untyped
-
     # Extracts the nested parameter from the given +keys+ by calling +dig+
     # at each step. Returns +nil+ if any intermediate step is +nil+.
     #


### PR DESCRIPTION
Updated the RBS for the `fetch` method in `ActionController::Parameters` to reflect that the block is optional.
The previous RBS incorrectly required a block, but according to the implementation, the block is optional.

Ref: https://api.rubyonrails.org/v6.0/classes/ActionController/Parameters.html#method-i-fetch