### PR TITLE
Enable rubocop to actionpack

### DIFF
--- a/gems/actionpack/.rubocop.yml
+++ b/gems/actionpack/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from: ../../.rubocop.yml
+
+RBS/Layout:
+  Enabled: true
+RBS/Lint:
+  Enabled: true
+RBS/Style:
+  Enabled: true

--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -145,13 +145,13 @@ module AbstractController::Callbacks::ClassMethods
   type after_action_callback[T] = Symbol | ^(T controller) [self: T] -> void | _AfterActionCallback
 
   def before_action: (*before_action_callback[instance], ?if: before_action_callback[instance], ?unless: before_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
-  def around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
+  def around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller, ^() -> void) [self: instance] -> void } -> void
   def after_action: (*after_action_callback[instance], ?if: after_action_callback[instance], ?unless: after_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
   def skip_before_action: (*before_action_callback[instance], ?if: before_action_callback[instance], ?unless: before_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
-  def skip_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
+  def skip_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller, ^() -> void) [self: instance] -> void } -> void
   def skip_after_action: (*after_action_callback[instance], ?if: after_action_callback[instance], ?unless: after_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
   def prepend_before_action: (*before_action_callback[instance], ?if: before_action_callback[instance], ?unless: before_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
-  def prepend_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
+  def prepend_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller, ^() -> void) [self: instance] -> void } -> void
   def prepend_after_action: (*after_action_callback[instance], ?if: after_action_callback[instance], ?unless: after_action_callback[instance], **untyped) ?{ (instance controller) [self: instance] -> void } -> void
 
   alias append_before_action before_action
@@ -176,7 +176,7 @@ module ActionController
     def include?: (untyped key) -> bool
     def as_json: () -> String
     def to_s: () -> String
-    def each_key: () { (untyped) -> untyped} -> Hash[untyped, untyped]
+    def each_key: () { (untyped) -> untyped } -> Hash[untyped, untyped]
                 | () -> Enumerator[untyped, self]
     def fetch: (untyped key, *untyped args) ?{ () -> untyped } -> untyped
   end

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -140,7 +140,7 @@ module AbstractController
     # a path. A subclass of +AbstractController::Base+
     # may return false. An Email controller for example does not
     # support paths, only full URLs.
-    def self.supports_path?: () -> ::TrueClass
+    def self.supports_path?: () -> true
 
     private
 
@@ -1502,7 +1502,7 @@ module ActionController
     #   render
     #
     # See Rack::Utils::SYMBOL_TO_STATUS_CODE for a full list of valid +status+ symbols.
-    def head: (untyped status, ?::Hash[untyped, untyped] options) -> ::TrueClass
+    def head: (untyped status, ?::Hash[untyped, untyped] options) -> true
 
     private
 
@@ -1762,7 +1762,7 @@ module ActionController
       # Returns false unless the request credentials response value matches the expected value.
       # First try the password as a ha1 digest password. If this fails, then try it as a plain
       # text password.
-      def validate_digest_response: (untyped request, untyped realm) { () -> untyped } -> (::FalseClass | untyped)
+      def validate_digest_response: (untyped request, untyped realm) { () -> untyped } -> (false | untyped)
 
       # Returns the expected response for a request of +http_method+ to +uri+ with the decoded +credentials+ and the expected +password+
       # Optional parameter +password_is_ha1+ is set to +true+ by default, since best practice is to store ha1 digest instead
@@ -1822,7 +1822,7 @@ module ActionController
       # Can be much shorter if the Stale directive is implemented. This would
       # allow a user to use new nonce without prompting the user again for their
       # username and password.
-      def validate_nonce: (untyped secret_key, untyped request, untyped value, ?untyped seconds_to_timeout) -> (::FalseClass | untyped)
+      def validate_nonce: (untyped secret_key, untyped request, untyped value, ?untyped seconds_to_timeout) -> (false | untyped)
 
       # Opaque based on digest of secret key
       def opaque: (untyped secret_key) -> untyped
@@ -2511,7 +2511,7 @@ module ActionController
     def _extract_parameters: (untyped parameters) -> untyped
 
     # Checks if we should perform parameters wrapping.
-    def _wrapper_enabled?: () -> (::FalseClass | untyped)
+    def _wrapper_enabled?: () -> (false | untyped)
 
     def _perform_parameter_wrapping: () -> untyped
   end
@@ -2901,7 +2901,7 @@ module ActionController
           # no-op
           def destroy: () -> nil
 
