### PR TITLE
activerecord: Add type for AR::QueryMethods::WhereChain#associated

### DIFF
--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -46,6 +46,7 @@ module ActiveRecord
 
   module QueryMethods
     class WhereChain[Relation]
+      def associated: (*Symbol associations) -> Relation
       def missing: (*Symbol associations) -> Relation
     end
   end

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -56,6 +56,7 @@ module ActiveRecord
 
   module QueryMethods
     class WhereChain[Relation]
+      def associated: (*Symbol associations) -> Relation
       def missing: (*Symbol associations) -> Relation
     end
   end

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -48,6 +48,7 @@ module ActiveRecord
 
   module QueryMethods
     class WhereChain[Relation]
+      def associated: (*Symbol associations) -> Relation
       def missing: (*Symbol associations) -> Relation
     end
   end


### PR DESCRIPTION
`ActiveRecord::QueryMethods::WhereChain#associated` has been added since v7.0.

refs: https://github.com/rails/rails/pull/40696