### PR TITLE
activerecord: Fix the location of #with_recursive

### DIFF
--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -19,13 +19,6 @@ module ActiveRecord
     def upsert_all: (untyped attributes, ?unique_by: untyped?, ?returning: untyped?, ?record_timestamps: bool?) -> untyped
   end
 
-  class Relation
-    module QueryMethods
-      def with_recursive: (*untyped) -> untyped
-      def with_recursive!: (*untyped) -> untyped
-    end
-  end
-
   module Inheritance
     module ClassMethods
       def primary_abstract_class: () -> void
@@ -44,6 +37,11 @@ module ActiveRecord
     def sql_runtime=: (untyped runtime) -> untyped
 
     extend RuntimeRegistry
+  end
+
+  module QueryMethods
+    def with_recursive: (*untyped) -> untyped
+    def with_recursive!: (*untyped) -> untyped
   end
 
   module QueryMethods


### PR DESCRIPTION
It is defined at `ActiveRecord::QueryMethods`, not `ActiveRecord:: Relation::QueryMethods`.

Unfortunately, it works well even if the wrong location.  But it conceals other methods defined in `AR::QueryMethods`.

refs: #662