-          def exists?: () -> ::TrueClass
+          def exists?: () -> true
         end
 
         class NullCookieJar < ActionDispatch::Cookies::CookieJar
@@ -2953,7 +2953,7 @@ module ActionController
 
     def masked_authenticity_token: (untyped session, ?form_options: ::Hash[untyped, untyped] form_options) -> untyped
 
-    def valid_authenticity_token?: (untyped session, untyped encoded_masked_token) -> (::FalseClass | untyped)
+    def valid_authenticity_token?: (untyped session, untyped encoded_masked_token) -> (false | untyped)
 
     def unmask_token: (untyped masked_token) -> untyped
 
@@ -3004,7 +3004,7 @@ module ActionController
     # +consider_all_requests_local+ is +false+. By default, it returns
     # +false+, but someone may set it to <tt>request.local?</tt> so local
     # requests in production still show the detailed exception pages.
-    def show_detailed_exceptions?: () -> ::FalseClass
+    def show_detailed_exceptions?: () -> false
 
     private
 
@@ -3995,7 +3995,7 @@ module ActionController
 
     def self.make_response!: (untyped request) -> untyped
 
-    def self.binary_params_for?: (untyped action) -> ::FalseClass
+    def self.binary_params_for?: (untyped action) -> false
 
     # Delegates to the class' <tt>controller_name</tt>.
     def controller_name: () -> untyped
@@ -4211,7 +4211,7 @@ module ActionController
 
     def initialize: (?::Hash[untyped, untyped] session) -> untyped
 
-    def exists?: () -> ::TrueClass
+    def exists?: () -> true
 
     def keys: () -> untyped
 
@@ -4490,7 +4490,7 @@ module ActionDispatch
         # Check response freshness (Last-Modified and ETag) against request
         # If-Modified-Since and If-None-Match conditions. If both headers are
         # supplied, both must match, or the request is not considered fresh.
-        def fresh?: (untyped response) -> (::FalseClass | untyped)
+        def fresh?: (untyped response) -> (false | untyped)
       end
 
       module Response
@@ -5055,15 +5055,15 @@ module Mime
 
     def ===: (untyped list) -> untyped
 
-    def ==: (untyped mime_type) -> (::FalseClass | untyped)
+    def ==: (untyped mime_type) -> (false | untyped)
 
     def eql?: (untyped other) -> untyped
 
-    def =~: (untyped mime_type) -> (::FalseClass | untyped)
+    def =~: (untyped mime_type) -> (false | untyped)
 
     def html?: () -> untyped
 
-    def all?: () -> ::FalseClass
+    def all?: () -> false
 
     attr_reader string: untyped
 
@@ -5085,9 +5085,9 @@ module Mime
 
     def initialize: () -> untyped
 
-    def all?: () -> ::TrueClass
+    def all?: () -> true
 
-    def html?: () -> ::TrueClass
+    def html?: () -> true
   end
 
   # ALL isn't a real MIME type, so we don't register it for lookup with the
@@ -5098,7 +5098,7 @@ module Mime
   class NullType
     include Singleton
 
-    def nil?: () -> ::TrueClass
+    def nil?: () -> true
 
     def ref: () -> nil
 
@@ -6276,29 +6276,29 @@ module ActionDispatch
 
         def type: () -> untyped
 
-        def symbol?: () -> ::FalseClass
+        def symbol?: () -> false
 
-        def literal?: () -> ::FalseClass
+        def literal?: () -> false
 
-        def terminal?: () -> ::FalseClass
+        def terminal?: () -> false
 
-        def star?: () -> ::FalseClass
+        def star?: () -> false
 
-        def cat?: () -> ::FalseClass
+        def cat?: () -> false
 
-        def group?: () -> ::FalseClass
+        def group?: () -> false
       end
 
       class Terminal < Node
         # :nodoc:
         alias symbol left
 
-        def terminal?: () -> ::TrueClass
+        def terminal?: () -> true
       end
 
       class Literal < Terminal
         # :nodoc:
-        def literal?: () -> ::TrueClass
+        def literal?: () -> true
 
         def type: () -> :LITERAL
       end
@@ -6307,7 +6307,7 @@ module ActionDispatch
         # :nodoc:
         def initialize: (?untyped x) -> untyped
 
-        def literal?: () -> ::FalseClass
+        def literal?: () -> false
       end
 
       class Slash < Terminal
@@ -6336,7 +6336,7 @@ module ActionDispatch
 
         def type: () -> :SYMBOL
 
