### PR TITLE
railties: Move the definition of PluginGenerator.app_path to railties.rbs

### DIFF
--- a/gems/railties/6.0/patch.rbs
+++ b/gems/railties/6.0/patch.rbs
@@ -1,13 +1,3 @@
-module Rails
-  module Generators
-    class PluginGenerator < AppBase
-      # It is necessary to satisfy alias target.
-      # TODO: Define this method to correct place.
-      def app_path: () -> untyped
-    end
-  end
-end
-
 # rbs gem has erb library but it doesn't have ERB::Compiler definition.
 class ERB
   class Compiler

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -1,0 +1,8 @@
+module Rails
+  module Generators
+    class PluginGenerator < AppBase
+      # It is necessary to satisfy alias target.
+      def app_path: () -> untyped
+    end
+  end
+end


### PR DESCRIPTION
As a preparation of https://github.com/ruby/gem_rbs_collection/pull/693, this moves the definition of `Rails::Generator::PluginGenerator#app_path` to railties.rbs