### PR TITLE
flexirest: Add Flexirest::BaseWithoutValidation#initialize

### DIFF
--- a/gems/flexirest/1.12/base_without_validation.rbs
+++ b/gems/flexirest/1.12/base_without_validation.rbs
@@ -9,6 +9,7 @@ module Flexirest
     include Caching
     extend Caching::ClassMethods
 
+    def initialize: (?untyped attrs) -> void
     def self._request: (String, Symbol, *untyped, **untyped) -> untyped
     def self._plain_request: (String, Symbol, *untyped, **untyped) -> untyped
     def self.prepare_direct_request: (String, Symbol, **untyped) -> untyped


### PR DESCRIPTION
`Flexirest::BaseWithoutValidation#initialize` can take `attrs` to build
a response object.                                                                                                                                                                                                            

https://github.com/flexirest/flexirest/blob/v.10.6/lib/flexirest/base_without_validation.rb#L22