### PR TITLE
actionview: signature updates

### DIFF
--- a/gems/actionview/6.0/actionview-generated.rbs
+++ b/gems/actionview/6.0/actionview-generated.rbs
@@ -6444,24 +6444,6 @@ module ActionView
     # In order to use this module, all you need is to implement
     # view_renderer that returns an ActionView::Renderer object.
     module RenderingHelper
-      # Returns the result of a render that's dictated by the options hash. The primary options are:
-      #
-      # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt>.
-      # * <tt>:file</tt> - Renders an explicit template file (this used to be the old default), add :locals to pass in those.
-      # * <tt>:inline</tt> - Renders an inline template similar to how it's done in the controller.
-      # * <tt>:plain</tt> - Renders the text passed in out. Setting the content
-      #   type as <tt>text/plain</tt>.
-      # * <tt>:html</tt> - Renders the HTML safe string passed in out, otherwise
-      #   performs HTML escape on the string first. Setting the content type as
-      #   <tt>text/html</tt>.
-      # * <tt>:body</tt> - Renders the text passed in, and inherits the content
-      #   type of <tt>text/plain</tt> from <tt>ActionDispatch::Response</tt>
-      #   object.
-      #
-      # If no options hash is passed or :update specified, the default is to render a partial and use the second parameter
-      # as the locals hash.
-      def render: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] locals) { () -> untyped } -> untyped
-
       # Overwrites _layout_for in the context object so it supports the case a block is
       # passed to a partial. Returns the contents that are yielded to a layout, given a
       # name or a block.

--- a/gems/actionview/6.0/actionview-generated.rbs
+++ b/gems/actionview/6.0/actionview-generated.rbs
@@ -6843,34 +6843,6 @@ module ActionView
       #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]" />
       def tag: (?untyped? name, ?untyped? options, ?bool open, ?bool escape) -> untyped
 
-      # Returns an HTML block tag of type +name+ surrounding the +content+. Add
-      # HTML attributes by passing an attributes hash to +options+.
-      # Instead of passing the content as an argument, you can also use a block
-      # in which case, you pass your +options+ as the second parameter.
-      # Set escape to false to disable attribute value escaping.
-      # Note: this is legacy syntax, see +tag+ method description for details.
-      #
-      # ==== Options
-      # The +options+ hash can be used with attributes with no value like (<tt>disabled</tt> and
-      # <tt>readonly</tt>), which you can give a value of true in the +options+ hash. You can use
-      # symbols or strings for the attribute names.
-      #
-      # ==== Examples
-      #   content_tag(:p, "Hello world!")
-      #    # => <p>Hello world!</p>
-      #   content_tag(:div, content_tag(:p, "Hello world!"), class: "strong")
-      #    # => <div class="strong"><p>Hello world!</p></div>
-      #   content_tag(:div, "Hello world!", class: ["strong", "highlight"])
-      #    # => <div class="strong highlight">Hello world!</div>
-      #   content_tag("select", options, multiple: true)
-      #    # => <select multiple="multiple">...options...</select>
-      #
-      #   <%= content_tag :div, class: "strong" do -%>
-      #     Hello world!
-      #   <% end -%>
-      #    # => <div class="strong">Hello world!</div>
-      def content_tag: (untyped name, ?untyped? content_or_options_with_block, ?untyped? options, ?bool escape) { () -> untyped } -> untyped
-
       # Returns a CDATA section with the given +content+. CDATA sections
       # are used to escape blocks of text containing characters which would
       # otherwise be recognized as markup. CDATA sections begin with the string

--- a/gems/actionview/6.0/actionview-generated.rbs
+++ b/gems/actionview/6.0/actionview-generated.rbs
@@ -3605,56 +3605,6 @@ module ActionView
       # FormOptionsHelper#collection_select and DateHelper#datetime_select.
       def fields: (?untyped? scope, ?model: untyped? model, **untyped options) { () -> untyped } -> untyped
 
