### PR TITLE
activerecord: Arel::Table.new takes table kwargs since v6.1

### DIFF
--- a/gems/activerecord/6.0/activerecord-6.0.rbs
+++ b/gems/activerecord/6.0/activerecord-6.0.rbs
@@ -52,3 +52,9 @@ module ActiveRecord
     def initialize: (untyped model, untyped inserts, on_duplicate: untyped, ?unique_by: untyped?, ?returning: untyped?) -> untyped
   end
 end
+
+module Arel
+  class Table
+    def initialize: (untyped name, ?type_caster: untyped? type_caster, ?as: untyped? as) -> untyped
+  end
+end

--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -23508,8 +23508,6 @@ module Arel
     # TableAlias and Table both have a #table_name which is the name of the underlying table
     alias table_name name
 
-    def initialize: (untyped name, ?type_caster: untyped? type_caster, ?as: untyped? as) -> untyped
-
     def alias: (?::String name) -> Nodes::TableAlias
 
     def from: () -> SelectManager

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -60,3 +60,9 @@ module ActiveRecord
     def initialize: (untyped model, untyped inserts, on_duplicate: untyped, ?unique_by: untyped?, ?returning: untyped?) -> untyped
   end
 end
+
+module Arel
+  class Table
+    def initialize: (untyped name, ?type_caster: untyped type_caster, ?as: untyped? as, ?klass: untyped?) -> void
+  end
+end

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -89,11 +89,17 @@ module ActiveRecord
     @record_timestamps: bool
 
     def initialize: (untyped model, untyped inserts, on_duplicate: untyped, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
-                  
+
     def record_timestamps?: () -> bool
 
     def keys_including_timestamps: () -> Set[String]
 
     def timestamps_for_create: () -> Hash[String, String]
+  end
+end
+
+module Arel
+  class Table
+    def initialize: (untyped name, ?type_caster: untyped type_caster, ?as: untyped? as, ?klass: untyped?) -> void
   end
 end

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -83,8 +83,8 @@ module ActiveRecord
 
   class MismatchedForeignKey < StatementInvalid
     def initialize: (?message: untyped?, ?sql: untyped?, ?binds: untyped?, ?table: untyped?,
-                     ?foreign_key: untyped?, ?target_table: untyped?, ?primary_key: untyped?, 
-                     ?primary_key_column: untyped?, ?query_parser: untyped?, 
+                     ?foreign_key: untyped?, ?target_table: untyped?, ?primary_key: untyped?,
+                     ?primary_key_column: untyped?, ?query_parser: untyped?,
                      ?connection_pool: ConnectionAdapters::ConnectionPool?) -> void
   end
 
@@ -110,11 +110,17 @@ module ActiveRecord
     @record_timestamps: bool
 
     def initialize: (untyped model, untyped inserts, on_duplicate: untyped, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
-                  
+
     def record_timestamps?: () -> bool
 
     def keys_including_timestamps: () -> Set[String]
 
     def timestamps_for_create: () -> Hash[String, String]
+  end
+end
+
+module Arel
+  class Table
+    def initialize: (untyped name, ?type_caster: untyped type_caster, ?as: untyped? as, ?klass: untyped?) -> void
   end
 end


### PR DESCRIPTION
refs:

* https://github.com/rails/rails/pull/39881
* https://github.com/rails/rails/blob/v6.1.7.8/activerecord/lib/arel/table.rb#L17