### PR TITLE
addressable: URI#query_values= supports Array[[String, String]]

### DIFF
--- a/gems/addressable/2.8/_test/test.rb
+++ b/gems/addressable/2.8/_test/test.rb
@@ -45,3 +45,20 @@ template.extract(uri)
 #   "two" => "2",
 #   "fragment" => "foo"
 # }
+
+uri = Addressable::URI.parse(
+  "http://example.com/a/b/c"
+)
+uri.query_values # => nil
+uri.query_values = {"one" => "1", "two" => "2"}
+uri.query_values # => {"one" => "1", "two" => "2"}
+uri.query_values = ["three", "four"]
+uri.query_values # => {"three" => nil, "four" => nil}
+uri.query_values = [["five", "5"], ["six", "6"]]
+uri.query_values # => {"five" => "5", "six" => "6"}
+uri.query_values = [["seven"], ["andup", ["8", "9", "10"]]]
+uri.query_values # => {"seven"=> nil, "andup"=>"10"}
+uri.query_values = [["seven", "7"], ["andup", ["8", "9", "10"]]]
+uri.query_values # => {"seven"=>"7", "andup"=>"10"}
+uri.query_values = nil
+uri.query_values # => nil

--- a/gems/addressable/2.8/addressable.rbs
+++ b/gems/addressable/2.8/addressable.rbs
@@ -49,6 +49,7 @@ module Addressable
                     | (singleton(Array) return_type) -> Array[String]
     def query_values=: (Hash[String, String]? new_query_values) -> Hash[String, String]?
                      | (Array[String] new_query_values) -> Array[String]
+                     | (Array[[String | Array[String]]] new_query_values) -> Array[[String | Array[String]]]
     def request_uri: () -> String
     def request_uri=: (String new_request_uri) -> String
     def fragment: () -> String?


### PR DESCRIPTION
Adds a missing method overload signature for `Addressable::URI#query_values=`.

This change supports the ability to set query values as an array of string tuples, like the examples below:

```ruby
uri.query_values = [['a', 'a'], ['b', 'c'], ['b', 'd'], ['b', 'e']]
uri.query
# => "a=a&b=c&b=d&b=e"
uri.query_values = [['a', 'a'], ['b', ['c', 'd', 'e']]]
uri.query
# => "a=a&b=c&b=d&b=e"
uri.query_values = [['flag'], ['key', 'value']]
uri.query
# => "flag&key=value"
```

For more information https://www.rubydoc.info/gems/addressable/Addressable/URI#query_values=-instance_method