-      # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object
-      # assigned to the template (identified by +object+). The text of label will default to the attribute name unless a translation
-      # is found in the current I18n locale (through helpers.label.<modelname>.<attribute>) or you specify it explicitly.
-      # Additional options on the label tag can be passed as a hash with +options+. These options will be tagged
-      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:value</tt> option, which is designed to
-      # target labels for radio_button tags (where the value is used in the ID of the input tag).
-      #
-      # ==== Examples
-      #   label(:post, :title)
-      #   # => <label for="post_title">Title</label>
-      #
-      # You can localize your labels based on model and attribute names.
-      # For example you can define the following in your locale (e.g. en.yml)
-      #
-      #   helpers:
-      #     label:
-      #       post:
-      #         body: "Write your entire text here"
-      #
-      # Which then will result in
-      #
-      #   label(:post, :body)
-      #   # => <label for="post_body">Write your entire text here</label>
-      #
-      # Localization can also be based purely on the translation of the attribute-name
-      # (if you are using ActiveRecord):
-      #
-      #   activerecord:
-      #     attributes:
-      #       post:
-      #         cost: "Total cost"
-      #
-      #   label(:post, :cost)
-      #   # => <label for="post_cost">Total cost</label>
-      #
-      #   label(:post, :title, "A short title")
-      #   # => <label for="post_title">A short title</label>
-      #
-      #   label(:post, :title, "A short title", class: "title_label")
-      #   # => <label for="post_title" class="title_label">A short title</label>
-      #
-      #   label(:post, :privacy, "Public Post", value: "public")
-      #   # => <label for="post_privacy_public">Public Post</label>
-      #
-      #   label(:post, :terms) do
-      #     raw('Accept <a href="/terms">Terms</a>.')
-      #   end
-      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
-      def label: (untyped object_name, untyped method, ?untyped? content_or_options, ?untyped? options) { () -> untyped } -> untyped
-
       # Returns an input tag of the "text" type tailored for accessing a specified attribute (identified by +method+) on an object
       # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
       # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
@@ -4351,56 +4301,6 @@ module ActionView
       # See the docs for the <tt>ActionView::FormHelper.fields</tt> helper method.
       def fields: (?untyped? scope, ?model: untyped? model, **untyped options) { () -> untyped } -> untyped
 
