### PR TITLE
Add signeture of Faraday::Connection#options

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -51,8 +51,12 @@ conn = Faraday.new(
   faraday.request :url_encoded
   faraday.response :logger, bodies: true
   faraday.adapter :net_http
+  faraday.options.open_timeout = 5
+  faraday.options.read_timeout = 10
+  faraday.options.write_timeout = 5
 end
 conn.post(URI("http://example.com/post"))
+conn.options(URI("http://example.com/options"))
 response = conn.post('/post') do |req|
   req.body = "{ query: 'chunky bacon' }"
 end

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -112,6 +112,10 @@ module Faraday
 
     attr_reader headers: Hash[String, String]
 
+    def options: () -> RequestOptions
+               | ((String | URI)? url, ?untyped params, ?untyped headers) -> Response
+               
+
     def get: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def head: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def delete: (?String | URI url, ?untyped params, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
@@ -120,6 +124,20 @@ module Faraday
     def post: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def put: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
     def patch: (?String | URI url, ?untyped body, ?untyped headers) ?{ (Faraday::Request) -> void } -> Faraday::Response
+  end
+
+  class RequestOptions
+    attr_accessor params_encoder: untyped
+    attr_accessor proxy: untyped
+    attr_accessor bind: untyped
+    attr_accessor timeout: untyped
+    attr_accessor open_timeout: untyped
+    attr_accessor read_timeout: untyped
+    attr_accessor write_timeout: untyped
+    attr_accessor boundary: untyped
+    attr_accessor oauth: untyped
+    attr_accessor context: untyped
+    attr_accessor on_data: untyped
   end
 
   class Error < StandardError


### PR DESCRIPTION
Add `Faraday::Connection#options` signature and `Faraday::RequestOptions` class.

After merging this Pull Request, the following code passes type checking.
```rb
conn = Faraday.new do |builder|
  builder.options.open_timeout = 5
  builder.options.read_timeout = 10
  builder.options.write_timeout = 5
end
```