### PR TITLE
addressable: Add Addressable::URI#omit and #omit!

### DIFF
--- a/gems/addressable/2.8/_test/test.rb
+++ b/gems/addressable/2.8/_test/test.rb
@@ -46,9 +46,7 @@ template.extract(uri)
 #   "fragment" => "foo"
 # }
 
-uri = Addressable::URI.parse(
-  "http://example.com/a/b/c"
-)
+uri = Addressable::URI.parse("http://example.com/a/b/c")
 uri.query_values # => nil
 uri.query_values = {"one" => "1", "two" => "2"}
 uri.query_values # => {"one" => "1", "two" => "2"}
@@ -62,3 +60,8 @@ uri.query_values = [["seven", "7"], ["andup", ["8", "9", "10"]]]
 uri.query_values # => {"seven"=>"7", "andup"=>"10"}
 uri.query_values = nil
 uri.query_values # => nil
+
+
+uri = Addressable::URI.parse("http://example.com/go?a=b&c=d")
+uri.omit(:query).to_s # => "http://example.com/go"
+uri.omit(:scheme, :path, :query).to_s # => "example.com"

--- a/gems/addressable/2.8/_test/test.rb
+++ b/gems/addressable/2.8/_test/test.rb
@@ -65,3 +65,9 @@ uri.query_values # => nil
 uri = Addressable::URI.parse("http://example.com/go?a=b&c=d")
 uri.omit(:query).to_s # => "http://example.com/go"
 uri.omit(:scheme, :path, :query).to_s # => "example.com"
+
+uri = Addressable::URI.parse("http://example.com/go?a=b&c=d")
+uri.omit!(:query)
+uri.to_s # => "http://example.com"
+uri.omit!(:scheme, :path)
+uri.to_s # => "example.com"

--- a/gems/addressable/2.8/addressable.rbs
+++ b/gems/addressable/2.8/addressable.rbs
@@ -31,6 +31,7 @@ module Addressable
     def domain: () -> String
     def authority: () -> String
     def authority=: (String new_authority) -> String
+    def omit: (*Symbol components) -> URI
     def origin: () -> String
     def origin=: (String new_origin) -> String
     attr_reader port: Integer

--- a/gems/addressable/2.8/addressable.rbs
+++ b/gems/addressable/2.8/addressable.rbs
@@ -32,6 +32,7 @@ module Addressable
     def authority: () -> String
     def authority=: (String new_authority) -> String
     def omit: (*Symbol components) -> URI
+    def omit!: (*Symbol components) -> URI
     def origin: () -> String
     def origin=: (String new_origin) -> String
     attr_reader port: Integer


### PR DESCRIPTION
Addressable::URI#omit allows for returning a new instance of Addressable::URI with the specified components omitted.

Addressable::URI#omit! is similar but updates the current Addressable::URI instance in place.


https://github.com/sporkmonger/addressable/blob/4229164843616783287ca359bbe38b574f1908a3/lib/addressable/uri.rb#L2285-L2314