### PR TITLE
flexirest: #after_request handler takes a response object

### DIFF
--- a/gems/flexirest/1.12/callbacks.rbs
+++ b/gems/flexirest/1.12/callbacks.rbs
@@ -4,7 +4,7 @@ module Flexirest
       def before_request: (Symbol method_name) -> void
                         | () { (Symbol name, Request request) -> (false | :retry | untyped) } -> void
       def after_request: (Symbol method_name) -> void
-                       | () { (Symbol name, Request request) -> (false | :retry | untyped) } -> void
+                       | () { (Symbol name, untyped response) -> (false | :retry | untyped) } -> void
     end
   end
 end


### PR DESCRIPTION
The after_request handler should take a response object instead of a request object.

refs:

* https://github.com/flexirest/flexirest/blob/master/docs/using-callbacks.md