### PR TITLE
railties: Add Rails::Railties.initializers

### DIFF
--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -6,3 +6,9 @@ module Rails
     end
   end
 end
+
+module Rails
+  class Railties
+    extend Initializable::ClassMethods
+  end
+end


### PR DESCRIPTION
We need to call "extend ClassMethods" manually to add `Rails::Railties.initializers`.