### PR TITLE
activesupport: Update the type of Array.wrap

### DIFF
--- a/gems/activesupport/6.0/_test/test.rb
+++ b/gems/activesupport/6.0/_test/test.rb
@@ -71,7 +71,7 @@ itself if Object.new.blank? \
 ActiveSupport::TimeZone['Asia/Tokyo'].to_s
 Time.find_zone(Object.name)
 
-Array.wrap(nil)
-Array.wrap([1, 2, 3])
-Array.wrap("hello")
-Array.wrap({a: 1, b: 2})
+Array.wrap(nil).map(&:to_s)
+Array.wrap([1, 2, 3]).map(&:to_s)
+Array.wrap("hello").map(&:to_s)
+Array.wrap({a: 1, b: 2}).map(&:to_s)

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -501,7 +501,7 @@ class Array[unchecked out Elem]
   #
   # The differences with <tt>Kernel#Array</tt> explained above
   # apply to the rest of <tt>object</tt>s.
-  def self.wrap: (nil) -> []
+  def self.wrap: (nil) -> Array[untyped]
                | [T] (_ToAry[T] array_like) -> Array[T]
                | [T] (T ele) -> [T]
 end

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -503,7 +503,7 @@ class Array[unchecked out Elem]
   # apply to the rest of <tt>object</tt>s.
   def self.wrap: (nil) -> Array[untyped]
                | [T] (_ToAry[T] array_like) -> Array[T]
-               | [T] (T ele) -> [T]
+               | [T] (T ele) -> Array[T]
 end
 
 module ActiveSupport


### PR DESCRIPTION
At present, `Array.wrap` will be return an empty tuple for untyped value because it matches to the first method_type: `(nil) -> []`.

In the type world, the behavior of an empty tuple is different from an empty array.  For example, calling a enumerable method will cause type an error:

```
app/app.rb:18:28: [error] Type `bot` does not have method `to_s`
│ Diagnostic ID: Ruby::NoMethod
│
└ Array.wrap(foo).map { |e| e.to_s }
                              ~~~~

```

This changes the return type of `Array.wrap` for nil value to `Array[untyped]`.

refs: https://github.com/ruby/gem_rbs_collection/pull/683