### PR TITLE
activestorage: Add ActiveStorage::Current

### DIFF
--- a/gems/activestorage/6.0/app/models/active_storage/current.rbs
+++ b/gems/activestorage/6.0/app/models/active_storage/current.rbs
@@ -1,0 +1,8 @@
+module ActiveStorage
+  class Current < ActiveSupport::CurrentAttributes
+    def self.host: () -> String
+    def self.host=: (String) -> String
+    def host: () -> String
+    def host=: (String) -> String
+  end
+end

--- a/gems/activestorage/6.1/app/models/active_storage/current.rbs
+++ b/gems/activestorage/6.1/app/models/active_storage/current.rbs
@@ -1,0 +1,1 @@
+../../../../6.0/app/models/active_storage/current.rbs

--- a/gems/activestorage/7.0/app/models/active_storage/current.rbs
+++ b/gems/activestorage/7.0/app/models/active_storage/current.rbs
@@ -1,0 +1,8 @@
+module ActiveStorage
+  class Current < ActiveSupport::CurrentAttributes
+    def self.url_options: () -> Hash[Symbol, untyped]
+    def self.url_options=: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+    def url_options: () -> Hash[Symbol, untyped]
+    def url_options=: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  end
+end


### PR DESCRIPTION
This contains https://github.com/ruby/gem_rbs_collection/pull/701.

refs:
    
* https://github.com/rails/rails/blob/v6.0.6.1/activestorage/app/models/active_storage/current.rb
* https://github.com/rails/rails/blob/v7.0.8.6/activestorage/app/models/active_storage/current.rb
    * `#url_options` has been added and `#host` has been deprecated