### PR TITLE
actionpack: signature updates

### DIFF
--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -161,6 +161,12 @@ end
 
 module ActionController
   class Parameters
+    # Deletes a key-value pair from +Parameters+ and returns the value. If
+    # +key+ is not found, returns +nil+ (or, with optional code block, yields
+    # +key+ and returns the result). Cf. +#extract!+, which returns the
+    # corresponding +ActionController::Parameters+ object.
+    def delete: (untyped key) ?{ () -> untyped } -> untyped
+
     def keys: () -> Array[untyped]
     def key?: () -> bool
     def has_key?: () -> bool

--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -261,3 +261,9 @@ module ActionController
     extend AbstractController::Caching::Fragments::ClassMethods
   end
 end
+
+module ActionController
+  class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
+    def fetch: (untyped key, *untyped args) ?{ () -> untyped } -> untyped
+  end
+end

--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -165,7 +165,7 @@ module ActionController
     # +key+ is not found, returns +nil+ (or, with optional code block, yields
     # +key+ and returns the result). Cf. +#extract!+, which returns the
     # corresponding +ActionController::Parameters+ object.
-    def delete: (untyped key) ?{ () -> untyped } -> untyped
+    def delete: (untyped key) ?{ (untyped key) -> untyped } -> untyped
 
     def keys: () -> Array[untyped]
     def key?: () -> bool

--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -272,6 +272,7 @@ end
 
 module ActionController
   class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
-    def fetch: (untyped key, *untyped args) ?{ () -> untyped } -> untyped
+    def fetch: (untyped key) ?{ () -> untyped } -> untyped
+             | (untyped key, untyped args) -> untyped
   end
 end

--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -263,6 +263,14 @@ module ActionController
 end
 
 module ActionController