-      # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object
-      # assigned to the template (identified by +object+). The text of label will default to the attribute name unless a translation
-      # is found in the current I18n locale (through helpers.label.<modelname>.<attribute>) or you specify it explicitly.
-      # Additional options on the label tag can be passed as a hash with +options+. These options will be tagged
-      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:value</tt> option, which is designed to
-      # target labels for radio_button tags (where the value is used in the ID of the input tag).
-      #
-      # ==== Examples
-      #   label(:title)
-      #   # => <label for="post_title">Title</label>
-      #
-      # You can localize your labels based on model and attribute names.
-      # For example you can define the following in your locale (e.g. en.yml)
-      #
-      #   helpers:
-      #     label:
-      #       post:
-      #         body: "Write your entire text here"
-      #
-      # Which then will result in
-      #
-      #   label(:body)
-      #   # => <label for="post_body">Write your entire text here</label>
-      #
-      # Localization can also be based purely on the translation of the attribute-name
-      # (if you are using ActiveRecord):
-      #
-      #   activerecord:
-      #     attributes:
-      #       post:
-      #         cost: "Total cost"
-      #
-      #   label(:cost)
-      #   # => <label for="post_cost">Total cost</label>
-      #
-      #   label(:title, "A short title")
-      #   # => <label for="post_title">A short title</label>
-      #
-      #   label(:title, "A short title", class: "title_label")
-      #   # => <label for="post_title" class="title_label">A short title</label>
-      #
-      #   label(:privacy, "Public Post", value: "public")
-      #   # => <label for="post_privacy_public">Public Post</label>
-      #
-      #   label(:terms) do
-      #     raw('Accept <a href="/terms">Terms</a>.')
-      #   end
-      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
-      def label: (untyped method, ?untyped? text, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
-
       # Returns a checkbox tag tailored for accessing a specified attribute (identified by +method+) on an object
       # assigned to the template (identified by +object+). This object must be an instance object (@object) and not a local object.
       # It's intended that +method+ returns an integer and if that integer is above zero, then the checkbox is checked.
@@ -4563,46 +4463,6 @@ module ActionView
       #           create: "Add %{model}"
       #
       def submit: (?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
-
-      # Add the submit button for the given form. When no value is given, it checks
-      # if the object is a new resource or not to create the proper label:
-      #
-      #   <%= form_for @post do |f| %>
-      #     <%= f.button %>
-      #   <% end %>
-      #
-      # In the example above, if <tt>@post</tt> is a new record, it will use "Create Post" as
-      # button label; otherwise, it uses "Update Post".
-      #
-      # Those labels can be customized using I18n under the +helpers.submit+ key
-      # (the same as submit helper) and using <tt>%{model}</tt> for translation interpolation:
-      #
-      #   en:
-      #     helpers:
-      #       submit:
-      #         create: "Create a %{model}"
-      #         update: "Confirm changes to %{model}"
-      #
-      # It also searches for a key specific to the given object:
-      #
-      #   en:
-      #     helpers:
-      #       submit:
-      #         post:
-      #           create: "Add %{model}"
-      #
-      # ==== Examples
-      #   button("Create post")
-      #   # => <button name='button' type='submit'>Create post</button>
-      #
-      #   button do
-      #     content_tag(:strong, 'Ask me!')
-      #   end
-      #   # => <button name='button' type='submit'>
-      #   #      <strong>Ask me!</strong>
-      #   #    </button>
-      #
-      def button: (?untyped? value, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
 
       def emitted_hidden_id?: () -> untyped
 

--- a/gems/actionview/6.0/actionview.rbs
+++ b/gems/actionview/6.0/actionview.rbs
@@ -152,6 +152,30 @@ end
 
 module ActionView
   module Helpers
+    module RenderingHelper
+      # Returns the result of a render that's dictated by the options hash. The primary options are:
+      #
+      # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt>.
+      # * <tt>:file</tt> - Renders an explicit template file (this used to be the old default), add :locals to pass in those.
+      # * <tt>:inline</tt> - Renders an inline template similar to how it's done in the controller.
+      # * <tt>:plain</tt> - Renders the text passed in out. Setting the content
+      #   type as <tt>text/plain</tt>.
+      # * <tt>:html</tt> - Renders the HTML safe string passed in out, otherwise
+      #   performs HTML escape on the string first. Setting the content type as
+      #   <tt>text/html</tt>.
+      # * <tt>:body</tt> - Renders the text passed in, and inherits the content
+      #   type of <tt>text/plain</tt> from <tt>ActionDispatch::Response</tt>
+      #   object.
+      #
+      # If no options hash is passed or :update specified, the default is to render a partial and use the second parameter
+      # as the locals hash.
+      def render: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] locals) ?{ () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
     module TagHelper
       # Returns an HTML block tag of type +name+ surrounding the +content+. Add
       # HTML attributes by passing an attributes hash to +options+.

--- a/gems/actionview/6.0/actionview.rbs
+++ b/gems/actionview/6.0/actionview.rbs
@@ -152,6 +152,40 @@ end
 
 module ActionView
   module Helpers
+    module TagHelper
+      # Returns an HTML block tag of type +name+ surrounding the +content+. Add
+      # HTML attributes by passing an attributes hash to +options+.
+      # Instead of passing the content as an argument, you can also use a block
+      # in which case, you pass your +options+ as the second parameter.
+      # Set escape to false to disable attribute value escaping.
+      # Note: this is legacy syntax, see +tag+ method description for details.
+      #
+      # ==== Options
+      # The +options+ hash can be used with attributes with no value like (<tt>disabled</tt> and
+      # <tt>readonly</tt>), which you can give a value of true in the +options+ hash. You can use
+      # symbols or strings for the attribute names.
+      #
+      # ==== Examples
+      #   content_tag(:p, "Hello world!")
+      #    # => <p>Hello world!</p>
+      #   content_tag(:div, content_tag(:p, "Hello world!"), class: "strong")
+      #    # => <div class="strong"><p>Hello world!</p></div>
+      #   content_tag(:div, "Hello world!", class: ["strong", "highlight"])
+      #    # => <div class="strong highlight">Hello world!</div>
+      #   content_tag("select", options, multiple: true)
+      #    # => <select multiple="multiple">...options...</select>
+      #
+      #   <%= content_tag :div, class: "strong" do -%>
+      #     Hello world!
+      #   <% end -%>
+      #    # => <div class="strong">Hello world!</div>
+      def content_tag: (untyped name, ?untyped? content_or_options_with_block, ?untyped? options, ?bool escape) ?{ () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
     module UrlHelper
       # Creates an anchor element of the given +name+ using a URL created by the set of +options+.
       # See the valid options in the documentation for +url_for+. It's also possible to

--- a/gems/actionview/6.0/actionview.rbs
+++ b/gems/actionview/6.0/actionview.rbs
@@ -1,5 +1,157 @@
 module ActionView
   module Helpers
+    class FormBuilder
+      # Add the submit button for the given form. When no value is given, it checks
+      # if the object is a new resource or not to create the proper label:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.button %>
+      #   <% end %>
+      #
+      # In the example above, if <tt>@post</tt> is a new record, it will use "Create Post" as
+      # button label; otherwise, it uses "Update Post".
+      #
+      # Those labels can be customized using I18n under the +helpers.submit+ key
+      # (the same as submit helper) and using <tt>%{model}</tt> for translation interpolation:
+      #
+      #   en:
+      #     helpers:
+      #       submit:
+      #         create: "Create a %{model}"
+      #         update: "Confirm changes to %{model}"
+      #
+      # It also searches for a key specific to the given object:
+      #
+      #   en:
+      #     helpers:
+      #       submit:
+      #         post:
+      #           create: "Add %{model}"
+      #
+      # ==== Examples
+      #   button("Create post")
+      #   # => <button name='button' type='submit'>Create post</button>
+      #
+      #   button do
+      #     content_tag(:strong, 'Ask me!')
+      #   end
+      #   # => <button name='button' type='submit'>
+      #   #      <strong>Ask me!</strong>
+      #   #    </button>
+      #
+      def button: (?untyped? value, ?::Hash[untyped, untyped] options) ?{ () -> untyped } -> untyped
+
+      # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). The text of label will default to the attribute name unless a translation
+      # is found in the current I18n locale (through helpers.label.<modelname>.<attribute>) or you specify it explicitly.
+      # Additional options on the label tag can be passed as a hash with +options+. These options will be tagged
+      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:value</tt> option, which is designed to
+      # target labels for radio_button tags (where the value is used in the ID of the input tag).
+      #
+      # ==== Examples
+      #   label(:title)
+      #   # => <label for="post_title">Title</label>
+      #
+      # You can localize your labels based on model and attribute names.
+      # For example you can define the following in your locale (e.g. en.yml)
+      #
+      #   helpers:
+      #     label:
+      #       post:
+      #         body: "Write your entire text here"
+      #
+      # Which then will result in
+      #
+      #   label(:body)
+      #   # => <label for="post_body">Write your entire text here</label>
+      #
+      # Localization can also be based purely on the translation of the attribute-name
+      # (if you are using ActiveRecord):
+      #
+      #   activerecord:
+      #     attributes:
+      #       post:
+      #         cost: "Total cost"
+      #
+      #   label(:cost)
+      #   # => <label for="post_cost">Total cost</label>
+      #
+      #   label(:title, "A short title")
+      #   # => <label for="post_title">A short title</label>
+      #
+      #   label(:title, "A short title", class: "title_label")
+      #   # => <label for="post_title" class="title_label">A short title</label>
+      #
+      #   label(:privacy, "Public Post", value: "public")
+      #   # => <label for="post_privacy_public">Public Post</label>
+      #
+      #   label(:terms) do
+      #     raw('Accept <a href="/terms">Terms</a>.')
+      #   end
+      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
+      def label: (untyped method, ?untyped? text, ?::Hash[untyped, untyped] options) ?{ () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module FormHelper
+      # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). The text of label will default to the attribute name unless a translation
+      # is found in the current I18n locale (through helpers.label.<modelname>.<attribute>) or you specify it explicitly.
+      # Additional options on the label tag can be passed as a hash with +options+. These options will be tagged
+      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:value</tt> option, which is designed to
+      # target labels for radio_button tags (where the value is used in the ID of the input tag).
+      #
+      # ==== Examples
+      #   label(:post, :title)
+      #   # => <label for="post_title">Title</label>
+      #
+      # You can localize your labels based on model and attribute names.
+      # For example you can define the following in your locale (e.g. en.yml)
+      #
+      #   helpers:
+      #     label:
+      #       post:
+      #         body: "Write your entire text here"
+      #
+      # Which then will result in
+      #
+      #   label(:post, :body)
+      #   # => <label for="post_body">Write your entire text here</label>
+      #
+      # Localization can also be based purely on the translation of the attribute-name
+      # (if you are using ActiveRecord):
+      #
+      #   activerecord:
+      #     attributes:
+      #       post:
+      #         cost: "Total cost"
+      #
+      #   label(:post, :cost)
+      #   # => <label for="post_cost">Total cost</label>
+      #
+      #   label(:post, :title, "A short title")
+      #   # => <label for="post_title">A short title</label>
+      #
+      #   label(:post, :title, "A short title", class: "title_label")
+      #   # => <label for="post_title" class="title_label">A short title</label>
+      #
+      #   label(:post, :privacy, "Public Post", value: "public")
+      #   # => <label for="post_privacy_public">Public Post</label>
+      #
+      #   label(:post, :terms) do
+      #     raw('Accept <a href="/terms">Terms</a>.')
+      #   end
+      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
+      def label: (untyped object_name, untyped method, ?untyped? content_or_options, ?untyped? options) ?{ () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
     module UrlHelper
       # Creates an anchor element of the given +name+ using a URL created by the set of +options+.
       # See the valid options in the documentation for +url_for+. It's also possible to


### PR DESCRIPTION
Split from #735 to be smaller. Type signature updates for invalid signatures in actionview, due to blocks being marked as required, but they should be optional.