### PR TITLE
activerecord: Fix #find does not take string(s) as primary key(s).

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -22,6 +22,8 @@ user = User.new
 user.articles.build(Hash.new)
 user.articles.build(ActionController::Parameters.new)
 
+User.find(1)
+User.find("1")
 User.eager_load(:address, friends: [:address, :followers])
 User.includes(:address, :friends).to_a
 User.preload(:address, friends: [:address, :followers])

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -329,9 +329,9 @@ module ActiveRecord
       def preload: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> self
       def find_by: (*untyped) -> Model?
       def find_by!: (*untyped) -> Model
-      def find: (PrimaryKey id) -> Model
-              | (Array[PrimaryKey]) -> Array[Model]
-              | (*PrimaryKey) -> Array[Model]
+      def find: (PrimaryKey | _ToI id) -> Model
+              | (Array[PrimaryKey | _ToI]) -> Array[Model]
+              | (*PrimaryKey | _ToI) -> Array[Model]
               | () { (Model) -> boolish } -> Model?
       def find_or_create_by: (*untyped) -> Model
                           | (*untyped) { (Model) -> void } -> Model
@@ -416,9 +416,9 @@ module ActiveRecord
       def preload: (*String | Symbol | Array[String | Symbol] | Hash[untyped, untyped], **(String | Symbol | Array[String | Symbol] | Hash[untyped, untyped])) -> Relation
       def find_by: (*untyped) -> Model?
       def find_by!: (*untyped) -> Model
-      def find: (PrimaryKey id) -> Model
-              | (Array[PrimaryKey]) -> Array[Model]
-              | (*PrimaryKey) -> Array[Model]
+      def find: (PrimaryKey | _ToI id) -> Model
+              | (Array[PrimaryKey | _ToI]) -> Array[Model]
+              | (*PrimaryKey | _ToI) -> Array[Model]
       def find_or_create_by: (*untyped) -> Model
                           | (*untyped) { (Model) -> void } -> Model
       def find_or_create_by!: (*untyped) -> Model


### PR DESCRIPTION
ActiveRecord supports automatic conversion from String to Integer on `#find` call.

The API document of `ActiveRecord::FinderMethods#find` says:

> If the primary key is an integer, find by id coerces its arguments
> by using to_i.
> https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find

Unfortunately, it's difficult to add the `_ToI` type only if the primary key is an integer.  So this adds it always.

Is it better to override the signature in rbs_rails side?