### PR TITLE
add ActiveRecord::Calculations module to ActiveRecord::Base

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -30,6 +30,7 @@ User.includes(:address, :friends).to_a
 User.preload(:address, friends: [:address, { followers: :users }]) # steep:ignore FallbackAny
 User.in_order_of(:id, [1, 5, 3])
 User.offset(5).limit(10)
+User.count(:id)
 
 t = User.arel_table
 User.limit(10).select(:id, "name", t[:age].as("years"), t[:email])

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -17,6 +17,7 @@ module ActiveRecord
     extend ::ActiveRecord::AttributeMethods::Write::ClassMethods
     extend ::ActiveRecord::Attributes::ClassMethods
     extend ::ActiveRecord::AutosaveAssociation::ClassMethods
+    extend ::ActiveRecord::Calculations
     extend ::ActiveRecord::Core::ClassMethods
     extend ::ActiveRecord::CounterCache::ClassMethods
     extend ::ActiveRecord::Inheritance::ClassMethods


### PR DESCRIPTION
I wanted to use `ActiveRecord::Calculations` methods like `User.count` as class methods of the model, so added code to extend `ActiveRecord::Calculations` module in `ActiveRecord::Base`.