### PR TITLE
activerecord: Add Arel::FactoryMethods#cast

### DIFF
--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -187,8 +187,12 @@ module Arel
   class DeleteManager < Arel::TreeManager
     def initialize: (?Arel::Table? table) -> untyped
   end
+
+  module FactoryMethods
+    def cast: (untyped name, untyped type) -> Nodes::NamedFunction
+  end
 end
-  
+
 module ActiveRecord
   class Relation
     module Methods[Model, PrimaryKey]

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -171,6 +171,10 @@ module Arel
   class DeleteManager < Arel::TreeManager
     def initialize: (?Arel::Table? table) -> untyped
   end
+
+  module FactoryMethods
+    def cast: (untyped name, untyped type) -> Nodes::NamedFunction
+  end
 end
 
 module ActiveRecord


### PR DESCRIPTION
`Arel::FactoryMethods#cast` was added since v7.1

refs: https://github.com/rails/rails/pull/48873