### PR TITLE
Add signeture of Faraday::Env

### DIFF
--- a/gems/faraday/2.5/_test/test.rb
+++ b/gems/faraday/2.5/_test/test.rb
@@ -114,5 +114,5 @@ Faraday::Middleware.unregister_middleware(:custom)
 custom_middleware = Faraday::Middleware.new(Object.new, { foo: 123 })
 custom_middleware.app
 custom_middleware.options.transform_keys
-custom_middleware.call(Object.new)
+custom_middleware.call(Faraday::Env.new)
 custom_middleware.close

--- a/gems/faraday/2.5/_test/test_adapter.rb
+++ b/gems/faraday/2.5/_test/test_adapter.rb
@@ -15,8 +15,8 @@ MyAdapter.supports_parallel?
 MyAdapter.new(Object.new, { test: 1234 })
 MyAdapter.new(Object.new)
 my_adapter = MyAdapter.new(Object.new) {}
-my_adapter.connection(Object.new)
-my_adapter.connection(Object.new) {}
+my_adapter.connection(Faraday::Env.new)
+my_adapter.connection(Faraday::Env.new) {}
 my_adapter.close
 my_adapter.send(:save_response, Object.new, 200, "🚀")
 my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 })
@@ -25,7 +25,7 @@ my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 }, "No probl
 my_adapter.send(:save_response, Object.new, 200, "🚀", { test: 34 }, "No problem!", true) {}
 my_adapter.send(:request_timeout, :read, { read_timeout: "ok" })
 my_adapter.send(:request_timeout, :open, { timeout: "ok" })
-response = my_adapter.call(Object.new)
+response = my_adapter.call(Faraday::Env.new)
 response.status
 response.headers
 response.success?

--- a/gems/faraday/2.5/_test/test_adapter_test.rb
+++ b/gems/faraday/2.5/_test/test_adapter_test.rb
@@ -1,6 +1,6 @@
 test = Faraday::Adapter::Test.new(Object.new) do |stubs|
   stubs.empty?
-  stub, meta = stubs.match(Object.new)
+  stub, meta = stubs.match(Faraday::Env.new)
   if stub && meta
     meta[:match_data]
   end
@@ -64,10 +64,10 @@ test = Faraday::Adapter::Test.new(Object.new) do |stubs|
   stubs.send(:new_stub, :get, "/path", { x_a: "a" }, nil) { [204, { x: 3 }, ""] }
   stubs.send(:matches?, {}, Object.new)
 end
-test.call(Object.new)
+test.call(Faraday::Env.new)
 
 stub = Faraday::Adapter::Test::Stub.new("example.com", "/path", "a=234", Faraday::Utils::Headers.new, "body", false, -> () { true })
-result, meta = stub.matches?(Object.new)
+result, meta = stub.matches?(Faraday::Env.new)
 if result
   meta.key?(:match_data)
 end
@@ -80,7 +80,7 @@ stub.body = "body"; stub.body&.to_str
 stub.strict_mode = true; stub.strict_mode
 stub.block = -> { true }; stub.block
 stub.path_match?("/request_path", {})
-stub.params_match?(Object.new) ? :ok : :bad
+stub.params_match?(Faraday::Env.new) ? :ok : :bad
 stub.headers_match?({ x_b: "ok" }) ? :ok : :bad
 stub.body_match?("request body") ? :ok : :bad
 stub.to_s

--- a/gems/faraday/2.5/faraday.rbs
+++ b/gems/faraday/2.5/faraday.rbs
@@ -33,14 +33,14 @@ module Faraday
     extend Parallelism
 
     def initialize: (?untyped? _app, ?::Hash[untyped, untyped] opts) ?{ () -> untyped } -> void
-    def connection: (untyped env) ?{ (untyped) -> untyped } -> untyped # TODO: `env` should be Faraday::Env
+    def connection: (Env | Hash[untyped, untyped] env) ?{ (untyped) -> untyped } -> untyped
     def close: () -> void
-    def call: (untyped env) -> Response # TODO: `env` should be Faraday::Env
+    def call: (Env env) -> Response
 
     private
 
     # TODO: The block parameter should be `Utils::Headers`, but it has not yet been defined.
