### PR TITLE
Add a string type to the `lock` method arguments

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
   validates :age, presence: true, if: ->(user) { user.something }
 
   scope :matured, -> { where(arel_table[:age].gteq(18)) }
+  scope :nowait, -> { lock("FOR UPDATE NOWAIT") }
 
   before_save -> (obj) { obj.something; self.something }
   around_save -> (obj, block) { block.call; obj.something }

--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -18818,9 +18818,9 @@ module ActiveRecord
 
     # Specifies locking settings (default to +true+). For more information
     # on locking, please see ActiveRecord::Locking.
-    def lock: (?bool locks) -> untyped
+    def lock: (?(bool|String) locks) -> untyped
 
-    def lock!: (?bool locks) -> untyped
+    def lock!: (?(bool|String) locks) -> untyped
 
     # Returns a chainable relation with zero records.
     #


### PR DESCRIPTION
The `lock` method accepts a string value as well as a boolean value.

```ruby
Account.lock("FOR UPDATE NOWAIT").find_by(name: "shugo")
```

This behavior remains the same in v6.0.x.

refs:

* https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/locking/pessimistic.rb
* https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/query_methods.rb#L757-L770
