### PR TITLE
activemodel: Add types for ActiveModel::Access

### DIFF
--- a/gems/activemodel/7.1/activemodel-7.1.rbs
+++ b/gems/activemodel/7.1/activemodel-7.1.rbs
@@ -1,4 +1,12 @@
 module ActiveModel
+  module Access
+    def slice: (*Symbol | String) -> ActiveSupport::HashWithIndifferentAccess[Symbol, untyped]
+
+    def values_at: (*Symbol | String) -> Array[untyped]
+  end
+end
+
+module ActiveModel
   module API
     extend ActiveSupport::Concern
     include ActiveModel::AttributeAssignment
@@ -40,5 +48,11 @@ module ActiveModel
     def match?: (Symbol | String attribute, ?(Symbol | String)? type, **untyped options) -> bool
 
     def strict_match?: (Symbol | String attribute, (Symbol | String)? type, **untyped options) -> bool
+  end
+end
+
+module ActiveModel
+  module Model
+    include ActiveModel::Access
   end
 end


### PR DESCRIPTION
It was added since v7.1

refs: https://github.com/rails/rails/pull/44544

Note: This contains https://github.com/ruby/gem_rbs_collection/pull/723.