-        def symbol?: () -> ::TrueClass
+        def symbol?: () -> true
       end
 
       class Unary < Node
@@ -6348,12 +6348,12 @@ module ActionDispatch
         # :nodoc:
         def type: () -> :GROUP
 
-        def group?: () -> ::TrueClass
+        def group?: () -> true
       end
 
       class Star < Unary
         # :nodoc:
-        def star?: () -> ::TrueClass
+        def star?: () -> true
 
         def type: () -> :STAR
 
@@ -6371,7 +6371,7 @@ module ActionDispatch
 
       class Cat < Binary
         # :nodoc:
-        def cat?: () -> ::TrueClass
+        def cat?: () -> true
 
         def type: () -> :CAT
       end
@@ -6575,7 +6575,7 @@ module ActionDispatch
         end
 
         class All
-          def self.call: (untyped _) -> ::TrueClass
+          def self.call: (untyped _) -> true
 
           def self.verb: () -> ::String
         end
@@ -7474,7 +7474,7 @@ module ActionDispatch
 
     def render_details: (untyped req) -> ::Array[200 | ::Hash[::String, "text/plain" | untyped] | ::Array[untyped]]
 
-    def blocked_by?: (untyped victim, untyped blocker, untyped all_threads) -> (::FalseClass | untyped)
+    def blocked_by?: (untyped victim, untyped blocker, untyped all_threads) -> (false | untyped)
   end
 end
 
@@ -7495,7 +7495,7 @@ module ActionDispatch
 
     def render: () -> untyped
 
-    def protect_against_forgery?: () -> ::FalseClass
+    def protect_against_forgery?: () -> false
 
     def params_valid?: () -> untyped
   end
@@ -8171,7 +8171,7 @@ module ActionDispatch
     # Default to 1 year, the minimum for browser preload lists.
     HSTS_EXPIRES_IN: ::Integer
 
-    def self.default_hsts_options: () -> { expires: untyped, subdomains: ::TrueClass, preload: ::FalseClass }
+    def self.default_hsts_options: () -> { expires: untyped, subdomains: true, preload: false }
 
     def initialize: (untyped app, ?secure_cookies: bool secure_cookies, ?hsts: ::Hash[untyped, untyped] hsts, ?redirect: ::Hash[untyped, untyped] redirect) -> untyped
 
@@ -8289,7 +8289,7 @@ module ActionDispatch
     #
     # Used by the +Static+ class to check the existence of a valid file
     # in the server's +public/+ directory (see Static#call).
-    def match?: (untyped path) -> (::FalseClass | untyped)
+    def match?: (untyped path) -> (false | untyped)
 
     def call: (untyped env) -> untyped
 
@@ -8473,11 +8473,11 @@ module ActionDispatch
   module Routing
     class Endpoint
       # :nodoc:
-      def dispatcher?: () -> ::FalseClass
+      def dispatcher?: () -> false
 
-      def redirect?: () -> ::FalseClass
+      def redirect?: () -> false
 
-      def matches?: (untyped req) -> ::TrueClass
+      def matches?: (untyped req) -> true
 
       def app: () -> untyped
 
@@ -9268,7 +9268,7 @@ module ActionDispatch
 
           def shallow?: () -> untyped
 
-          def singleton?: () -> ::FalseClass
+          def singleton?: () -> false
         end
 
         class SingletonResource < Resource
@@ -9289,7 +9289,7 @@ module ActionDispatch
 
           alias nested_scope path
 
-          def singleton?: () -> ::TrueClass
+          def singleton?: () -> true
         end
 
         def resources_path_names: (untyped options) -> untyped
@@ -9356,7 +9356,7 @@ module ActionDispatch
 
         def parent_resource: () -> untyped
 
-        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (::TrueClass | ::FalseClass)
+        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> bool
 
         def apply_action_options: (untyped options) -> untyped
 
@@ -9839,7 +9839,7 @@ module ActionDispatch
 
       def initialize: (untyped status, untyped block) -> untyped
 
-      def redirect?: () -> ::TrueClass
+      def redirect?: () -> true
 
       def call: (untyped env) -> untyped
 
@@ -9896,7 +9896,7 @@ module ActionDispatch
       class Dispatcher < Routing::Endpoint
         def initialize: (untyped raise_on_name_error) -> untyped
 
-        def dispatcher?: () -> ::TrueClass
+        def dispatcher?: () -> true
 
         def serve: (untyped req) -> untyped
 
@@ -10163,7 +10163,7 @@ module ActionDispatch
         # If no route is generated the formatter will raise ActionController::UrlGenerationError
         def generate: () -> untyped
 
