### PR TITLE
activerecord: AR::Relation#new should take block argument as optional

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -19265,20 +19265,6 @@ module ActiveRecord
 
     def bind_attribute: (untyped name, untyped value) { (untyped, untyped) -> untyped } -> untyped
 
-    # Initializes new record from relation while maintaining the current
-    # scope.
-    #
-    # Expects arguments in the same format as {ActiveRecord::Base.new}[rdoc-ref:Core.new].
-    #
-    #   users = User.where(name: 'DHH')
-    #   user = users.new # => #<User id: nil, name: "DHH", created_at: nil, updated_at: nil>
-    #
-    # You can also pass a block to new with the new record as argument:
-    #
-    #   user = users.new { |user| user.name = 'Oscar' }
-    #   user.name # => Oscar
-    def new: (?untyped? attributes) { () -> untyped } -> untyped
-
     alias build new
 
     # Tries to create a new record with the same scoped attributes

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -306,6 +306,24 @@ end
 
 module ActiveRecord
   class Relation
+    # Initializes new record from relation while maintaining the current
+    # scope.
+    #
+    # Expects arguments in the same format as {ActiveRecord::Base.new}[rdoc-ref:Core.new].
+    #
+    #   users = User.where(name: 'DHH')
+    #   user = users.new # => #<User id: nil, name: "DHH", created_at: nil, updated_at: nil>
+    #
+    # You can also pass a block to new with the new record as argument:
+    #
+    #   user = users.new { |user| user.name = 'Oscar' }
+    #   user.name # => Oscar
+    def new: (?untyped? attributes) ?{ () -> untyped } -> untyped
+  end
+end
+
+module ActiveRecord
+  class Relation
     module Methods[Model, PrimaryKey]
       def all: () -> self
       def ids: () -> Array[PrimaryKey]


### PR DESCRIPTION
Now the block argument for `AR::Relation#new` is defined as required, but it must be optional.

refs:

* https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-new
* https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation.rb#L69