+  module ContentSecurityPolicy
+    module ClassMethods
+      def content_security_policy: (?bool enabled, **untyped options) ?{ (untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionController
   class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
     def fetch: (untyped key, *untyped args) ?{ () -> untyped } -> untyped
   end

--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -1,4 +1,51 @@
 module ActionDispatch
+  class Cookies
+    class CookieJar
+      def fetch: (untyped name, *untyped args) ?{ () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Http
+    class Headers
+      # Returns the value for the given key mapped to @env.
+      #
+      # If the key is not found and an optional code block is not provided,
+      # raises a <tt>KeyError</tt> exception.
+      #
+      # If the code block is provided, then it will be run and
+      # its result returned.
+      def fetch: (untyped key) ?{ () -> untyped } -> untyped
+               | (untyped key, untyped default) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  class Request
+    class Session
+      # Returns value of the given key from the session, or raises +KeyError+
+      # if can't find the given key and no default value is set.
+      # Returns default value if specified.
+      #
+      #   session.fetch(:foo)
+      #   # => KeyError: key not found: "foo"
+      #
+      #   session.fetch(:foo, :bar)
+      #   # => :bar
+      #
+      #   session.fetch(:foo) do
+      #     :bar
+      #   end
+      #   # => :bar
+      def fetch: (untyped key) ?{ () -> untyped } -> untyped
+               | (untyped key, untyped default) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
   class RequestId
     X_REQUEST_ID: ::String
 

--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -276,6 +276,61 @@ module ActionDispatch
 end
 
 module ActionDispatch
+  module Routing
+    module Redirection
+      # Redirect any path to another path:
+      #
+      #   get "/stories" => redirect("/posts")
+      #
+      # This will redirect the user, while ignoring certain parts of the request, including query string, etc.
+      # <tt>/stories</tt>, <tt>/stories?foo=bar</tt>, etc all redirect to <tt>/posts</tt>.
+      #
+      # You can also use interpolation in the supplied redirect argument:
+      #
+      #   get 'docs/:article', to: redirect('/wiki/%{article}')
+      #
+      # Note that if you return a path without a leading slash then the URL is prefixed with the
+      # current SCRIPT_NAME environment variable. This is typically '/' but may be different in
+      # a mounted engine or where the application is deployed to a subdirectory of a website.
+      #
+      # Alternatively you can use one of the other syntaxes:
+      #
+      # The block version of redirect allows for the easy encapsulation of any logic associated with
+      # the redirect in question. Either the params and request are supplied as arguments, or just
+      # params, depending of how many arguments your block accepts. A string is required as a
+      # return value.
+      #
+      #   get 'jokes/:number', to: redirect { |params, request|
+      #     path = (params[:number].to_i.even? ? "wheres-the-beef" : "i-love-lamp")
+      #     "http://#{request.host_with_port}/#{path}"
+      #   }
+      #
+      # Note that the +do end+ syntax for the redirect block wouldn't work, as Ruby would pass
+      # the block to +get+ instead of +redirect+. Use <tt>{ ... }</tt> instead.
+      #
+      # The options version of redirect allows you to supply only the parts of the URL which need
+      # to change, it also supports interpolation of the path similar to the first example.
+      #
+      #   get 'stores/:name',       to: redirect(subdomain: 'stores', path: '/%{name}')
+      #   get 'stores/:name(*all)', to: redirect(subdomain: 'stores', path: '/%{name}%{all}')
+      #   get '/stories', to: redirect(path: '/posts')
+      #
+      # This will redirect the user, while changing only the specified parts of the request,
+      # for example the +path+ option in the last example.
+      # <tt>/stories</tt>, <tt>/stories?foo=bar</tt>, redirect to <tt>/posts</tt> and <tt>/posts?foo=bar</tt> respectively.
+      #
+      # Finally, an object which responds to call can be supplied to redirect, allowing you to reuse
+      # common redirect routes. The call method must accept two arguments, params and request, and return
+      # a string.
+      #
+      #   get 'accounts/:name' => redirect(SubdomainRedirector.new('api'))
+      #
+      def redirect: (*untyped args) ?{ () -> untyped } -> (OptionRedirect | PathRedirect | Redirect)
+    end
+  end
+end
+
+module ActionDispatch
   module Http
     module MimeNegotiation
       class InvalidType < Mime::Type::InvalidMimeType

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -9880,57 +9880,6 @@ module ActionDispatch
 
       def inspect: () -> ::String
     end
-
-    module Redirection
-      # Redirect any path to another path:
-      #
-      #   get "/stories" => redirect("/posts")
-      #
-      # This will redirect the user, while ignoring certain parts of the request, including query string, etc.
-      # <tt>/stories</tt>, <tt>/stories?foo=bar</tt>, etc all redirect to <tt>/posts</tt>.
-      #
-      # You can also use interpolation in the supplied redirect argument:
-      #
-      #   get 'docs/:article', to: redirect('/wiki/%{article}')
-      #
-      # Note that if you return a path without a leading slash then the URL is prefixed with the
-      # current SCRIPT_NAME environment variable. This is typically '/' but may be different in
-      # a mounted engine or where the application is deployed to a subdirectory of a website.
-      #
-      # Alternatively you can use one of the other syntaxes:
-      #
-      # The block version of redirect allows for the easy encapsulation of any logic associated with
-      # the redirect in question. Either the params and request are supplied as arguments, or just
-      # params, depending of how many arguments your block accepts. A string is required as a
-      # return value.
-      #
-      #   get 'jokes/:number', to: redirect { |params, request|
-      #     path = (params[:number].to_i.even? ? "wheres-the-beef" : "i-love-lamp")
-      #     "http://#{request.host_with_port}/#{path}"
-      #   }
-      #
-      # Note that the +do end+ syntax for the redirect block wouldn't work, as Ruby would pass
-      # the block to +get+ instead of +redirect+. Use <tt>{ ... }</tt> instead.
-      #
-      # The options version of redirect allows you to supply only the parts of the URL which need
-      # to change, it also supports interpolation of the path similar to the first example.
-      #
-      #   get 'stores/:name',       to: redirect(subdomain: 'stores', path: '/%{name}')
-      #   get 'stores/:name(*all)', to: redirect(subdomain: 'stores', path: '/%{name}%{all}')
-      #   get '/stories', to: redirect(path: '/posts')
-      #
-      # This will redirect the user, while changing only the specified parts of the request,
-      # for example the +path+ option in the last example.
-      # <tt>/stories</tt>, <tt>/stories?foo=bar</tt>, redirect to <tt>/posts</tt> and <tt>/posts?foo=bar</tt> respectively.
-      #
-      # Finally, an object which responds to call can be supplied to redirect, allowing you to reuse
-      # common redirect routes. The call method must accept two arguments, params and request, and return
-      # a string.
-      #
-      #   get 'accounts/:name' => redirect(SubdomainRedirector.new('api'))
-      #
-      def redirect: (*untyped args) { () -> untyped } -> (OptionRedirect | PathRedirect | Redirect)
-    end
   end
 end
 

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -1252,8 +1252,6 @@ module ActionController
     include AbstractController::Callbacks
 
     module ClassMethods
-      def content_security_policy: (?bool enabled, **untyped options) { (untyped) -> untyped } -> untyped
-
       def content_security_policy_report_only: (?bool report_only, **untyped options) -> untyped
     end
 

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -3662,12 +3662,6 @@ module ActionController
     # <tt>ActionController::Parameters</tt> instance.
     def transform_keys!: () { () -> untyped } -> untyped
 
-    # Deletes a key-value pair from +Parameters+ and returns the value. If
-    # +key+ is not found, returns +nil+ (or, with optional code block, yields
-    # +key+ and returns the result). Cf. +#extract!+, which returns the
-    # corresponding +ActionController::Parameters+ object.
-    def delete: (untyped key) { () -> untyped } -> untyped
-
     # Returns a new instance of <tt>ActionController::Parameters</tt> with only
     # items that the block evaluates to true.
     def select: () { () -> untyped } -> untyped

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -4223,8 +4223,6 @@ module ActionController
 
     def dig: (*untyped keys) -> untyped
 
-    def fetch: (untyped key, *untyped args) { () -> untyped } -> untyped
-
     private
 
     def load!: () -> untyped
@@ -4830,15 +4828,6 @@ module ActionDispatch
       alias include? key?
 
       DEFAULT: untyped
-
-      # Returns the value for the given key mapped to @env.
-      #
-      # If the key is not found and an optional code block is not provided,
-      # raises a <tt>KeyError</tt> exception.
-      #
-      # If the code block is provided, then it will be run and
-      # its result returned.
-      def fetch: (untyped key, ?untyped default) { () -> untyped } -> untyped
 
       def each: () { (untyped) -> untyped } -> untyped
 
@@ -7290,8 +7279,6 @@ module ActionDispatch
       # Returns the value of the cookie by +name+, or +nil+ if no such cookie exists.
       def []: (untyped name) -> untyped
 
-      def fetch: (untyped name, *untyped args) { () -> untyped } -> untyped
-
       def key?: (untyped name) -> untyped
 
       alias has_key? key?
@@ -8432,22 +8419,6 @@ module ActionDispatch
 
       # Deletes given key from the session.
       def delete: (untyped key) -> untyped
-
-      # Returns value of the given key from the session, or raises +KeyError+
-      # if can't find the given key and no default value is set.
-      # Returns default value if specified.
-      #
-      #   session.fetch(:foo)
-      #   # => KeyError: key not found: "foo"
-      #
-      #   session.fetch(:foo, :bar)
-      #   # => :bar
-      #
-      #   session.fetch(:foo) do
-      #     :bar
-      #   end
-      #   # => :bar
-      def fetch: (untyped key, ?untyped default) { () -> untyped } -> untyped
 
       def inspect: () -> untyped
 


### PR DESCRIPTION
Split from #735 to be smaller. Type signature updates for invalid signatures in actionpack, the majority are due to blocks being marked as required, but they should be optional.