### PR TITLE
activerecord: Support QueryObject Pattern for AR::Base.scope

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -1,3 +1,8 @@
+class FunQuery
+  def self.call(*args)
+  end
+end
+
 class User < ActiveRecord::Base
   enum status: { active: 0, inactive: 1 }, _suffix: true
   enum role: { admin: 0, user: 1 }, _prefix: :user_role
@@ -11,6 +16,7 @@ class User < ActiveRecord::Base
   scope :name_like, ->(name) { where(arel_table[:name].matches("%#{sanitize_sql_like(name)}%")) }
   scope :matured, -> { where(arel_table[:age].gteq(18)) }
   scope :nowait, -> { lock("FOR UPDATE NOWAIT") }
+  scope :fun, FunQuery
 
   before_save -> (obj) { obj.something; self.something }
   around_save -> (obj, block) { block.call; obj.something }

--- a/gems/activerecord/6.0/_test/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rbs
@@ -1,3 +1,7 @@
+class FunQuery
+  def self.call: (*untyped) -> untyped
+end
+
 class User < ActiveRecord::Base
   class ActiveRecord_Relation < ActiveRecord::Relation
     include ActiveRecord::Relation::Methods[User, Integer]

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -422,6 +422,10 @@ module ActiveRecord
   end
 
   class Base
+    interface _Callable[Relation]
+      def call: (*untyped) -> Relation
+    end
+
     module ClassMethods[Model, Relation, PrimaryKey]
       def all: () -> Relation
       def ids: () -> Array[PrimaryKey]
@@ -505,7 +509,7 @@ module ActiveRecord
       def select: (*Symbol | String | Arel::Nodes::t) -> Relation
                 | () { (Model) -> boolish } -> Array[Model]
       def reselect: (*Symbol | String | Arel::Nodes::t) -> Relation
-      def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void) ?{ (Module extention) [self: Relation] -> void } -> void
+      def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void | _Callable[Relation]) ?{ (Module extention) [self: Relation] -> void } -> void
       def count: () -> ::Integer
               | () { (Model) -> boolish } -> ::Integer
               | (Symbol | String column_name) -> ::Integer
@@ -679,7 +683,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def select: (*Symbol | String | Arel::Nodes::t) -> Relation
             | () { (Model) -> boolish } -> Array[Model]
   def reselect: (*Symbol | String | Arel::Nodes::t) -> Relation
-  def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void) ?{ (Module extention) [self: Relation] -> void } -> void
+  def scope: (Symbol, ^(*untyped, **untyped) [self: Relation] -> void | ActiveRecord::Base::_Callable[Relation]) ?{ (Module extention) [self: Relation] -> void } -> void
   def count: () -> ::Integer
           | () { (Model) -> boolish } -> ::Integer
           | (Symbol | String column_name) -> ::Integer


### PR DESCRIPTION
ActiveRecord::Base.scope can take an object having `call` method as 2nd argument "body".  QueryObject pattern is a technique to implement complicated query using a class having `call` method.

This allows to pass a QueryObject (_Callable) to the scope definition.

refs:

* https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/scoping/named.rb#L171
* https://github.com/Selleo/pattern/blob/master/lib/patterns/query.rb
* https://takaokouji.github.io/output/query-object/ (Japanese)