### PR TITLE
Add signeture of Faraday::Connection#ssl

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -51,6 +51,8 @@ conn = Faraday.new(
   faraday.request :url_encoded
   faraday.response :logger, bodies: true
   faraday.adapter :net_http
+  faraday.ssl.client_cert = 'client_cert'
+  faraday.ssl.client_key = 'client_key'
 end
 conn.post(URI("http://example.com/post"))
 response = conn.post('/post') do |req|

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -111,6 +111,7 @@ module Faraday
     include _BuilderDelegatable
 
     attr_reader headers: Hash[String, String]
+    attr_reader ssl: SSLOptions
 
     def get: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def head: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
@@ -120,6 +121,23 @@ module Faraday
     def post: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def put: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def patch: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+  end
+
+  class SSLOptions
+    attr_accessor verify: untyped
+    attr_accessor verify_hostname: untyped
+    attr_accessor ca_file: untyped
+    attr_accessor ca_path: untyped
+    attr_accessor verify_mode: untyped
+    attr_accessor cert_store: untyped
+    attr_accessor client_cert: untyped
+    attr_accessor client_key: untyped
+    attr_accessor certificate: untyped
+    attr_accessor private_key: untyped
+    attr_accessor verify_depth: untyped
+    attr_accessor version: untyped
+    attr_accessor min_version: untyped
+    attr_accessor max_version: untyped
   end
 
   class Error < StandardError


### PR DESCRIPTION
Add `Faraday::Connection#ssl` signature and `Faraday::SSLOptions` class.

After merging this Pull Request, the following code passes type checking.
```rb
conn = Faraday.new do |builder|
  builder.ssl.client_cert = 'client_cert'
  builder.ssl.client_key = 'client_key'
end
```