### PR TITLE
activerecord: CollectionProxy#build can take an array of EachPair

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -826,6 +826,7 @@ module ActiveRecord
       #   person.pets.size  # => 5 # size of the collection
       #   person.pets.count # => 0 # count from database
       def build: (?_EachPair attributes) ?{ () -> untyped } -> untyped
+               | (Array[_EachPair] attributes) ?{ () -> untyped } -> Array[untyped]
 
       alias new build
 


### PR DESCRIPTION
As described above, `CollectionProxy#build` takes an array of attributes and returns list of instances of the model.