### PR TITLE
activejob: Add types for ActiveJob::Logging 

### DIFF
--- a/gems/activejob/6.0/_test/activejob.rb
+++ b/gems/activejob/6.0/_test/activejob.rb
@@ -22,4 +22,12 @@ class SendMessageJob < ActiveJob::Base
 end
 
 SendMessageJob.perform_now
+SendMessageJob.logger
+SendMessageJob.logger = ActiveSupport::Logger.new(STDOUT)
+SendMessageJob.log_arguments = false
+SendMessageJob.log_arguments
+SendMessageJob.log_arguments?
 SendMessageJob.set(queue: :another_queue).perform_later(flag: false)
+job = SendMessageJob.new(flag: false)
+job.logger
+job.logger = ActiveSupport::Logger.new(STDOUT)

--- a/gems/activejob/6.0/activejob-generated.rbs
+++ b/gems/activejob/6.0/activejob-generated.rbs
@@ -630,15 +630,6 @@ end
 
 module ActiveJob
   module Logging
-    # nodoc:
-    extend ActiveSupport::Concern
-
-    private
-
-    def tag_logger: (*untyped tags) { () -> untyped } -> untyped
-
-    def logger_tagged_by_active_job?: () -> untyped
-
     class LogSubscriber < ActiveSupport::LogSubscriber
       # nodoc:
       def enqueue: (untyped event) -> untyped

--- a/gems/activejob/6.0/activejob.rbs
+++ b/gems/activejob/6.0/activejob.rbs
@@ -8,6 +8,8 @@ module ActiveJob
     extend ActiveJob::QueueAdapter::ClassMethods
     extend ActiveJob::QueueName::ClassMethods
     extend ActiveJob::QueuePriority::ClassMethods
+    extend ActiveJob::Logging::ClassMethods
+    include ActiveJob::Logging
 
     def self.queue_as: (*untyped) -> void | ...
     def self.queue_with_priority: (?untyped? priority) -> void | ...
@@ -27,10 +29,21 @@ module ActiveJob
     # nodoc:
     extend ActiveSupport::Concern
 
+    module ClassMethods
+      def logger: () -> untyped
+      def logger=: (untyped val) -> untyped
+      def log_arguments: () -> bool
+      def log_arguments=: (bool value) -> bool
+      def log_arguments?: () -> bool
+    end
+
+    def logger: () -> untyped
+    def logger=: (untyped val) -> untyped
+
     private
 
-    def tag_logger: (*untyped tags) { () -> untyped } -> untyped
+    def tag_logger: (*Array[String] tags) { () -> untyped } -> untyped
 
-    def logger_tagged_by_active_job?: () -> untyped
+    def logger_tagged_by_active_job?: () -> bool
   end
 end

--- a/gems/activejob/6.0/activejob.rbs
+++ b/gems/activejob/6.0/activejob.rbs
@@ -21,3 +21,16 @@ module ActiveJob
     def self.discard_on: (*untyped) -> void | ...
   end
 end
+
+module ActiveJob
+  module Logging
+    # nodoc:
+    extend ActiveSupport::Concern
+
+    private
+
+    def tag_logger: (*untyped tags) { () -> untyped } -> untyped
+
+    def logger_tagged_by_active_job?: () -> untyped
+  end
+end


### PR DESCRIPTION
- `logger` is defined using `Class#cattr_accessor` in activesupport with instance_reader/instance_writer/instance_accessor set to true.
  - The default for `logger` is ActiveSupport::TaggedLogging, but it is not necessarily an instance of ActiveSupport::TaggedLogging or an inheritor of ActiveSupport::TaggedLogging (e.g. lograge). Therefore, it is defined as untyped.
- `log_arguments` is defined using `Class#class_attribute` in activesupport with instance_accessor set to false and instance_predicate set to true.