-        def different_controller?: () -> (::FalseClass | untyped)
+        def different_controller?: () -> (false | untyped)
 
         private
 
@@ -11023,7 +11023,7 @@ module ActionDispatch
       #
       #   # Asserts that the redirection matches the regular expression
       #   assert_redirected_to %r(\Ahttp://example.org)
-      def assert_redirected_to: (?::Hash[untyped, untyped] options, ?untyped? message) -> (::TrueClass | untyped)
+      def assert_redirected_to: (?::Hash[untyped, untyped] options, ?untyped? message) -> (true | untyped)
 
       private
 

--- a/gems/actionpack/6.0/patch.rbs
+++ b/gems/actionpack/6.0/patch.rbs
@@ -2,23 +2,23 @@ module ActionController
   class Metal
     # It is necessary to satisfy alias target.
     # TODO: Define this method to correct place.
-    def session: -> untyped
-    def headers: -> untyped
-    def status: -> untyped
+    def session: () -> untyped
+    def headers: () -> untyped
+    def status: () -> untyped
     def status=: (untyped status) -> untyped
-    def location: -> untyped
+    def location: () -> untyped
     def location=: (untyped location) -> untyped
-    def content_type: -> untyped
+    def content_type: () -> untyped
     def content_type=: (untyped content_type) -> untyped
-    def media_type: -> untyped
+    def media_type: () -> untyped
   end
 
   class LiveTestResponse < Live::Response
     # It is necessary to satisfy alias target.
     # TODO: Define this method to correct place.
-    def successful?: -> untyped
-    def not_found?: -> untyped
-    def server_error?: -> untyped
+    def successful?: () -> untyped
+    def not_found?: () -> untyped
+    def server_error?: () -> untyped
   end
 end
 


### PR DESCRIPTION
<details>

<summary>rubocop log</summary>

