### PR TITLE
activerecord: Add #arel_table to AR::Relation

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -8,6 +8,8 @@ class User < ActiveRecord::Base
   validates :name, presence: true, if: -> { something }
   validates :age, presence: true, if: ->(user) { user.something }
 
+  scope :matured, -> { where(arel_table[:age].gteq(18)) }
+
   before_save -> (obj) { obj.something; self.something }
   around_save -> (obj, block) { block.call; obj.something }
 

--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -23516,8 +23516,6 @@ module Arel
 
     def having: (untyped expr) -> untyped
 
-    def []: (untyped name) -> untyped
-
     def hash: () -> untyped
 
     def eql?: (untyped other) -> untyped

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -319,6 +319,8 @@ module ActiveRecord
     #   user = users.new { |user| user.name = 'Oscar' }
     #   user.name # => Oscar
     def new: (?untyped? attributes) ?{ () -> untyped } -> untyped
+
+    def arel_table: () -> Arel::Table
   end
 end
 
@@ -652,6 +654,12 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
             | () { (Model) -> boolish } -> Array[Model]
   def reselect: (*Symbol | String) -> Relation
   def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void) ?{ (Module extention) [self: Relation] -> void } -> void
+end
+
+module Arel
+  class Table
+    def []: (untyped name) -> Arel::Attributes::Attribute
+  end
 end
 
 # https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/unary.rb


### PR DESCRIPTION
The ActiveRecord::Relation provides methods defined at AR::Base via delegation (see ActiveRecord::Delegation).

Therefore AR::Relation also provides `#arel_table`.  It is often used in the scope definition.