### PR TITLE
rake: Support task arguments and `sh` with env hash

### DIFF
--- a/gems/rake/13.0/_test/test.rb
+++ b/gems/rake/13.0/_test/test.rb
@@ -10,5 +10,16 @@ class Task < Rake::TaskLib
     task :test do
       ruby "test/unittest.rb"
     end
+
+    task :test_with_1_arg, :name do |t, args|
+      value = args[:name]
+      puts "#{args[:name]}=#{value}"
+    end
+
+    task :test_with_2_args, %i[name1 name2] do |t, args|
+      args.each do |name, value|
+        puts "#{name}=#{value}"
+      end
+    end
   end
 end

--- a/gems/rake/13.0/_test/test.rb
+++ b/gems/rake/13.0/_test/test.rb
@@ -21,5 +21,12 @@ class Task < Rake::TaskLib
         puts "#{name}=#{value}"
       end
     end
+
+    task :test_with_sh do
+      sh "ruby test/unittest_without_env.rb"
+
+      env = { "RACK_ENV" => "test" }
+      sh env, "ruby test/unittest_with_env.rb"
+    end
   end
 end

--- a/gems/rake/13.0/rake.rbs
+++ b/gems/rake/13.0/rake.rbs
@@ -3,6 +3,16 @@ module Rake
     include Rake::DSL
   end
 
+  class Task
+  end
+
+  class TaskArguments
+    include Enumerable[untyped]
+
+    def []: (untyped index) -> untyped
+    def each: () ?{ (untyped, untyped) -> void } -> void
+  end
+
   module DSL
     private
 
@@ -16,7 +26,7 @@ module Rake
     def multitask: (*untyped args) ?{ () -> void } -> void
     def namespace: (?untyped name) ?{ () -> void } -> void
     def rule: (*untyped args) ?{ () -> void } -> void
-    def task: (*untyped args) ?{ () -> void } -> void
+    def task: (*untyped args) ?{ (Rake::Task, Rake::TaskArguments) -> void } -> void
   end
 end
 

--- a/gems/rake/13.0/rake.rbs
+++ b/gems/rake/13.0/rake.rbs
@@ -32,6 +32,7 @@ end
 
 module FileUtils
   def sh: (*String cmd, **untyped options) ?{ (bool, Process::Status) -> void } -> void
+    | (Hash[String, String] env, *String cmd, **untyped options) ?{ (bool, Process::Status) -> void } -> void
   def ruby: (*String args, **untyped options) ?{ (bool, Process::Status) -> void } -> void
   def safe_ln: (*untyped args, **untyped options) -> void
   def split_all: (String path) -> Array[String]


### PR DESCRIPTION
This patch 2 changes to `rake`

1. Support rake task arguments within `task` block
2. Support env hash to `FileUtils#sh` in rake