```
Offenses:

gems/actionpack/6.0/actioncontroller.rbs:148:175: C: [Corrected] RBS/Layout/ExtraSpacing: Unnecessary spacing detected.
  def around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
                                                                                                                                                                              ^
gems/actionpack/6.0/actioncontroller.rbs:151:180: C: [Corrected] RBS/Layout/ExtraSpacing: Unnecessary spacing detected.
  def skip_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
                                                                                                                                                                                   ^
gems/actionpack/6.0/actioncontroller.rbs:154:183: C: [Corrected] RBS/Layout/ExtraSpacing: Unnecessary spacing detected.
  def prepend_around_action: (*around_action_callback[instance], ?if: around_action_callback[instance], ?unless: around_action_callback[instance], **untyped) ?{ (instance controller,  ^() -> void) [self: instance] -> void } -> void
                                                                                                                                                                                      ^
gems/actionpack/6.0/actioncontroller.rbs:179:44: C: [Corrected] RBS/Layout/SpaceAroundBraces: Use one space before }.
    def each_key: () { (untyped) -> untyped} -> Hash[untyped, untyped]
                                           ^
gems/actionpack/6.0/actionpack-generated.rbs:143:36: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def self.supports_path?: () -> ::TrueClass
                                   ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:1505:70: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def head: (untyped status, ?::Hash[untyped, untyped] options) -> ::TrueClass
                                                                     ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:1765:92: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
      def validate_digest_response: (untyped request, untyped realm) { () -> untyped } -> (::FalseClass | untyped)
                                                                                           ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:1825:113: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
      def validate_nonce: (untyped secret_key, untyped request, untyped value, ?untyped seconds_to_timeout) -> (::FalseClass | untyped)
                                                                                                                ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:2514:35: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def _wrapper_enabled?: () -> (::FalseClass | untyped)
                                  ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:2904:30: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
          def exists?: () -> ::TrueClass
                             ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:2956:88: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def valid_authenticity_token?: (untyped session, untyped encoded_masked_token) -> (::FalseClass | untyped)
                                                                                       ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:3007:42: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def show_detailed_exceptions?: () -> ::FalseClass
                                         ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:3998:54: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def self.binary_params_for?: (untyped action) -> ::FalseClass
                                                     ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:4214:24: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def exists?: () -> ::TrueClass
                       ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:4493:44: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def fresh?: (untyped response) -> (::FalseClass | untyped)
                                           ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:5058:37: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def ==: (untyped mime_type) -> (::FalseClass | untyped)
                                    ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:5062:37: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def =~: (untyped mime_type) -> (::FalseClass | untyped)
                                    ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:5066:21: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def all?: () -> ::FalseClass
                    ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:5088:21: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def all?: () -> ::TrueClass
                    ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:5090:22: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def html?: () -> ::TrueClass
                     ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:5101:21: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def nil?: () -> ::TrueClass
                    ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6279:28: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def symbol?: () -> ::FalseClass
                           ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6281:29: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def literal?: () -> ::FalseClass
                            ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6283:30: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def terminal?: () -> ::FalseClass
                             ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6285:26: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def star?: () -> ::FalseClass
                         ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6287:25: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def cat?: () -> ::FalseClass
                        ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6289:27: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def group?: () -> ::FalseClass
                          ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6296:30: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def terminal?: () -> ::TrueClass
                             ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6301:29: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def literal?: () -> ::TrueClass
                            ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6310:29: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def literal?: () -> ::FalseClass
                            ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6339:28: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def symbol?: () -> ::TrueClass
                           ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6351:27: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def group?: () -> ::TrueClass
                          ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6356:26: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def star?: () -> ::TrueClass
                         ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6374:25: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def cat?: () -> ::TrueClass
                        ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:6578:41: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
          def self.call: (untyped _) -> ::TrueClass
                                        ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:7477:81: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def blocked_by?: (untyped victim, untyped blocker, untyped all_threads) -> (::FalseClass | untyped)
                                                                                ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:7498:41: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def protect_against_forgery?: () -> ::FalseClass
                                        ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:8174:74: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
    def self.default_hsts_options: () -> { expires: untyped, subdomains: ::TrueClass, preload: ::FalseClass }
                                                                         ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:8174:96: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def self.default_hsts_options: () -> { expires: untyped, subdomains: ::TrueClass, preload: ::FalseClass }
                                                                                               ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:8292:36: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
    def match?: (untyped path) -> (::FalseClass | untyped)
                                   ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:8476:30: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
      def dispatcher?: () -> ::FalseClass
                             ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:8478:28: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
      def redirect?: () -> ::FalseClass
                           ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:8480:38: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
      def matches?: (untyped req) -> ::TrueClass
                                     ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9271:33: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
          def singleton?: () -> ::FalseClass
                                ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9292:33: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
          def singleton?: () -> ::TrueClass
                                ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9359:114: C: [Corrected] RBS/Style/RedundantParentheses: Don't use parentheses around simple type.
        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (bool)
                                                                                                                 ^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9359:115: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (::TrueClass | ::FalseClass)
                                                                                                                  ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9359:115: C: [Corrected] RBS/Style/TrueFalse: Use bool instead of ::TrueClass | ::FalseClass
        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (::TrueClass | ::FalseClass)
                                                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9359:115: C: [Corrected] RBS/Style/TrueFalse: Use bool instead of true | false
        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (true | false)
                                                                                                                  ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9359:129: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (::TrueClass | ::FalseClass)
                                                                                                                                ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9842:28: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
      def redirect?: () -> ::TrueClass
                           ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:9899:32: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
        def dispatcher?: () -> ::TrueClass
                               ^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:10166:43: C: [Corrected] RBS/Style/ClassicType: Use false instead of ::FalseClass
        def different_controller?: () -> (::FalseClass | untyped)
                                          ^^^^^^^^^^^^
gems/actionpack/6.0/actionpack-generated.rbs:11026:92: C: [Corrected] RBS/Style/ClassicType: Use true instead of ::TrueClass
      def assert_redirected_to: (?::Hash[untyped, untyped] options, ?untyped? message) -> (::TrueClass | untyped)
                                                                                           ^^^^^^^^^^^
gems/actionpack/6.0/patch.rbs:5:18: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def session: -> untyped
                 ^
gems/actionpack/6.0/patch.rbs:6:18: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def headers: -> untyped
                 ^
gems/actionpack/6.0/patch.rbs:7:17: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def status: -> untyped
                ^
gems/actionpack/6.0/patch.rbs:9:19: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def location: -> untyped
                  ^
gems/actionpack/6.0/patch.rbs:11:23: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def content_type: -> untyped
                      ^
gems/actionpack/6.0/patch.rbs:13:21: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def media_type: -> untyped
                    ^
gems/actionpack/6.0/patch.rbs:19:22: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def successful?: -> untyped
                     ^
gems/actionpack/6.0/patch.rbs:20:21: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def not_found?: -> untyped
                    ^
gems/actionpack/6.0/patch.rbs:21:24: C: [Corrected] RBS/Style/EmptyArgument: Insert () when empty argument
    def server_error?: -> untyped
                       ^

632 files inspected, 63 offenses detected, 63 offenses corrected
```

</details>