### PR TITLE
Enable rubocop-on-rbs on protobuf

### DIFF
--- a/gems/protobuf/.rubocop.yml
+++ b/gems/protobuf/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from: ../../.rubocop.yml
+
+RBS/Layout:
+  Enabled: true
+RBS/Lint:
+  Enabled: true
+RBS/Style:
+  Enabled: true

--- a/gems/protobuf/3.10.3/_test/services.rbs
+++ b/gems/protobuf/3.10.3/_test/services.rbs
@@ -1,6 +1,5 @@
 module Services
   class UserService < Protobuf::Rpc::Service
-
   end
 
   class UserRequest < Protobuf::Message

--- a/gems/protobuf/3.10.3/field.rbs
+++ b/gems/protobuf/3.10.3/field.rbs
@@ -4,36 +4,36 @@ module Protobuf
     # Enum collections allows receiving String, Symbol, and Integers for updates.
 
     class FieldArray[Elem, WriteElem] < Array[Elem]
-        attr_reader field: untyped
+      attr_reader field: untyped
 
-        def initialize: (untyped field) -> void
+      def initialize: (untyped field) -> void
 
-        def <<: (WriteElem? val) -> self?
+      def <<: (WriteElem? val) -> self?
 
-        def []=: (int index, WriteElem? obj) -> WriteElem?
+      def []=: (int index, WriteElem? obj) -> WriteElem?
 
-        def push: (WriteElem? val) -> self?
+      def push: (WriteElem? val) -> self?
 
-        def replace: (Array[WriteElem] val) -> self
+      def replace: (Array[WriteElem] val) -> self
 
-        # Return a hash-representation of the given values for this field type.
-        # The value in this case would be an array.
-        def to_hash_value: () -> Array[untyped]
+      # Return a hash-representation of the given values for this field type.
+      # The value in this case would be an array.
+      def to_hash_value: () -> Array[untyped]
 
-        # Return a hash-representation of the given values for this field type
-        # that is safe to convert to JSON.
-        # The value in this case would be an array.
-        def to_json_hash_value: () -> Array[untyped]
+      # Return a hash-representation of the given values for this field type
+      # that is safe to convert to JSON.
+      # The value in this case would be an array.
+      def to_json_hash_value: () -> Array[untyped]
 
-        def to_s: () -> String
+      def to_s: () -> String
 
-        def unshift: (WriteElem? val) -> self?
+      def unshift: (WriteElem? val) -> self?
 
-        private
+      private
 
-        def normalize: (untyped value) -> untyped
+      def normalize: (untyped value) -> untyped
 
-        def raise_type_error: (untyped val) -> bot
+      def raise_type_error: (untyped val) -> bot
     end
 
     class FieldHash[Key, Value, WValue] < Hash[Key, Value]

--- a/gems/protobuf/3.10.3/rpc_method.rbs
+++ b/gems/protobuf/3.10.3/rpc_method.rbs
@@ -10,7 +10,7 @@ module Protobuf
 
       attr_reader response_type: singleton(Message)
 
-      def initialize: (Symbol, singleton(Message), singleton(Message)) ?{ (instance) [self: instance] -> void} -> void
+      def initialize: (Symbol, singleton(Message), singleton(Message)) ?{ (instance) [self: instance] -> void } -> void
     end
   end
 end


### PR DESCRIPTION
<details>

<summary>rubocop log</summary>

```
Offenses:

gems/protobuf/3.10.3/_test/services.rbs:3:1: C: [Corrected] RBS/Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.
gems/protobuf/3.10.3/field.rbs:7:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        attr_reader field: untyped
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:9:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def initialize: (untyped field) -> void
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:11:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def <<: (WriteElem? val) -> self?
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:13:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def []=: (int index, WriteElem? obj) -> WriteElem?
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:15:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def push: (WriteElem? val) -> self?
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:17:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def replace: (Array[WriteElem] val) -> self
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:19:9: C: [Corrected] RBS/Layout/CommentIndentation: Incorrect indentation detected (column 6 instead of 8).
        # Return a hash-representation of the given values for this field type.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gems/protobuf/3.10.3/field.rbs:20:9: C: [Corrected] RBS/Layout/CommentIndentation: Incorrect indentation detected (column 6 instead of 8).
        # The value in this case would be an array.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gems/protobuf/3.10.3/field.rbs:21:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def to_hash_value: () -> Array[untyped]
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:23:9: C: [Corrected] RBS/Layout/CommentIndentation: Incorrect indentation detected (column 6 instead of 8).
        # Return a hash-representation of the given values for this field type
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gems/protobuf/3.10.3/field.rbs:24:9: C: [Corrected] RBS/Layout/CommentIndentation: Incorrect indentation detected (column 6 instead of 8).
        # that is safe to convert to JSON.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gems/protobuf/3.10.3/field.rbs:25:9: C: [Corrected] RBS/Layout/CommentIndentation: Incorrect indentation detected (column 6 instead of 8).
        # The value in this case would be an array.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gems/protobuf/3.10.3/field.rbs:26:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def to_json_hash_value: () -> Array[untyped]
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:28:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def to_s: () -> String
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:30:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def unshift: (WriteElem? val) -> self?
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:32:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        private
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:34:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def normalize: (untyped value) -> untyped
^^^^^^^^
gems/protobuf/3.10.3/field.rbs:36:1: C: [Corrected] RBS/Layout/IndentationWidth: Use 6 (not 8) spaces for indentation.
        def raise_type_error: (untyped val) -> bot
^^^^^^^^
gems/protobuf/3.10.3/rpc_method.rbs:13:110: C: [Corrected] RBS/Layout/SpaceAroundBraces: Use one space before }.
      def initialize: (Symbol, singleton(Message), singleton(Message)) ?{ (instance) [self: instance] -> void} -> void
                                                                                                             ^

630 files inspected, 20 offenses detected, 20 offenses corrected
```

</details>