### PR TITLE
activerecord: signature updates

### DIFF
--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -17349,66 +17349,6 @@ module ActiveRecord
   module Batches
     ORDER_IGNORE_MESSAGE: ::String
 
-    # Looping through a collection of records from the database
-    # (using the Scoping::Named::ClassMethods.all method, for example)
-    # is very inefficient since it will try to instantiate all the objects at once.
-    #
-    # In that case, batch processing methods allow you to work
-    # with the records in batches, thereby greatly reducing memory consumption.
-    #
-    # The #find_each method uses #find_in_batches with a batch size of 1000 (or as
-    # specified by the +:batch_size+ option).
-    #
-    #   Person.find_each do |person|
-    #     person.do_awesome_stuff
-    #   end
-    #
-    #   Person.where("age > 21").find_each do |person|
-    #     person.party_all_night!
-    #   end
-    #
-    # If you do not provide a block to #find_each, it will return an Enumerator
-    # for chaining with other methods:
-    #
-    #   Person.find_each.with_index do |person, index|
-    #     person.award_trophy(index + 1)
-    #   end
-    #
-    # ==== Options
-    # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
-    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
-    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
-    # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
-    #   an order is present in the relation.
-    #
-    # Limits are honored, and if present there is no requirement for the batch
-    # size: it can be less than, equal to, or greater than the limit.
-    #
-    # The options +start+ and +finish+ are especially useful if you want
-    # multiple workers dealing with the same processing queue. You can make
-    # worker 1 handle all the records between id 1 and 9999 and worker 2
-    # handle from 10000 and beyond by setting the +:start+ and +:finish+
-    # option on each worker.
-    #
-    #   # In worker 1, let's process until 9999 records.
-    #   Person.find_each(finish: 9_999) do |person|
-    #     person.party_all_night!
-    #   end
-    #
-    #   # In worker 2, let's process from record 10_000 and onwards.
-    #   Person.find_each(start: 10_000) do |person|
-    #     person.party_all_night!
-    #   end
-    #
-    # NOTE: It's not possible to set the order. That is automatically set to
-    # ascending on the primary key ("id ASC") to make the batch ordering
-    # work. This also means that this method only works when the primary key is
-    # orderable (e.g. an integer or string).
-    #
-    # NOTE: By its nature, batch processing is subject to race conditions if
-    # other processes are modifying the database.
-    def find_each: (?error_on_ignore: untyped? error_on_ignore, ?batch_size: ::Integer batch_size, ?finish: untyped? finish, ?start: untyped? start) { (untyped) -> untyped } -> untyped
-
     # Yields each batch of records that was found by the find options as
     # an array.
     #

--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -16104,8 +16104,6 @@ module ActiveRecord
     def no_touching?: () -> untyped
 
     def touch_later: () -> untyped
-
-    def touch: () -> untyped
   end
 end
 

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -954,3 +954,9 @@ module ActiveRecord
     end
   end
 end
+
+module ActiveRecord
+  module NoTouching
+    def touch: (*untyped, **untyped) -> untyped
+  end
+end

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -402,6 +402,7 @@ module ActiveRecord
       def offset: (Integer) -> self
       def offset!: (Integer) -> self
       def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+                   | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
       def sum: (?untyped? column_name) -> Integer
@@ -493,6 +494,7 @@ module ActiveRecord
       def offset: (Integer) -> Relation
       def lock: (?untyped locks) -> Relation
       def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+                   | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
       def sum: (?untyped? column_name) -> Integer
@@ -510,6 +512,70 @@ module ActiveRecord
               | () { (Model) -> boolish } -> ::Integer
               | (Symbol | String column_name) -> ::Integer
     end
+  end
+end
+
+module ActiveRecord
+  module Batches
+    # Looping through a collection of records from the database
+    # (using the Scoping::Named::ClassMethods.all method, for example)
+    # is very inefficient since it will try to instantiate all the objects at once.
+    #
+    # In that case, batch processing methods allow you to work
+    # with the records in batches, thereby greatly reducing memory consumption.
+    #
+    # The #find_each method uses #find_in_batches with a batch size of 1000 (or as
+    # specified by the +:batch_size+ option).
+    #
+    #   Person.find_each do |person|
+    #     person.do_awesome_stuff
+    #   end
+    #
+    #   Person.where("age > 21").find_each do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    # If you do not provide a block to #find_each, it will return an Enumerator
+    # for chaining with other methods:
+    #
+    #   Person.find_each.with_index do |person, index|
+    #     person.award_trophy(index + 1)
+    #   end
+    #
+    # ==== Options
+    # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
+    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
+    #   an order is present in the relation.
+    #
+    # Limits are honored, and if present there is no requirement for the batch
+    # size: it can be less than, equal to, or greater than the limit.
+    #
+    # The options +start+ and +finish+ are especially useful if you want
+    # multiple workers dealing with the same processing queue. You can make
+    # worker 1 handle all the records between id 1 and 9999 and worker 2
+    # handle from 10000 and beyond by setting the +:start+ and +:finish+
+    # option on each worker.
+    #
+    #   # In worker 1, let's process until 9999 records.
+    #   Person.find_each(finish: 9_999) do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    #   # In worker 2, let's process from record 10_000 and onwards.
+    #   Person.find_each(start: 10_000) do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    # NOTE: It's not possible to set the order. That is automatically set to
+    # ascending on the primary key ("id ASC") to make the batch ordering
+    # work. This also means that this method only works when the primary key is
+    # orderable (e.g. an integer or string).
+    #
+    # NOTE: By its nature, batch processing is subject to race conditions if
+    # other processes are modifying the database.
+    def find_each: (?error_on_ignore: untyped? error_on_ignore, ?batch_size: ::Integer batch_size, ?finish: untyped? finish, ?start: untyped? start) ?{ (untyped) -> untyped } -> untyped
   end
 end
 
@@ -578,6 +644,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey]
   def offset: (Integer) -> self
   def offset!: (Integer) -> self
   def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+               | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
   def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
   def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
   def sum: (?untyped? column_name) -> Integer
@@ -667,6 +734,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def offset: (Integer) -> Relation
   def lock: (?untyped locks) -> Relation
   def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+               | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
   def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
   def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
   def sum: (?untyped? column_name) -> Integer


### PR DESCRIPTION
Split from #735 to be smaller. Type signature updates for invalid signatures in activerecord, the majority are due to blocks being marked as required, but they should be optional. Another update for `NoTouching#touch` to match its declaration (see [    def touch(*, **) # :nodoc:](https://github.com/rails/rails/blob/dd8f7185faeca6ee968a6e9367f6d8601a83b8db/activerecord/lib/active_record/no_touching.rb#L61)).