### PR TITLE
activerecord: Add AR::Relation#sanitize_sql_like

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   validates :name, presence: true, if: -> { something }
   validates :age, presence: true, if: ->(user) { user.something }
 
+  scope :name_like, ->(name) { where(arel_table[:name].matches("%#{sanitize_sql_like(name)}%")) }
   scope :matured, -> { where(arel_table[:age].gteq(18)) }
 
   before_save -> (obj) { obj.something; self.something }

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -326,6 +326,11 @@ module ActiveRecord
     #   user.name # => Oscar
     def new: (?untyped? attributes) ?{ () -> untyped } -> untyped
 
+    # ActiveRecord::Relation delegates method calls to a ActiveRecord::Base class.
+    # To represent the behavior in the RBS system, we define and include the class methods of ActiveRecord::Base here.
+
+    include Sanitization::ClassMethods
+
     def arel_table: () -> Arel::Table
   end
 end


### PR DESCRIPTION
The ActiveRecord::Relation provides methods defined at AR::Base via delegation (see ActiveRecord::Delegation).

This allows to use sanitize_sql_like and its family via AR::Relation. It is often used in the scope definition.