### PR TITLE
Fix signetures for ActiveModelSerializers

### DIFF
--- a/gems/active_model_serializers/0.10/_test/test.rb
+++ b/gems/active_model_serializers/0.10/_test/test.rb
@@ -12,6 +12,7 @@ module Test
   end
 
   class ArticleSerializer < ActiveModel::Serializer
+    attribute :title
     attribute :title, key: :name
     attributes :body, :tag_names
 
@@ -21,7 +22,12 @@ module Test
   end
 
   resource = Article.new(title: "Hello", body: "World", tags: [Tag.new(name: "foo"), Tag.new(name: "bar")])
-  serialization = ActiveModelSerializers::SerializableResource.new(resource, serializer: ArticleSerializer)
+  ArticleSerializer.new(resource).as_json
+
+  serialization = ActiveModelSerializers::SerializableResource.new(resource)
   serialization.to_json
   serialization.as_json
+
+  serialization_json = ActiveModelSerializers::SerializableResource.new(resource, adapter: :json)
+  serialization_json.to_json
 end

--- a/gems/active_model_serializers/0.10/active_model.rbs
+++ b/gems/active_model_serializers/0.10/active_model.rbs
@@ -1,12 +1,12 @@
 module ActiveModel
   class Serializer[T]
     def self.attributes: (*Symbol attrs) -> void
-    def self.attribute: (Symbol attr, Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
+    def self.attribute: (Symbol attr, ?Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
 
     attr_accessor object: T
     attr_accessor root: untyped
     attr_accessor scope: untyped
 
-    def initialize: (T object, Hash[Symbol, untyped] options) -> void
+    def initialize: (T object, ?Hash[Symbol, untyped] options) -> void
   end
 end

--- a/gems/active_model_serializers/0.10/active_model_serializers.rbs
+++ b/gems/active_model_serializers/0.10/active_model_serializers.rbs
@@ -6,7 +6,7 @@ module ActiveModelSerializers
   end
 
   class SerializableResource
-    def initialize: (untyped resource, Hash[Symbol, untyped] options) -> void
+    def initialize: (untyped resource, ?Hash[Symbol, untyped] options) -> void
     def to_json: -> String
     def as_json: -> Hash[Symbol, untyped]
   end


### PR DESCRIPTION
These `options` are optional positional arguments, so this commit fixes method signatures.

* ActiveModel::Serializer.attribute
    * https://github.com/rails-api/active_model_serializers/blob/v0.10.14/lib/active_model/serializer.rb#L226
* ActiveModel::Serializer#initialize
    * https://github.com/rails-api/active_model_serializers/blob/v0.10.14/lib/active_model/serializer.rb#L319
* ActiveModelSerializers::SerializableResource
    * https://github.com/rails-api/active_model_serializers/blob/v0.10.14/lib/active_model_serializers/serializable_resource.rb#L17
