### PR TITLE
activerecord: Add types for strict_loading

### DIFF
--- a/gems/activerecord/6.1/_test/activerecord-6.1.rb
+++ b/gems/activerecord/6.1/_test/activerecord-6.1.rb
@@ -7,3 +7,7 @@ user.articles.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by
 user.articles.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
 user.values_at(:name, :age)
 user.values_at("name", :age)
+User.strict_loading
+User.strict_loading(false)
+user.strict_loading!
+user.strict_loading?

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -4,10 +4,16 @@ module ActiveRecord
       def delegated_type: (Symbol role, types: Array[String], **untyped options) -> void
     end
     extend DelegatedType
+
+    module ClassMethods[Model, Relation, PrimaryKey]
+      def strict_loading: (?bool value) -> Relation
+    end
   end
 
   module Core
     def values_at: (*Symbol | String) -> Array[untyped]
+    def strict_loading!: () -> bool
+    def strict_loading?: () -> bool
   end
 
   class AssociationRelation

--- a/gems/activerecord/7.0/_test/test.rb
+++ b/gems/activerecord/7.0/_test/test.rb
@@ -34,6 +34,8 @@ module Test
   User.insert_all!([{ id: 1, name: 'James' }], returning: %i[id name], record_timestamps: true)
   User.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
   User.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
+  User.strict_loading
+  User.strict_loading(false)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)
@@ -47,4 +49,7 @@ module Test
   user.articles.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
   user.values_at(:name, :age)
   user.values_at("name", :age)
+  user.strict_loading!
+  user.strict_loading!(false, mode: :n_plus_one_only)
+  user.strict_loading?
 end

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -2,10 +2,16 @@ module ActiveRecord
   class Base
     include Encryption::EncryptableRecord
     extend Encryption::EncryptableRecord::ClassMethods
+
+    module ClassMethods[Model, Relation, PrimaryKey]
+      def strict_loading: (?bool value) -> Relation
+    end
   end
 
   module Core
     def values_at: (*Symbol | String) -> Array[untyped]
+    def strict_loading!: (?bool value, ?mode: Symbol) -> bool
+    def strict_loading?: () -> bool
   end
 
   class AssociationRelation

--- a/gems/activerecord/7.1/_test/test.rb
+++ b/gems/activerecord/7.1/_test/test.rb
@@ -42,6 +42,8 @@ module Test
   User.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
   User.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
   User.with(admin_users: User.where(role: 0))
+  User.strict_loading
+  User.strict_loading(false)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)
@@ -56,6 +58,9 @@ module Test
   user.generate_token_for(:password_reset)
   user.values_at(:name, :age)
   user.values_at("name", :age)
+  user.strict_loading!
+  user.strict_loading!(false, mode: :n_plus_one_only)
+  user.strict_loading?
 
   user = User.new
   user.normalize_attribute(:email)

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -8,10 +8,16 @@ module ActiveRecord
     extend SecurePassword::ClassMethods
     include TokenFor
     extend TokenFor::ClassMethods
+
+    module ClassMethods[Model, Relation, PrimaryKey]
+      def strict_loading: (?bool value) -> Relation
+    end
   end
 
   module Core
     def values_at: (*Symbol | String) -> Array[untyped]
+    def strict_loading!: (?bool value, ?mode: Symbol) -> bool
+    def strict_loading?: () -> bool
   end
 
   class AssociationRelation

--- a/gems/activerecord/7.2/_test/test.rb
+++ b/gems/activerecord/7.2/_test/test.rb
@@ -40,6 +40,8 @@ module Test
   User.upsert({ id: 1, name: 'James' }, returning: %i[id name], unique_by: :id, record_timestamps: true)
   User.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
   User.with(admin_users: User.where(role: 0))
+  User.strict_loading
+  User.strict_loading(false)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)
@@ -54,6 +56,9 @@ module Test
   user.generate_token_for(:password_reset)
   user.values_at(:name, :age)
   user.values_at("name", :age)
+  user.strict_loading!
+  user.strict_loading!(false, mode: :n_plus_one_only)
+  user.strict_loading?
 
   user = User.new
   user.normalize_attribute(:email)

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -8,10 +8,16 @@ module ActiveRecord
     extend SecurePassword::ClassMethods
     include TokenFor
     extend TokenFor::ClassMethods
+
+    module ClassMethods[Model, Relation, PrimaryKey]
+      def strict_loading: (?bool value) -> Relation
+    end
   end
 
   module Core
     def values_at: (*Symbol | String) -> Array[untyped]
+    def strict_loading!: (?bool value, ?mode: Symbol) -> bool
+    def strict_loading?: () -> bool
   end
 
   class Relation


### PR DESCRIPTION
Add types for below three methods.

- strict_loading(value = true)
  - https://api.rubyonrails.org/v6.1.7.3/classes/ActiveRecord/QueryMethods.html#method-i-strict_loading
- strict_loading?()
  - https://api.rubyonrails.org/v6.1.7.3/classes/ActiveRecord/Core.html#method-i-strict_loading-3F
- strict_loading!()
  - https://api.rubyonrails.org/v6.1.7.3/classes/ActiveRecord/Core.html#method-i-strict_loading-21

Arguments have been added to strict_loading! since 7.0.

- up to 6.1
  - https://api.rubyonrails.org/v6.1.7.3/classes/ActiveRecord/Core.html#method-i-strict_loading-21
- since 7.0
  - https://api.rubyonrails.org/v7.0/classes/ActiveRecord/Core.html#method-i-strict_loading-21

This methods have been added since 6.1.

https://github.com/rails/rails/pull/37400