### PR TITLE
activemodel: Add types for ActiveModel::AttributeRegistration

### DIFF
--- a/gems/activemodel/7.1/_test/test.rb
+++ b/gems/activemodel/7.1/_test/test.rb
@@ -1,11 +1,14 @@
 require "active_model"
 
 class Person
+  include ActiveModel::Attributes
   include ActiveModel::Validations
 
   # @dynamic name, name=
-  attr_accessor :name
+  attribute :name, :string
 end
+
+Person.attribute_types
 
 ActiveModel::Error::CALLBACKS_OPTIONS
 ActiveModel::Error::MESSAGE_OPTIONS

--- a/gems/activemodel/7.1/_test/test.rbs
+++ b/gems/activemodel/7.1/_test/test.rbs
@@ -1,4 +1,8 @@
 class Person
+  include ActiveModel::Attributes
+  extend ActiveModel::Attributes::ClassMethods
+  include ActiveModel::AttributeRegistration
+  extend ActiveModel::AttributeRegistration::ClassMethods
   include ActiveModel::Validations
   extend ActiveModel::Validations::ClassMethods
 

--- a/gems/activemodel/7.1/activemodel-7.1.rbs
+++ b/gems/activemodel/7.1/activemodel-7.1.rbs
@@ -20,6 +20,21 @@ module ActiveModel
 end
 
 module ActiveModel
+  module Attributes
+    include ActiveModel::AttributeRegistration
+  end
+end
+
+module ActiveModel
+  module AttributeRegistration
+    module ClassMethods
+      def attribute: (untyped name, ?untyped? type, ?default: untyped, **untyped options) -> untyped
+      def attribute_types: () -> Hash[untyped, untyped]
+    end
+  end
+end
+
+module ActiveModel
   class Error
     CALLBACKS_OPTIONS: ::Array[:if | :unless | :on | :allow_nil | :allow_blank | :strict]
 


### PR DESCRIPTION
It was added at v7.1

ref: https://github.com/rails/rails/pull/44664