### PR TITLE
activerecord: Add types for create_with to singleton that inherited activerecord base

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -38,6 +38,8 @@ User.preload(:address, friends: [:address, { followers: :users }]) # steep:ignor
 User.in_order_of(:id, [1, 5, 3])
 User.offset(5).limit(10)
 User.count
+User.create_with(name: 'name', age: 1)
+User.create_with(nil)
 
 t = User.arel_table
 User.limit(10).select(:id, "name", t[:age].as("years"), t[:email])

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -515,6 +515,7 @@ module ActiveRecord
       def count: () -> ::Integer
               | () { (Model) -> boolish } -> ::Integer
               | (Symbol | String column_name) -> ::Integer
+      def create_with: (nil | Hash[untyped, untyped]) -> Relation
     end
   end
 end
@@ -755,6 +756,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey]
   def count: () -> ::Integer
           | () { (Model) -> boolish } -> ::Integer
           | (Symbol | String column_name) -> ::Integer
+  def create_with: (nil | Hash[untyped, untyped]) -> Relation
 end
 
 module Arel

--- a/gems/activerecord/6.1/_test/activerecord-6.1.rb
+++ b/gems/activerecord/6.1/_test/activerecord-6.1.rb
@@ -11,3 +11,5 @@ User.strict_loading
 User.strict_loading(false)
 user.strict_loading!
 user.strict_loading?
+User.create_with(secret: 'secret', key: 'key')
+User.create_with(nil)

--- a/gems/activerecord/7.0/_test/test.rb
+++ b/gems/activerecord/7.0/_test/test.rb
@@ -36,6 +36,8 @@ module Test
   User.upsert_all([{ id: 1, name: 'James' }], returning: %i[id name], unique_by: :id, record_timestamps: true)
   User.strict_loading
   User.strict_loading(false)
+  User.create_with(name: 'name', age: 1)
+  User.create_with(nil)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)

--- a/gems/activerecord/7.1/_test/test.rb
+++ b/gems/activerecord/7.1/_test/test.rb
@@ -44,6 +44,8 @@ module Test
   User.with(admin_users: User.where(role: 0))
   User.strict_loading
   User.strict_loading(false)
+  User.create_with(name: 'name', age: 1)
+  User.create_with(nil)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)

--- a/gems/activerecord/7.2/_test/test.rb
+++ b/gems/activerecord/7.2/_test/test.rb
@@ -42,6 +42,8 @@ module Test
   User.with(admin_users: User.where(role: 0))
   User.strict_loading
   User.strict_loading(false)
+  User.create_with(name: 'name', age: 1)
+  User.create_with(nil)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)


### PR DESCRIPTION
Singleton that inherited activerecord base can handle create_with method.

https://github.com/rails/rails/blob/6df15e25c875e9c1ee39acb0bc161b6c47531331/activerecord/test/cases/scoping/relation_scoping_test.rb#L499-L507

- create_with
  - https://api.rubyonrails.org/v6.0.6.1/classes/ActiveRecord/QueryMethods.html#method-i-create_with