### PR TITLE
activerecord: Support insert_all on relation

### DIFF
--- a/gems/activerecord/6.1/_test/activerecord-6.1.rb
+++ b/gems/activerecord/6.1/_test/activerecord-6.1.rb
@@ -1,0 +1,7 @@
+user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
+user.articles.insert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+user.articles.insert!({ id: 1, name: 'James' }, returning: %i[id name], record_timestamps: true)
+user.articles.insert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
+user.articles.insert_all!([{ id: 1, name: 'James' }], returning: %i[id name], record_timestamps: true)
+user.articles.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+user.articles.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -6,6 +6,26 @@ module ActiveRecord
     extend DelegatedType
   end
 
+  class AssociationRelation
+    def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+  end
+
+  module Associations
+    class CollectionProxy
+      def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    end
+  end
+
   module Enum
     def enum: (Hash[Symbol, untyped] definitions) -> void
   end

--- a/gems/activerecord/7.0/_test/test.rb
+++ b/gems/activerecord/7.0/_test/test.rb
@@ -9,6 +9,9 @@ module Test
   end
 
   class User < ApplicationRecord
+    # @dynamic articles
+    has_many :articles
+
     enum status: { active: 0, inactive: 1 }, _suffix: true
     enum :role, { admin: 0, user: 1 }, _prefix: true
     enum :classify, %w[hoge fuga], _default: "hoge"
@@ -17,6 +20,9 @@ module Test
     encrypts :secret, :key
     encrypts :token, deterministic: true
     encrypts :phrase, ignore_case: true
+  end
+
+  class Article < ActiveRecord::Base
   end
 
   User.where.missing.to_sql
@@ -33,4 +39,10 @@ module Test
   user.encrypted_attribute?(:secret)
   user.decrypt
   user.ciphertext_for(:token)
+  user.articles.insert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.insert!({ id: 1, name: 'James' }, returning: %i[id name], record_timestamps: true)
+  user.articles.insert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.insert_all!([{ id: 1, name: 'James' }], returning: %i[id name], record_timestamps: true)
+  user.articles.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
 end

--- a/gems/activerecord/7.0/_test/test.rbs
+++ b/gems/activerecord/7.0/_test/test.rbs
@@ -7,5 +7,18 @@ module Test
 
     class ActiveRecord_Relation < ::ActiveRecord::Relation
     end
+
+    def articles: () -> Article::ActiveRecord_Associations_CollectionProxy
+  end
+
+  class Article < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[Article, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ActiveRecord::Relation
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[Article, Integer]
+    end
   end
 end

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -4,6 +4,26 @@ module ActiveRecord
     extend Encryption::EncryptableRecord::ClassMethods
   end
 
+  class AssociationRelation
+    def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+  end
+
+  module Associations
+    class CollectionProxy
+      def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    end
+  end
+
   module Inheritance
     module ClassMethods
       def primary_abstract_class: () -> void

--- a/gems/activerecord/7.1/_test/test.rb
+++ b/gems/activerecord/7.1/_test/test.rb
@@ -9,6 +9,9 @@ module Test
   end
 
   class User < ApplicationRecord
+    # @dynamic articles
+    has_many :articles
+
     enum status: { active: 0, inactive: 1 }, _suffix: true
     enum :role, { admin: 0, user: 1 }, _prefix: true
     enum :classify, %w[hoge fuga], _default: "hoge"
@@ -22,6 +25,9 @@ module Test
       # @type var email: String
       email.strip.downcase
     }
+  end
+
+  class Article < ActiveRecord::Base
   end
 
   User.where.missing.to_sql
@@ -38,6 +44,12 @@ module Test
   user.encrypted_attribute?(:secret)
   user.decrypt
   user.ciphertext_for(:token)
+  user.articles.insert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.insert!({ id: 1, name: 'James' }, returning: %i[id name], record_timestamps: true)
+  user.articles.insert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.insert_all!([{ id: 1, name: 'James' }], returning: %i[id name], record_timestamps: true)
+  user.articles.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
 
   user = User.new
   user.normalize_attribute(:email)

--- a/gems/activerecord/7.1/_test/test.rbs
+++ b/gems/activerecord/7.1/_test/test.rbs
@@ -7,5 +7,18 @@ module Test
 
     class ActiveRecord_Relation < ::ActiveRecord::Relation
     end
+
+    def articles: () -> Article::ActiveRecord_Associations_CollectionProxy
+  end
+
+  class Article < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[Article, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ActiveRecord::Relation
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[Article, Integer]
+    end
   end
 end

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -6,6 +6,26 @@ module ActiveRecord
     extend Normalization::ClassMethods
   end
 
+  class AssociationRelation
+    def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+  end
+
+  module Associations
+    class CollectionProxy
+      def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+      def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    end
+  end
+
   module Inheritance
     module ClassMethods
       def primary_abstract_class: () -> void


### PR DESCRIPTION
ActiveRecord supports insert and upsert methods on relation classes (AssociationRelation and CollectionProxy) since v6.1.

refs:

* https://github.com/rails/rails/pull/38899
* https://github.com/rails/rails/blob/v6.1.7.8/activerecord/CHANGELOG.md

Note:

The implementation will be moved into AR::Relation since v7.2.