### PR TITLE
railties: signature updates

### DIFF
--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -1997,10 +1997,6 @@ module Rails
     # Defines additional Rack env configuration that is added on each call.
     def env_config: () -> untyped
 
-    # Defines the routes for this engine. If a block is given to
-    # routes, it is appended to the engine.
-    def routes: () { () -> untyped } -> untyped
-
     # Define the configuration object for the engine.
     def config: () -> untyped
 

--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -1434,12 +1434,6 @@ module Rails
     class MiddlewareStackProxy
       def initialize: (?untyped operations, ?untyped delete_operations) -> untyped
 
-      def insert_before: (*untyped args) { () -> untyped } -> untyped
-
-      alias insert insert_before
-
-      def insert_after: (*untyped args) { () -> untyped } -> untyped
-
       def swap: (*untyped args) { () -> untyped } -> untyped
 
       def use: (*untyped args) { () -> untyped } -> untyped

--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -1436,8 +1436,6 @@ module Rails
 
       def swap: (*untyped args) { () -> untyped } -> untyped
 
-      def use: (*untyped args) { () -> untyped } -> untyped
-
       def delete: (*untyped args) { () -> untyped } -> untyped
 
       def unshift: (*untyped args) { () -> untyped } -> untyped

--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -1434,12 +1434,6 @@ module Rails
     class MiddlewareStackProxy
       def initialize: (?untyped operations, ?untyped delete_operations) -> untyped
 
-      def swap: (*untyped args) { () -> untyped } -> untyped
-
-      def delete: (*untyped args) { () -> untyped } -> untyped
-
-      def unshift: (*untyped args) { () -> untyped } -> untyped
-
       def merge_into: (untyped other) -> untyped
 
       def +: (untyped other) -> MiddlewareStackProxy

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -1,11 +1,17 @@
 module Rails
   module Configuration
     class MiddlewareStackProxy
+      def delete: (*untyped args) ?{ () -> untyped } -> untyped
+
       def insert_before: (*untyped args) ?{ () -> untyped } -> untyped
 
       alias insert insert_before
 
       def insert_after: (*untyped args) ?{ () -> untyped } -> untyped
+
+      def swap: (*untyped args) ?{ () -> untyped } -> untyped
+
+      def unshift: (*untyped args) ?{ () -> untyped } -> untyped
 
       def use: (*untyped args) ?{ () -> untyped } -> untyped
     end

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -13,6 +13,14 @@ module Rails
 end
 
 module Rails
+  class Engine
+    # Defines the routes for this engine. If a block is given to
+    # routes, it is appended to the engine.
+    def routes: () ?{ () -> untyped } -> untyped
+  end
+end
+
+module Rails
   module Generators
     class PluginGenerator < AppBase
       # It is necessary to satisfy alias target.

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -6,6 +6,8 @@ module Rails
       alias insert insert_before
 
       def insert_after: (*untyped args) ?{ () -> untyped } -> untyped
+
+      def use: (*untyped args) ?{ () -> untyped } -> untyped
     end
   end
 end

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -1,4 +1,16 @@
 module Rails
+  module Configuration
+    class MiddlewareStackProxy
+      def insert_before: (*untyped args) ?{ () -> untyped } -> untyped
+
+      alias insert insert_before
+
+      def insert_after: (*untyped args) ?{ () -> untyped } -> untyped
+    end
+  end
+end
+
+module Rails
   module Generators
     class PluginGenerator < AppBase
       # It is necessary to satisfy alias target.


### PR DESCRIPTION
Split from #735 to be smaller. Type signature updates for invalid signatures in railties, due to blocks being marked as required, but they should be optional.