### PR TITLE
mysql2: Add Mysql2::Error

### DIFF
--- a/gems/mysql2/0.5/_test/error_handling.rb
+++ b/gems/mysql2/0.5/_test/error_handling.rb
@@ -1,0 +1,7 @@
+require "mysql2"
+
+begin
+  Mysql2::Client.new.query("INSERT INTO users (name) VALUES ('john')")
+rescue Mysql2::Error => e
+  puts e.error_number
+end

--- a/gems/mysql2/0.5/error.rbs
+++ b/gems/mysql2/0.5/error.rbs
@@ -1,0 +1,5 @@
+module Mysql2
+  class Error < StandardError
+    attr_reader error_number: Integer
+  end
+end


### PR DESCRIPTION
Mysql2::Error is a class that is raised when an operation such as inserting a record fails. https://github.com/brianmario/mysql2/blob/f6a9b68b42a51d1a370403f11eb88527dcb42dc6/lib/mysql2/error.rb