### PR TITLE
Support Symbol value for :block in #allow_browser

### DIFF
--- a/gems/actionpack/7.2/_test/test.rb
+++ b/gems/actionpack/7.2/_test/test.rb
@@ -5,3 +5,7 @@ end
 class BarController < ActionController::Base
   allow_browser versions: { safari: 17.5, chrome: 127, ie: false }, block: -> { head :not_acceptable }
 end
+
+class CanalController < ActionController::Base
+  allow_browser versions: { safari: 17.5, chrome: 127, ie: false }, block: :handle_outdated_browser
+end

--- a/gems/actionpack/7.2/_test/test.rbs
+++ b/gems/actionpack/7.2/_test/test.rbs
@@ -3,3 +3,6 @@ end
 
 class BarController < ActionController::Base
 end
+
+class CanalController < ActionController::Base
+end

--- a/gems/actionpack/7.2/actioncontroller-7.2.rbs
+++ b/gems/actionpack/7.2/actioncontroller-7.2.rbs
@@ -3,7 +3,7 @@ module ActionController
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def allow_browser: (versions: :modern | Hash[untyped, false | _ToS], ?block: ^() [self: Base] -> void, **untyped options) -> void
+      def allow_browser: (versions: :modern | Hash[untyped, false | _ToS], ?block: (^() [self: Base] -> void | Symbol), **untyped options) -> void
     end
   end
 


### PR DESCRIPTION
Thanks to https://github.com/rails/rails/pull/53158, the `:block` option now supports Symbol value.

This patch follows the upstream changes.