### PR TITLE
actionpack: Make the block arg for HTTP routing methods optional

### DIFF
--- a/gems/actionpack/6.0/_test/test.rb
+++ b/gems/actionpack/6.0/_test/test.rb
@@ -29,3 +29,13 @@ class ApplicationController < ActionController::Base
     params.fetch(:person)
   end
 end
+
+rs = ActionDispatch::Routing::RouteSet.new
+rs.draw do
+  resource :foo
+  resources :bar, only: %i[index]
+  namespace :baz do
+    get :qux
+    post :quux
+  end
+end

--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -13,3 +13,217 @@ module ActionDispatch
     def internal_request_id: () -> String
   end
 end
+
+module ActionDispatch
+  module Routing
+    class RouteSet
+      def draw: () { () [self: Mapper] -> untyped } -> nil
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    class Mapper
+      module HttpHelpers
+        # Define a route that only recognizes HTTP GET.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   get 'bacon', to: 'food#bacon'
+        def get: (*untyped args) ?{ () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP POST.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   post 'bacon', to: 'food#bacon'
+        def post: (*untyped args) ?{ () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP PATCH.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   patch 'bacon', to: 'food#bacon'
+        def patch: (*untyped args) ?{ () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP PUT.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   put 'bacon', to: 'food#bacon'
+        def put: (*untyped args) ?{ () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP DELETE.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   delete 'broccoli', to: 'food#broccoli'
+        def delete: (*untyped args) ?{ () -> untyped } -> untyped
+
+        private
+
+        def map_method: (untyped method, untyped args) ?{ () -> untyped } -> untyped
+      end
+
+      module Resources
+        # Sometimes, you have a resource that clients always look up without
+        # referencing an ID. A common example, /profile always shows the
+        # profile of the currently logged in user. In this case, you can use
+        # a singular resource to map /profile (rather than /profile/:id) to
+        # the show action:
+        #
+        #   resource :profile
+        #
+        # This creates six different routes in your application, all mapping to
+        # the +Profiles+ controller (note that the controller is named after
+        # the plural):
+        #
+        #   GET       /profile/new
+        #   GET       /profile
+        #   GET       /profile/edit
+        #   PATCH/PUT /profile
+        #   DELETE    /profile
+        #   POST      /profile
+        #
+        # === Options
+        # Takes same options as resources[rdoc-ref:#resources]
+        def resource: (*untyped resources) ?{ () -> untyped } -> untyped
+
+        # In Rails, a resourceful route provides a mapping between HTTP verbs
+        # and URLs and controller actions. By convention, each action also maps
+        # to particular CRUD operations in a database. A single entry in the
+        # routing file, such as
+        #
+        #   resources :photos
+        #
+        # creates seven different routes in your application, all mapping to
+        # the +Photos+ controller:
+        #
+        #   GET       /photos
+        #   GET       /photos/new
+        #   POST      /photos
+        #   GET       /photos/:id
+        #   GET       /photos/:id/edit
+        #   PATCH/PUT /photos/:id
+        #   DELETE    /photos/:id
+        #
+        # Resources can also be nested infinitely by using this block syntax:
+        #
+        #   resources :photos do
+        #     resources :comments
+        #   end
+        #
+        # This generates the following comments routes:
+        #
+        #   GET       /photos/:photo_id/comments
+        #   GET       /photos/:photo_id/comments/new
+        #   POST      /photos/:photo_id/comments
+        #   GET       /photos/:photo_id/comments/:id
+        #   GET       /photos/:photo_id/comments/:id/edit
+        #   PATCH/PUT /photos/:photo_id/comments/:id
+        #   DELETE    /photos/:photo_id/comments/:id
+        #
+        # === Options
+        # Takes same options as match[rdoc-ref:Base#match] as well as:
+        #
+        # [:path_names]
+        #   Allows you to change the segment component of the +edit+ and +new+ actions.
+        #   Actions not specified are not changed.
+        #
+        #     resources :posts, path_names: { new: "brand_new" }
+        #
+        #   The above example will now change /posts/new to /posts/brand_new.
+        #
+        # [:path]
+        #   Allows you to change the path prefix for the resource.
+        #
+        #     resources :posts, path: 'postings'
+        #
+        #   The resource and all segments will now route to /postings instead of /posts.
+        #
+        # [:only]
+        #   Only generate routes for the given actions.
+        #
+        #     resources :cows, only: :show
+        #     resources :cows, only: [:show, :index]
+        #
+        # [:except]
+        #   Generate all routes except for the given actions.
+        #
+        #     resources :cows, except: :show
+        #     resources :cows, except: [:show, :index]
+        #
+        # [:shallow]
+        #   Generates shallow routes for nested resource(s). When placed on a parent resource,
+        #   generates shallow routes for all nested resources.
+        #
+        #     resources :posts, shallow: true do
+        #       resources :comments
+        #     end
+        #
+        #   Is the same as:
+        #
+        #     resources :posts do
+        #       resources :comments, except: [:show, :edit, :update, :destroy]
+        #     end
+        #     resources :comments, only: [:show, :edit, :update, :destroy]
+        #
+        #   This allows URLs for resources that otherwise would be deeply nested such
+        #   as a comment on a blog post like <tt>/posts/a-long-permalink/comments/1234</tt>
+        #   to be shortened to just <tt>/comments/1234</tt>.
+        #
+        #   Set <tt>shallow: false</tt> on a child resource to ignore a parent's shallow parameter.
+        #
+        # [:shallow_path]
+        #   Prefixes nested shallow routes with the specified path.
+        #
+        #     scope shallow_path: "sekret" do
+        #       resources :posts do
+        #         resources :comments, shallow: true
+        #       end
+        #     end
+        #
+        #   The +comments+ resource here will have the following routes generated for it:
+        #
+        #     post_comments    GET       /posts/:post_id/comments(.:format)
+        #     post_comments    POST      /posts/:post_id/comments(.:format)
+        #     new_post_comment GET       /posts/:post_id/comments/new(.:format)
+        #     edit_comment     GET       /sekret/comments/:id/edit(.:format)
+        #     comment          GET       /sekret/comments/:id(.:format)
+        #     comment          PATCH/PUT /sekret/comments/:id(.:format)
+        #     comment          DELETE    /sekret/comments/:id(.:format)
+        #
+        # [:shallow_prefix]
+        #   Prefixes nested shallow route names with specified prefix.
+        #
+        #     scope shallow_prefix: "sekret" do
+        #       resources :posts do
+        #         resources :comments, shallow: true
+        #       end
+        #     end
+        #
+        #   The +comments+ resource here will have the following routes generated for it:
+        #
+        #     post_comments           GET       /posts/:post_id/comments(.:format)
+        #     post_comments           POST      /posts/:post_id/comments(.:format)
+        #     new_post_comment        GET       /posts/:post_id/comments/new(.:format)
+        #     edit_sekret_comment     GET       /comments/:id/edit(.:format)
+        #     sekret_comment          GET       /comments/:id(.:format)
+        #     sekret_comment          PATCH/PUT /comments/:id(.:format)
+        #     sekret_comment          DELETE    /comments/:id(.:format)
+        #
+        # [:format]
+        #   Allows you to specify the default value for optional +format+
+        #   segment or disable it by supplying +false+.
+        #
+        # [:param]
+        #   Allows you to override the default param name of +:id+ in the URL.
+        #
+        # === Examples
+        #
+        #   # routes call <tt>Admin::PostsController</tt>
+        #   resources :posts, module: "admin"
+        #
+        #   # resource actions are at /admin/posts.
+        #   resources :posts, path: "admin/posts"
+        def resources: (*untyped resources) ?{ () -> untyped } -> untyped
+      end
+    end
+  end
+end

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -9037,42 +9037,6 @@ module ActionDispatch
         def define_generate_prefix: (untyped app, untyped name) -> untyped
       end
 
-      module HttpHelpers
-        # Define a route that only recognizes HTTP GET.
-        # For supported arguments, see match[rdoc-ref:Base#match]
-        #
-        #   get 'bacon', to: 'food#bacon'
-        def get: (*untyped args) { () -> untyped } -> untyped
-
-        # Define a route that only recognizes HTTP POST.
-        # For supported arguments, see match[rdoc-ref:Base#match]
-        #
-        #   post 'bacon', to: 'food#bacon'
-        def post: (*untyped args) { () -> untyped } -> untyped
-
-        # Define a route that only recognizes HTTP PATCH.
-        # For supported arguments, see match[rdoc-ref:Base#match]
-        #
-        #   patch 'bacon', to: 'food#bacon'
-        def patch: (*untyped args) { () -> untyped } -> untyped
-
-        # Define a route that only recognizes HTTP PUT.
-        # For supported arguments, see match[rdoc-ref:Base#match]
-        #
-        #   put 'bacon', to: 'food#bacon'
-        def put: (*untyped args) { () -> untyped } -> untyped
-
-        # Define a route that only recognizes HTTP DELETE.
-        # For supported arguments, see match[rdoc-ref:Base#match]
-        #
-        #   delete 'broccoli', to: 'food#broccoli'
-        def delete: (*untyped args) { () -> untyped } -> untyped
-
-        private
-
-        def map_method: (untyped method, untyped args) { () -> untyped } -> untyped
-      end
-
       # You may wish to organize groups of controllers under a namespace.
       # Most commonly, you might group a number of administrative controllers
       # under an +admin+ namespace. You would place these controllers under
@@ -9428,168 +9392,6 @@ module ActionDispatch
 
         def resources_path_names: (untyped options) -> untyped
 
-        # Sometimes, you have a resource that clients always look up without
-        # referencing an ID. A common example, /profile always shows the
-        # profile of the currently logged in user. In this case, you can use
-        # a singular resource to map /profile (rather than /profile/:id) to
-        # the show action:
-        #
-        #   resource :profile
-        #
-        # This creates six different routes in your application, all mapping to
-        # the +Profiles+ controller (note that the controller is named after
-        # the plural):
-        #
-        #   GET       /profile/new
-        #   GET       /profile
-        #   GET       /profile/edit
-        #   PATCH/PUT /profile
-        #   DELETE    /profile
-        #   POST      /profile
-        #
-        # === Options
-        # Takes same options as resources[rdoc-ref:#resources]
-        def resource: (*untyped resources) { () -> untyped } -> untyped
-
-        # In Rails, a resourceful route provides a mapping between HTTP verbs
-        # and URLs and controller actions. By convention, each action also maps
-        # to particular CRUD operations in a database. A single entry in the
-        # routing file, such as
-        #
-        #   resources :photos
-        #
-        # creates seven different routes in your application, all mapping to
-        # the +Photos+ controller:
-        #
-        #   GET       /photos
-        #   GET       /photos/new
-        #   POST      /photos
-        #   GET       /photos/:id
-        #   GET       /photos/:id/edit
-        #   PATCH/PUT /photos/:id
-        #   DELETE    /photos/:id
-        #
-        # Resources can also be nested infinitely by using this block syntax:
-        #
-        #   resources :photos do
-        #     resources :comments
-        #   end
-        #
-        # This generates the following comments routes:
-        #
-        #   GET       /photos/:photo_id/comments
-        #   GET       /photos/:photo_id/comments/new
-        #   POST      /photos/:photo_id/comments
-        #   GET       /photos/:photo_id/comments/:id
-        #   GET       /photos/:photo_id/comments/:id/edit
-        #   PATCH/PUT /photos/:photo_id/comments/:id
-        #   DELETE    /photos/:photo_id/comments/:id
-        #
-        # === Options
-        # Takes same options as match[rdoc-ref:Base#match] as well as:
-        #
-        # [:path_names]
-        #   Allows you to change the segment component of the +edit+ and +new+ actions.
-        #   Actions not specified are not changed.
-        #
-        #     resources :posts, path_names: { new: "brand_new" }
-        #
-        #   The above example will now change /posts/new to /posts/brand_new.
-        #
-        # [:path]
-        #   Allows you to change the path prefix for the resource.
-        #
-        #     resources :posts, path: 'postings'
-        #
-        #   The resource and all segments will now route to /postings instead of /posts.
-        #
-        # [:only]
-        #   Only generate routes for the given actions.
-        #
-        #     resources :cows, only: :show
-        #     resources :cows, only: [:show, :index]
-        #
-        # [:except]
-        #   Generate all routes except for the given actions.
-        #
-        #     resources :cows, except: :show
-        #     resources :cows, except: [:show, :index]
-        #
-        # [:shallow]
-        #   Generates shallow routes for nested resource(s). When placed on a parent resource,
-        #   generates shallow routes for all nested resources.
-        #
-        #     resources :posts, shallow: true do
-        #       resources :comments
-        #     end
-        #
-        #   Is the same as:
-        #
-        #     resources :posts do
-        #       resources :comments, except: [:show, :edit, :update, :destroy]
-        #     end
-        #     resources :comments, only: [:show, :edit, :update, :destroy]
-        #
-        #   This allows URLs for resources that otherwise would be deeply nested such
-        #   as a comment on a blog post like <tt>/posts/a-long-permalink/comments/1234</tt>
-        #   to be shortened to just <tt>/comments/1234</tt>.
-        #
-        #   Set <tt>shallow: false</tt> on a child resource to ignore a parent's shallow parameter.
-        #
-        # [:shallow_path]
-        #   Prefixes nested shallow routes with the specified path.
-        #
-        #     scope shallow_path: "sekret" do
-        #       resources :posts do
-        #         resources :comments, shallow: true
-        #       end
-        #     end
-        #
-        #   The +comments+ resource here will have the following routes generated for it:
-        #
-        #     post_comments    GET       /posts/:post_id/comments(.:format)
-        #     post_comments    POST      /posts/:post_id/comments(.:format)
-        #     new_post_comment GET       /posts/:post_id/comments/new(.:format)
-        #     edit_comment     GET       /sekret/comments/:id/edit(.:format)
-        #     comment          GET       /sekret/comments/:id(.:format)
-        #     comment          PATCH/PUT /sekret/comments/:id(.:format)
-        #     comment          DELETE    /sekret/comments/:id(.:format)
-        #
-        # [:shallow_prefix]
-        #   Prefixes nested shallow route names with specified prefix.
-        #
-        #     scope shallow_prefix: "sekret" do
-        #       resources :posts do
-        #         resources :comments, shallow: true
-        #       end
-        #     end
-        #
-        #   The +comments+ resource here will have the following routes generated for it:
-        #
-        #     post_comments           GET       /posts/:post_id/comments(.:format)
-        #     post_comments           POST      /posts/:post_id/comments(.:format)
-        #     new_post_comment        GET       /posts/:post_id/comments/new(.:format)
-        #     edit_sekret_comment     GET       /comments/:id/edit(.:format)
-        #     sekret_comment          GET       /comments/:id(.:format)
-        #     sekret_comment          PATCH/PUT /comments/:id(.:format)
-        #     sekret_comment          DELETE    /comments/:id(.:format)
-        #
-        # [:format]
-        #   Allows you to specify the default value for optional +format+
-        #   segment or disable it by supplying +false+.
-        #
-        # [:param]
-        #   Allows you to override the default param name of +:id+ in the URL.
-        #
-        # === Examples
-        #
-        #   # routes call <tt>Admin::PostsController</tt>
-        #   resources :posts, module: "admin"
-        #
-        #   # resource actions are at /admin/posts.
-        #   resources :posts, path: "admin/posts"
-        def resources: (*untyped resources) { () -> untyped } -> untyped
-
         # To add a route to the collection:
         #
         #   resources :photos do
@@ -9620,9 +9422,6 @@ module ActionDispatch
         def new: () { () -> untyped } -> untyped
 
         def nested: () { () -> untyped } -> untyped
-
-        # See ActionDispatch::Routing::Mapper::Scoping#namespace.
-        def namespace: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
 
         def shallow: () { () -> untyped } -> untyped
 
@@ -10417,8 +10216,6 @@ module ActionDispatch
       def make_request: (untyped env) -> untyped
 
       public
-
-      def draw: () { () -> untyped } -> nil
 
       def append: () { () -> untyped } -> untyped
 


### PR DESCRIPTION
Some methods for routing requires block argument wrongly.  This make them optional.

Note:

I removed the type for `ActionDispatch::Routing::Mapper::Resources#namespace` because it conceals the block argument in spite of bypassing all arguments to `ActionDispatch::Routing::Mapper::Scope`.

Before:

```
$ bundle exec rbs -I sig method ActionDispatch::Routing::Mapper namespace
::ActionDispatch::Routing::Mapper#namespace
  defined_in: ::ActionDispatch::Routing::Mapper::Resources
  implementation: ::ActionDispatch::Routing::Mapper::Resources
  accessibility: public
  types:
      (untyped path, ?::Hash[untyped, untyped] options) -> untyped   at /Users/tkomiya/work/rbs/gem_rbs_collection/gems/actionpack/6.0/_test/.gem_rbs_collection/actionpack/6.0/actionpack-generated.rbs:9625:23...9625:83
```

After:

```
$ bundle exec rbs -I sig method ActionDispatch::Routing::Mapper namespace
::ActionDispatch::Routing::Mapper#namespace
  defined_in: ::ActionDispatch::Routing::Mapper::Scoping
  implementation: ::ActionDispatch::Routing::Mapper::Scoping
  accessibility: public
  types:
      (untyped path, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped   at /Users/tkomiya/work/rbs/gem_rbs_collection/gems/actionpack/6.0/_test/.gem_rbs_collection/actionpack/6.0/actionpack-generated.rbs:9174:23...9174:101
```