### PR TITLE
Enable rubocop-on-rbs to activestorage

### DIFF
--- a/gems/activestorage/.rubocop.yml
+++ b/gems/activestorage/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from: ../../.rubocop.yml
+
+RBS/Layout:
+  Enabled: true
+RBS/Lint:
+  Enabled: true
+RBS/Style:
+  Enabled: true

--- a/gems/activestorage/6.1/lib/attached/model.rbs
+++ b/gems/activestorage/6.1/lib/attached/model.rbs
@@ -47,7 +47,7 @@ module ActiveStorage
       def has_one_attached: (
         (::String | ::Symbol) name,
         ?dependent: ::Symbol dependent,
-        ?service: (::String | ::Symbol| nil) service,
+        ?service: (::String | ::Symbol | nil) service,
         ?strict_loading: bool strict_loading
       ) -> void
 
@@ -93,7 +93,7 @@ module ActiveStorage
       def has_many_attached: (
         (::String | ::Symbol) name,
         ?dependent: ::Symbol dependent,
-        ?service: (::String | ::Symbol| nil) service,
+        ?service: (::String | ::Symbol | nil) service,
         ?strict_loading: bool strict_loading
       ) -> void
     end


### PR DESCRIPTION
```
Offenses:

gems/activestorage/6.1/lib/attached/model.rbs:50:39: C: [Corrected] RBS/Layout/SpaceAroundOperators: Use one space before |.
        ?service: (::String | ::Symbol| nil) service,
                                      ^
gems/activestorage/6.1/lib/attached/model.rbs:96:39: C: [Corrected] RBS/Layout/SpaceAroundOperators: Use one space before |.
        ?service: (::String | ::Symbol| nil) service,
                                      ^

632 files inspected, 2 offenses detected, 2 offenses corrected
```