### PR TITLE
rails-html-sanitizer: Add types for rails-html-sanitizer gem

### DIFF
--- a/gems/rails-html-sanitizer/1.6/_test/test.rb
+++ b/gems/rails-html-sanitizer/1.6/_test/test.rb
@@ -1,0 +1,15 @@
+require "rails-html-sanitizer"
+
+full_sanitizer = Rails::HTML::FullSanitizer.new
+full_sanitizer.sanitize("<b>Bold</b> no more!  <a href='more.html'>See more here</a>...")
+
+link_sanitizer = Rails::HTML::LinkSanitizer.new
+link_sanitizer.sanitize('<a href="example.com">Only the link text will be kept.</a>')
+
+safe_list_sanitizer = Rails::HTML::SafeListSanitizer.new
+
+# sanitize via an extensive safe list of allowed elements
+safe_list_sanitizer.sanitize("<b>Bold</b> no more!  <a href='more.html'>See more here</a>...")
+
+# sanitize only the supplied tags and attributes
+safe_list_sanitizer.sanitize("<b>Bold</b> no more!  <a href='more.html'>See more here</a>...", tags: %w(table tr td), attributes: %w(id class style))

--- a/gems/rails-html-sanitizer/1.6/rails-html-sanitizer.rbs
+++ b/gems/rails-html-sanitizer/1.6/rails-html-sanitizer.rbs
@@ -1,0 +1,53 @@
+module Rails
+  module Html = HTML
+end
+
+module Rails
+  module HTML
+    class Sanitizer
+      def sanitize: (String html, ?Hash[untyped, untyped] options) -> String
+    end
+
+    module Concern
+      module ComposedSanitize
+        def sanitize: (String html, ?Hash[untyped, untyped] options) -> String
+      end
+    end
+
+    class FullSanitizer = HTML4::FullSanitizer
+    class LinkSanitizer = HTML4::LinkSanitizer
+    class SafeListSanitizer = HTML4::SafeListSanitizer
+    class WhiteListSanitizer = SafeListSanitizer
+  end
+
+  module HTML4
+    class FullSanitizer < Rails::HTML::Sanitizer
+      include HTML::Concern::ComposedSanitize
+    end
+
+    class LinkSanitizer < Rails::HTML::Sanitizer
+      include HTML::Concern::ComposedSanitize
+    end
+
+    class SafeListSanitizer < Rails::HTML::Sanitizer
+      include HTML::Concern::ComposedSanitize
+    end
+  end
+
+  module HTML5
+    class Sanitizer
+    end
+
+    class FullSanitizer < Rails::HTML::Sanitizer
+      include HTML::Concern::ComposedSanitize
+    end
+
+    class LinkSanitizer < Rails::HTML::Sanitizer
+      include HTML::Concern::ComposedSanitize
+    end
+
+    class SafeListSanitizer < Rails::HTML::Sanitizer
+      include HTML::Concern::ComposedSanitize
+    end
+  end
+end


### PR DESCRIPTION
This gem is responsible for sanitizing HTML fragments in Rails applications. Specifically, this is the set of sanitizers used to implement the Action View SanitizerHelper methods sanitize, sanitize_css, strip_tags and strip_links.

refs: https://github.com/rails/rails-html-sanitizer