### PR TITLE
activemodel: signature updates

### DIFF
--- a/gems/activemodel/6.0/activemodel-6.0.rbs
+++ b/gems/activemodel/6.0/activemodel-6.0.rbs
@@ -1,0 +1,10 @@
+module ActiveModel
+  class Errors
+    # Delete messages for +key+. Returns the deleted messages.
+    #
+    #   person.errors[:name]        # => ["cannot be nil"]
+    #   person.errors.delete(:name) # => ["cannot be nil"]
+    #   person.errors[:name]        # => []
+    def delete: (untyped key) -> untyped
+  end
+end

--- a/gems/activemodel/6.0/activemodel-generated.rbs
+++ b/gems/activemodel/6.0/activemodel-generated.rbs
@@ -1411,13 +1411,6 @@ module ActiveModel
 
     alias key? include?
 
-    # Delete messages for +key+. Returns the deleted messages.
-    #
-    #   person.errors[:name]        # => ["cannot be nil"]
-    #   person.errors.delete(:name) # => ["cannot be nil"]
-    #   person.errors[:name]        # => []
-    def delete: (untyped key) -> untyped
-
     # When passed a symbol or a name of a method, returns an array of errors
     # for the method.
     #

--- a/gems/activemodel/6.0/activemodel-generated.rbs
+++ b/gems/activemodel/6.0/activemodel-generated.rbs
@@ -2901,9 +2901,6 @@ module ActiveModel
   module Type
     attr_accessor self.registry: untyped
 
-    # Add a new type to the registry, allowing it to be gotten through ActiveModel::Type#lookup
-    def self.register: (untyped type_name, ?untyped? klass, **untyped options) { () -> untyped } -> untyped
-
     def self.lookup: (*untyped args, **untyped kwargs) -> untyped
 
     def self.default_value: () -> untyped

--- a/gems/activemodel/6.0/activemodel.rbs
+++ b/gems/activemodel/6.0/activemodel.rbs
@@ -367,6 +367,13 @@ module ActiveModel
 end
 
 module ActiveModel
+  module Type
+    # Add a new type to the registry, allowing it to be gotten through ActiveModel::Type#lookup
+    def self.register: (untyped type_name, ?untyped? klass, **untyped options) ?{ () -> untyped } -> untyped
+  end
+end
+
+module ActiveModel
   module Validations
     module ClassMethods
       # This method is a shortcut to all default validators and any custom

--- a/gems/activemodel/7.0/activemodel-7.0.rbs
+++ b/gems/activemodel/7.0/activemodel-7.0.rbs
@@ -42,3 +42,14 @@ module ActiveModel
     def strict_match?: (Symbol | String attribute, (Symbol | String)? type, **untyped options) -> bool
   end
 end
+
+module ActiveModel
+  class Errors
+    # Delete messages for +key+. Returns the deleted messages.
+    #
+    #   person.errors[:name]        # => ["cannot be nil"]
+    #   person.errors.delete(:name) # => ["cannot be nil"]
+    #   person.errors[:name]        # => []
+    def delete: (untyped key, ?untyped type, **untyped) -> untyped
+  end
+end

--- a/gems/activemodel/7.1/activemodel-7.1.rbs
+++ b/gems/activemodel/7.1/activemodel-7.1.rbs
@@ -52,6 +52,17 @@ module ActiveModel
 end
 
 module ActiveModel
+  class Errors
+    # Delete messages for +key+. Returns the deleted messages.
+    #
+    #   person.errors[:name]        # => ["cannot be nil"]
+    #   person.errors.delete(:name) # => ["cannot be nil"]
+    #   person.errors[:name]        # => []
+    def delete: (untyped key, ?untyped type, **untyped) -> untyped
+  end
+end
+
+module ActiveModel
   module Model
     include ActiveModel::Access
   end


### PR DESCRIPTION
Split from #735 to be smaller. Type signature updates for invalid signatures in activemodel, one is due to the block being marked as required, but it should be optional. The other (`delete`) is updated to match the method declaration (see https://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-delete).