### PR TITLE
activemodel: Remove ActiveModel::Attributes#initialize

### DIFF
--- a/gems/activemodel/6.0/_test/test.rb
+++ b/gems/activemodel/6.0/_test/test.rb
@@ -9,4 +9,5 @@ class Person
   def foo? = true
 end
 
-Person.new.send(:valid?)
+person = Person.new(name: 'John Doe')
+person.valid?

--- a/gems/activemodel/6.0/_test/test.rbs
+++ b/gems/activemodel/6.0/_test/test.rbs
@@ -1,4 +1,5 @@
 class Person
+  include ActiveModel::Model
   include ActiveModel::Validations
   extend ActiveModel::Validations::ClassMethods
 

--- a/gems/activemodel/6.0/activemodel-generated.rbs
+++ b/gems/activemodel/6.0/activemodel-generated.rbs
@@ -852,8 +852,6 @@ module ActiveModel
       def define_default_attribute: (untyped name, untyped value, untyped `type`) -> untyped
     end
 
-    def initialize: () -> untyped
-
     # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
     #
     #   class Person


### PR DESCRIPTION
Now `ActiveModel::Attributes#initialize` has been typed as `() -> untyped`. But it's incorrect. The original implementation takes positional arguments via varargs and passes it to other constructors using `super` method. So it does not care the number of arguments.

refs:

* https://github.com/rails/rails/blob/v6.1.7.8/activemodel/lib/active_model/attributes.rb#L75
* https://github.com/rails/rails/blob/v7.2.1/activemodel/lib/active_model/attributes.rb#L106

Unfortunately, the current type conceals the correct type of the constructor.
Usually, many models using ActiveModel::Model takes keyword arguments (ex. `Person.new(name: 'John')`. But, unfortunately, the current type of ActiveModel::Atributes conceals the type of constructors for them.

This comments out the definition of ActiveModel::Attributes#initialize not to conceal the type of constructor.