### PR TITLE
fix Sidekiq::Logger::Formatters::Base#ctx

### DIFF
--- a/gems/sidekiq/7.0/logger.rbs
+++ b/gems/sidekiq/7.0/logger.rbs
@@ -4,7 +4,7 @@ module Sidekiq
 
     module Formatters
       class Base < ::Logger::Formatter
-        def ctx: () -> Context
+        def ctx: () -> Hash[String, untyped]
 
         def format_context: () -> String?
 


### PR DESCRIPTION
The return value of `ctx` should not be `Context`, but `Hash[String, untyped]`, which is the return value of `Context.current`.

see: https://github.com/sidekiq/sidekiq/blob/630d22fce8821aaab96ba9de6cd0440512af42c7/lib/sidekiq/logger.rb#L85