### PR TITLE
chore: fix typo recommentd => recommend in bin/init_new_gem

### DIFF
--- a/bin/init_new_gem
+++ b/bin/init_new_gem
@@ -40,7 +40,7 @@ begin
 end while (version = $stdin.gets.chomp).empty?
 
 puts "Your GitHub account if you want to become the maintainer of RBS for this gem (default: skip adding you to the maintainer)"
-puts "We recommentd to add your account to maintain the RBS actively."
+puts "We recommend to add your account to maintain the RBS actively."
 puts "See https://github.com/ruby/gem_rbs_collection/blob/main/docs/CONTRIBUTING.md#gem-reviewer"
 print '> '
 github_account = $stdin.gets.chomp.tap { break if _1.empty? }


### PR DESCRIPTION
I noticed typo on executing bin/init_new_gem, So I fixed it.

```diff
- puts "We recommentd to add your account to maintain the RBS actively."
+ puts "We recommend to add your account to maintain the RBS actively."
```