### PR TITLE
actionview: Fix typo in module name: CaptureHelper

### DIFF
--- a/gems/actionview/6.0/actionview.rbs
+++ b/gems/actionview/6.0/actionview.rbs
@@ -1,6 +1,6 @@
 module ActionView
   module Helpers
-    module CaptionHelper
+    module CaptureHelper
       # Calling <tt>content_for</tt> stores a block of markup in an identifier for later use.
       # In order to access this stored content in other templates, helper modules
       # or the layout, you would pass the identifier as an argument to <tt>content_for</tt>.


### PR DESCRIPTION
Fix typo in the module name: s/CaptionHelper/CaptureHelper/.

This typo was added in https://github.com/ruby/gem_rbs_collection/pull/728.