### PR TITLE
activerecord: Support insert_all on relation (for Rails 7.2)

### DIFF
--- a/gems/activerecord/7.2/_test/test.rb
+++ b/gems/activerecord/7.2/_test/test.rb
@@ -9,6 +9,9 @@ module Test
   end
 
   class User < ApplicationRecord
+    # @dynamic articles
+    has_many :articles
+
     enum status: { active: 0, inactive: 1 }, _suffix: true
     enum :role, { admin: 0, user: 1 }, _prefix: true
     enum :classify, %w[hoge fuga], _default: "hoge"
@@ -22,6 +25,9 @@ module Test
       # @type var email: String
       email.strip.downcase
     }
+  end
+
+  class Article < ApplicationRecord
   end
 
   User.where.missing.to_sql
@@ -38,6 +44,12 @@ module Test
   user.encrypted_attribute?(:secret)
   user.decrypt
   user.ciphertext_for(:token)
+  user.articles.insert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.insert!({ id: 1, name: 'James' }, returning: %i[id name], record_timestamps: true)
+  user.articles.insert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.insert_all!([{ id: 1, name: 'James' }], returning: %i[id name], record_timestamps: true)
+  user.articles.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
+  user.articles.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
 
   user = User.new
   user.normalize_attribute(:email)

--- a/gems/activerecord/7.2/_test/test.rbs
+++ b/gems/activerecord/7.2/_test/test.rbs
@@ -7,5 +7,18 @@ module Test
 
     class ActiveRecord_Relation < ::ActiveRecord::Relation
     end
+
+    def articles: () -> Article::ActiveRecord_Associations_CollectionProxy
+  end
+
+  class Article < ApplicationRecord
+    extend ::ActiveRecord::Base::ClassMethods[Article, ActiveRecord_Relation, Integer]
+
+    class ActiveRecord_Relation < ::ActiveRecord::Relation
+    end
+
+    class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+      include ::ActiveRecord::Relation::Methods[Article, Integer]
+    end
   end
 end

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -6,6 +6,15 @@ module ActiveRecord
     extend Normalization::ClassMethods
   end
 
+  class Relation
+    def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+  end
+
   module Inheritance
     module ClassMethods
       def primary_abstract_class: () -> void
@@ -83,34 +92,30 @@ module ActiveRecord
 
   class MismatchedForeignKey < StatementInvalid
     def initialize: (?message: untyped?, ?sql: untyped?, ?binds: untyped?, ?table: untyped?,
-                     ?foreign_key: untyped?, ?target_table: untyped?, ?primary_key: untyped?, 
-                     ?primary_key_column: untyped?, ?query_parser: untyped?, 
+                     ?foreign_key: untyped?, ?target_table: untyped?, ?primary_key: untyped?,
+                     ?primary_key_column: untyped?, ?query_parser: untyped?,
                      ?connection_pool: ConnectionAdapters::ConnectionPool?) -> void
   end
 
-  module Persistence
-    extend ActiveSupport::Concern
+  module Querying
+    def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
 
-    module ClassMethods
-      def insert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
 
-      def insert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
 
-      def insert!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
 
-      def insert_all!: (untyped attributes, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
+    def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
 
-      def upsert: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
-
-      def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
-    end
+    def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
   end
 
   class InsertAll
     @record_timestamps: bool
 
     def initialize: (untyped model, untyped inserts, on_duplicate: untyped, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
-                  
+
     def record_timestamps?: () -> bool
 
     def keys_including_timestamps: () -> Set[String]


### PR DESCRIPTION
ActiveRecord supports insert and upsert methods on relation classes (AssociationRelation and CollectionProxy) since v6.1.

The implementation of insert_all has been changed since v7.2. The implementation was moved to AR::Relation from AR::Persistence.  So types follow the new structure.

refs:

* #658
* https://github.com/rails/rails/pull/38899
* https://github.com/rails/rails/pull/51805
* https://github.com/rails/rails/blob/v6.1.7.8/activerecord/CHANGELOG.md