-    def save_response: (untyped env, Integer status, String body, ?Hash[untyped, untyped]? headers, ?String? reason_phrase, ?finished: bool) ?{ (untyped) -> void } -> Response # TODO: `env` should be Faraday::Env
+    def save_response: (Env env, Integer status, String body, ?Hash[untyped, untyped]? headers, ?String? reason_phrase, ?finished: bool) ?{ (untyped) -> void } -> Response
     def request_timeout: (:read | :open | :write `type`, Hash[Symbol, untyped] options) -> Integer?
 
     TIMEOUT_KEYS: { read: :read_timeout, open: :open_timeout, write: :write_timeout }
@@ -56,21 +56,21 @@ module Faraday
 
         def initialize: (?strict_mode: bool) ?{ (self) -> void } -> void
         def empty?: () -> bool
-        def match: (untyped env) -> ((false | nil) | [Stub, meta]) # TODO: `env` should be Faraday::Env
-        def get: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def head: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def post: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def put: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def patch: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def delete: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
-        def options: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void # TODO: `env` should be Faraday::Env
+        def match: (Env env) -> ((false | nil) | [Stub, meta])
+        def get: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def head: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def post: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def put: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def patch: (String | URI | Regexp path, ?(^(String) -> bool | _ToS)? body, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def delete: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
+        def options: (String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers) { (Env env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
         def verify_stubbed_calls: () -> void
         def strict_mode=: (boolish value) -> void
 
         private # protected is not yet supported. See https://github.com/ruby/rbs/issues/579
 
         def new_stub: (:get | :head | :post | :put | :patch | :delete | :options request_method, String | URI | Regexp path, ?::Hash[Symbol | String, untyped] headers, ?(^(String) -> bool | _ToS)? body) { (untyped env, meta) -> [Integer, ::Hash[String | Symbol, untyped], String] } -> void
-        def matches?: (::Hash[Symbol, untyped] stack, untyped env) -> ([Stub, meta] | nil) # TODO: `env` should be Faraday::Env
+        def matches?: (::Hash[Symbol, untyped] stack, Env env) -> ([Stub, meta] | nil)
       end
 
       class Stub
@@ -83,9 +83,9 @@ module Faraday
         attr_accessor block: Proc?
 
         def initialize: (String? host, String? path, String? query, Utils::Headers? headers, String? body, boolish strict_mode, Proc block) -> void
-        def matches?: (untyped env) -> [bool, meta] # TODO: `env` should be Faraday::Env
+        def matches?: (Env env) -> [bool, meta]
         def path_match?: (String request_path, meta) -> bool
-        def params_match?: (untyped env) -> bool # TODO: `env` should be Faraday::Env
+        def params_match?: (Env env) -> bool
         def headers_match?: (::Hash[String | Symbol, untyped] request_headers) -> bool
         def body_match?: (String request_body) -> bool
         def to_s: () -> ::String
@@ -94,7 +94,7 @@ module Faraday
       def initialize: (untyped app) ?{ (Stubs stubs) -> void } -> void
                     | (untyped app, untyped? stubs) ?{ (untyped stubs) -> void } -> void
       def configure: () { (untyped) -> void } -> void
-      def call: (untyped env) -> untyped # TODO: `env` should be Faraday::Env
+      def call: (Env env) -> untyped
     end
   end
 
@@ -258,7 +258,7 @@ module Faraday
     attr_reader options: Hash[untyped, untyped]
 
     def initialize: (?untyped? app, ?::Hash[untyped, untyped] options) -> void
-    def call: (untyped env) -> untyped # TODO: `env` should be Faraday::Env
+    def call: (Env env) -> untyped
     def close: () -> void
   end
 
@@ -309,5 +309,23 @@ module Faraday
 
       def add_parsed: (Symbol | String key, String value) -> untyped
     end
+  end
+
+  class Env
+    attr_accessor method: Symbol
+    attr_accessor request_body: String
+    attr_accessor url: URI::HTTP | URI::HTTPS
+    attr_accessor request: Faraday::RequestOptions
+    attr_accessor request_headers: Hash[String, String]
+    attr_accessor ssl: Faraday::SSLOptions
+    attr_accessor parallel_manager: untyped
+    attr_accessor params: untyped
+    attr_accessor response: untyped
+    attr_accessor response_headers: untyped
+    attr_accessor status: untyped
+    attr_accessor reason_phrase: untyped
+    attr_accessor response_body: untyped
+
+    alias body request_body
   end
 end


### PR DESCRIPTION
Add signature of `Faraday::Env` class.

After merging this Pull Request, the following code passes type checking.
```rb
Faraday::Middleware.new(Object.new, { foo: 123 }).call(Faraday::Env.new)
```