### PR TITLE
Add RackBuilder and support middleware setup in Faraday

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -46,7 +46,12 @@ response.success?
 conn = Faraday.new(
   url: 'http://example.com/test2',
   headers: { 'Content-Type' => 'application/json' }
-)
+) do |faraday|
+  faraday.use :raise_error
+  faraday.request :url_encoded
+  faraday.response :logger, bodies: true
+  faraday.adapter :net_http
+end
 conn.post(URI("http://example.com/post"))
 response = conn.post('/post') do |req|
   req.body = "{ query: 'chunky bacon' }"

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -3,7 +3,15 @@ module Faraday
 
   attr_reader self.default_adapter: Symbol
 
-  def self.new: (?untyped url, ?untyped options) ?{ (?untyped) -> void } -> Faraday::Connection
+  def self.new: (?untyped url, ?untyped options) ?{ (?Faraday::Connection) -> void } -> Faraday::Connection
+
+  interface _BuilderDelegatable
+    def use: (Symbol | Class klass, *untyped args) ?{ (?) -> void } -> void
+    def request: (Symbol | Class klass, *untyped args) ?{ (?) -> void } -> void
+    def response: (Symbol | Class klass, *untyped args) ?{ (?) -> void } -> void
+    def adapter: (Symbol | Class klass, *untyped args) ?{ (?) -> void } -> void
+    def app: () -> untyped
+  end
 
   class Adapter
     extend MiddlewareRegistry
@@ -100,6 +108,8 @@ module Faraday
   end
 
   class Connection
+    include _BuilderDelegatable
+
     attr_reader headers: Hash[String, String]
 
     def get: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
@@ -170,6 +180,10 @@ module Faraday
   end
 
   class ParsingError < Error
+  end
+
+  class RackBuilder
+    include _BuilderDelegatable
   end
 
   class Response


### PR DESCRIPTION
Faraday supports [Middleware](https://github.com/yykamei/gem_rbs_collection/tree/main), which allows developers to inject arbitrary behavior for request/response.

With this pull request, `steep check` will pass with the following code:

```ruby
conn = Faraday.new do |f|
  f.request :json
  f.response :logger
  f.response :json
  f.adapter :net_http
end
```