### PR TITLE
Move bundled gems from rbs/stdlib

### DIFF
--- a/gems/abbrev/.rubocop.yml
+++ b/gems/abbrev/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/abbrev/0.1/_test/test.rb
+++ b/gems/abbrev/0.1/_test/test.rb
@@ -1,0 +1,10 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "abbrev"
+
+Abbrev.abbrev([])
+Abbrev.abbrev(%w(abbrev))
+Abbrev.abbrev(%w(abbrev), 'abb')
+Abbrev.abbrev(%w(abbrev), /^abb/)
+Abbrev.abbrev(%w(abbrev), nil)

--- a/gems/abbrev/0.1/abbrev.rbs
+++ b/gems/abbrev/0.1/abbrev.rbs
@@ -1,0 +1,66 @@
+# <!-- rdoc-file=lib/abbrev.rb -->
+# Calculates the set of unambiguous abbreviations for a given set of strings.
+#
+#     require 'abbrev'
+#     require 'pp'
+#
+#     pp Abbrev.abbrev(['ruby'])
+#     #=>  {"ruby"=>"ruby", "rub"=>"ruby", "ru"=>"ruby", "r"=>"ruby"}
+#
+#     pp Abbrev.abbrev(%w{ ruby rules })
+#
+# *Generates:*
+#     { "ruby"  =>  "ruby",
+#       "rub"   =>  "ruby",
+#       "rules" =>  "rules",
+#       "rule"  =>  "rules",
+#       "rul"   =>  "rules" }
+#
+# It also provides an array core extension, Array#abbrev.
+#
+#     pp %w{ summer winter }.abbrev
+#
+# *Generates:*
+#     { "summer"  => "summer",
+#       "summe"   => "summer",
+#       "summ"    => "summer",
+#       "sum"     => "summer",
+#       "su"      => "summer",
+#       "s"       => "summer",
+#       "winter"  => "winter",
+#       "winte"   => "winter",
+#       "wint"    => "winter",
+#       "win"     => "winter",
+#       "wi"      => "winter",
+#       "w"       => "winter" }
+#
+module Abbrev
+  # <!--
+  #   rdoc-file=lib/abbrev.rb
+  #   - abbrev(words, pattern = nil)
+  # -->
+  # Given a set of strings, calculate the set of unambiguous abbreviations for
+  # those strings, and return a hash where the keys are all the possible
+  # abbreviations and the values are the full strings.
+  #
+  # Thus, given `words` is "car" and "cone", the keys pointing to "car" would be
+  # "ca" and "car", while those pointing to "cone" would be "co", "con", and
+  # "cone".
+  #
+  #     require 'abbrev'
+  #
+  #     Abbrev.abbrev(%w{ car cone })
+  #     #=> {"ca"=>"car", "con"=>"cone", "co"=>"cone", "car"=>"car", "cone"=>"cone"}
+  #
+  # The optional `pattern` parameter is a pattern or a string. Only input strings
+  # that match the pattern or start with the string are included in the output
+  # hash.
+  #
+  #     Abbrev.abbrev(%w{car box cone crab}, /b/)
+  #     #=> {"box"=>"box", "bo"=>"box", "b"=>"box", "crab" => "crab"}
+  #
+  #     Abbrev.abbrev(%w{car box cone}, 'ca')
+  #     #=> {"car"=>"car", "ca"=>"car"}
+  #
+  def self?.abbrev: (Array[String], ?String | Regexp | nil) -> Hash[String, String]
+end

--- a/gems/abbrev/0.1/array.rbs
+++ b/gems/abbrev/0.1/array.rbs
@@ -1,0 +1,26 @@
+%a{annotate:rdoc:skip}
+class Array[unchecked out Elem]
+  # <!--
+  #   rdoc-file=lib/abbrev.rb
+  #   - abbrev(pattern = nil)
+  # -->
+  # Calculates the set of unambiguous abbreviations for the strings in `self`.
+  #
+  #     require 'abbrev'
+  #     %w{ car cone }.abbrev
+  #     #=> {"car"=>"car", "ca"=>"car", "cone"=>"cone", "con"=>"cone", "co"=>"cone"}
+  #
+  # The optional `pattern` parameter is a pattern or a string. Only input strings
+  # that match the pattern or start with the string are included in the output
+  # hash.
+  #
+  #     %w{ fast boat day }.abbrev(/^.a/)
+  #     #=> {"fast"=>"fast", "fas"=>"fast", "fa"=>"fast", "day"=>"day", "da"=>"day"}
+  #
+  #     Abbrev.abbrev(%w{car box cone}, "ca")
+  #     #=> {"car"=>"car", "ca"=>"car"}
+  #
+  # See also Abbrev.abbrev
+  #
+  def abbrev: (?String | Regexp | nil) -> Hash[String, String]
+end

--- a/gems/abbrev/_reviewers.yaml
+++ b/gems/abbrev/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/base64/.rubocop.yml
+++ b/gems/base64/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/base64/0.1/_test/test.rb
+++ b/gems/base64/0.1/_test/test.rb
@@ -1,0 +1,9 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "base64"
+
+Base64.decode64(Base64.encode64(""))
+Base64.strict_decode64(Base64.strict_encode64(""))
+Base64.urlsafe_decode64(Base64.urlsafe_encode64(""))
+Base64.urlsafe_decode64(Base64.urlsafe_encode64("", padding: "true"))

--- a/gems/base64/0.1/base64.rbs
+++ b/gems/base64/0.1/base64.rbs
@@ -1,0 +1,355 @@
+# <!-- rdoc-file=lib/base64.rb -->
+# Module Base64 provides methods for:
+#
+# *   Encoding a binary string (containing non-ASCII characters) as a string of
+#     printable ASCII characters.
+# *   Decoding such an encoded string.
+#
+# Base64 is commonly used in contexts where binary data is not allowed or
+# supported:
+#
+# *   Images in HTML or CSS files, or in URLs.
+# *   Email attachments.
+#
+# A Base64-encoded string is about one-third larger that its source. See the
+# [Wikipedia article](https://en.wikipedia.org/wiki/Base64) for more
+# information.
+#
+# This module provides three pairs of encode/decode methods. Your choices among
+# these methods should depend on:
+#
+# *   Which character set is to be used for encoding and decoding.
+# *   Whether "padding" is to be used.
+# *   Whether encoded strings are to contain newlines.
+#
+# Note: Examples on this page assume that the including program has executed:
+#
+#     require 'base64'
+#
+# ## Encoding Character Sets
+#
+# A Base64-encoded string consists only of characters from a 64-character set:
+#
+# *   `('A'..'Z')`.
+# *   `('a'..'z')`.
+# *   `('0'..'9')`.
+# *   `=`, the 'padding' character.
+# *   Either:
+#     *   `%w[+ /]`:
+#         [RFC-2045-compliant](https://datatracker.ietf.org/doc/html/rfc2045);
+#         *not* safe for URLs.
+#     *   `%w[- _]`:
+#         [RFC-4648-compliant](https://datatracker.ietf.org/doc/html/rfc4648);
+#         safe for URLs.
+#
+# If you are working with Base64-encoded strings that will come from or be put
+# into URLs, you should choose this encoder-decoder pair of RFC-4648-compliant
+# methods:
+#
+# *   Base64.urlsafe_encode64 and Base64.urlsafe_decode64.
+#
+# Otherwise, you may choose any of the pairs in this module, including the pair
+# above, or the RFC-2045-compliant pairs:
+#
+# *   Base64.encode64 and Base64.decode64.
+# *   Base64.strict_encode64 and Base64.strict_decode64.
+#
+# ## Padding
+#
+# Base64-encoding changes a triplet of input bytes into a quartet of output
+# characters.
+#
+# **Padding in Encode Methods**
+#
+# Padding -- extending an encoded string with zero, one, or two trailing `=`
+# characters -- is performed by methods Base64.encode64, Base64.strict_encode64,
+# and, by default, Base64.urlsafe_encode64:
+#
+#     Base64.encode64('s')                         # => "cw==\n"
+#     Base64.strict_encode64('s')                  # => "cw=="
+#     Base64.urlsafe_encode64('s')                 # => "cw=="
+#     Base64.urlsafe_encode64('s', padding: false) # => "cw"
+#
+# When padding is performed, the encoded string is always of length *4n*, where
+# `n` is a non-negative integer:
+#
+# *   Input bytes of length *3n* generate unpadded output characters of length
+#     *4n*:
+#
+#         # n = 1:  3 bytes => 4 characters.
+#         Base64.strict_encode64('123')      # => "MDEy"
+#         # n = 2:  6 bytes => 8 characters.
+#         Base64.strict_encode64('123456')   # => "MDEyMzQ1"
+#
+# *   Input bytes of length *3n+1* generate padded output characters of length
+#     *4(n+1)*, with two padding characters at the end:
+#
+#         # n = 1:  4 bytes => 8 characters.
+#         Base64.strict_encode64('1234')     # => "MDEyMw=="
+#         # n = 2:  7 bytes => 12 characters.
+#         Base64.strict_encode64('1234567')  # => "MDEyMzQ1Ng=="
+#
+# *   Input bytes of length *3n+2* generate padded output characters of length
+#     *4(n+1)*, with one padding character at the end:
+#
+#         # n = 1:  5 bytes => 8 characters.
+#         Base64.strict_encode64('12345')    # => "MDEyMzQ="
+#         # n = 2:  8 bytes => 12 characters.
+#         Base64.strict_encode64('12345678') # => "MDEyMzQ1Njc="
+#
+# When padding is suppressed, for a positive integer *n*:
+#
+# *   Input bytes of length *3n* generate unpadded output characters of length
+#     *4n*:
+#
+#         # n = 1:  3 bytes => 4 characters.
+#         Base64.urlsafe_encode64('123', padding: false)      # => "MDEy"
+#         # n = 2:  6 bytes => 8 characters.
+#         Base64.urlsafe_encode64('123456', padding: false)   # => "MDEyMzQ1"
+#
+# *   Input bytes of length *3n+1* generate unpadded output characters of length
+#     *4n+2*, with two padding characters at the end:
+#
+#         # n = 1:  4 bytes => 6 characters.
+#         Base64.urlsafe_encode64('1234', padding: false)     # => "MDEyMw"
+#         # n = 2:  7 bytes => 10 characters.
+#         Base64.urlsafe_encode64('1234567', padding: false)  # => "MDEyMzQ1Ng"
+#
+# *   Input bytes of length *3n+2* generate unpadded output characters of length
+#     *4n+3*, with one padding character at the end:
+#
+#         # n = 1:  5 bytes => 7 characters.
+#         Base64.urlsafe_encode64('12345', padding: false)    # => "MDEyMzQ"
+#         # m = 2:  8 bytes => 11 characters.
+#         Base64.urlsafe_encode64('12345678', padding: false) # => "MDEyMzQ1Njc"
+#
+# **Padding in Decode Methods**
+#
+# All of the Base64 decode methods support (but do not require) padding.
+#
+# Method Base64.decode64 does not check the size of the padding:
+#
+#     Base64.decode64("MDEyMzQ1Njc") # => "01234567"
+#     Base64.decode64("MDEyMzQ1Njc=") # => "01234567"
+#     Base64.decode64("MDEyMzQ1Njc==") # => "01234567"
+#
+# Method Base64.strict_decode64 strictly enforces padding size:
+#
+#     Base64.strict_decode64("MDEyMzQ1Njc")   # Raises ArgumentError
+#     Base64.strict_decode64("MDEyMzQ1Njc=")  # => "01234567"
+#     Base64.strict_decode64("MDEyMzQ1Njc==") # Raises ArgumentError
+#
+# Method Base64.urlsafe_decode64 allows padding in `str`, which if present, must
+# be correct: see [Padding](Base64.html#module-Base64-label-Padding), above:
+#
+#     Base64.urlsafe_decode64("MDEyMzQ1Njc") # => "01234567"
+#     Base64.urlsafe_decode64("MDEyMzQ1Njc=") # => "01234567"
+#     Base64.urlsafe_decode64("MDEyMzQ1Njc==") # Raises ArgumentError.
+#
+# ## Newlines
+#
+# An encoded string returned by Base64.encode64 or Base64.urlsafe_encode64 has
+# an embedded newline character after each 60-character sequence, and, if
+# non-empty, at the end:
+#
+#     # No newline if empty.
+#     encoded = Base64.encode64("\x00" *  0)
+#     encoded.index("\n") # => nil
+#
+#     # Newline at end of short output.
+#     encoded = Base64.encode64("\x00" *  1)
+#     encoded.size        # => 4
+#     encoded.index("\n") # => 4
+#
+#     # Newline at end of longer output.
+#     encoded = Base64.encode64("\x00" * 45)
+#     encoded.size        # => 60
+#     encoded.index("\n") # => 60
+#
+#     # Newlines embedded and at end of still longer output.
+#     encoded = Base64.encode64("\x00" * 46)
+#     encoded.size                          # => 65
+#     encoded.rindex("\n")                  # => 65
+#     encoded.split("\n").map {|s| s.size } # => [60, 4]
+#
+# The string to be encoded may itself contain newlines, which are encoded as
+# Base64:
+#
+#       #   Base64.encode64("\n\n\n") # => "CgoK\n"
+#     s = "This is line 1\nThis is line 2\n"
+#     Base64.encode64(s) # => "VGhpcyBpcyBsaW5lIDEKVGhpcyBpcyBsaW5lIDIK\n"
+#
+module Base64
+  # <!--
+  #   rdoc-file=lib/base64.rb
+  #   - decode64(str)
+  # -->
+  # Returns a string containing the decoding of an RFC-2045-compliant
+  # Base64-encoded string `str`:
+  #
+  #     s = "VGhpcyBpcyBsaW5lIDEKVGhpcyBpcyBsaW5lIDIK\n"
+  #     Base64.decode64(s) # => "This is line 1\nThis is line 2\n"
+  #
+  # Non-Base64 characters in `str` are ignored; see [Encoding Character
+  # Set](Base64.html#module-Base64-label-Encoding+Character+Sets) above: these
+  # include newline characters and characters `-` and `/`:
+  #
+  #     Base64.decode64("\x00\n-_") # => ""
+  #
+  # Padding in `str` (even if incorrect) is ignored:
+  #
+  #     Base64.decode64("MDEyMzQ1Njc")   # => "01234567"
+  #     Base64.decode64("MDEyMzQ1Njc=")  # => "01234567"
+  #     Base64.decode64("MDEyMzQ1Njc==") # => "01234567"
+  #
+  def self?.decode64: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/base64.rb
+  #   - encode64(bin)
+  # -->
+  # Returns a string containing the RFC-2045-compliant Base64-encoding of `bin`.
+  #
+  # Per RFC 2045, the returned string may contain the URL-unsafe characters `+` or
+  # `/`; see [Encoding Character
+  # Set](Base64.html#module-Base64-label-Encoding+Character+Sets) above:
+  #
+  #     Base64.encode64("\xFB\xEF\xBE") # => "++++\n"
+  #     Base64.encode64("\xFF\xFF\xFF") # => "////\n"
+  #
+  # The returned string may include padding; see
+  # [Padding](Base64.html#module-Base64-label-Padding) above.
+  #
+  #     Base64.encode64('*') # => "Kg==\n"
+  #
+  # The returned string ends with a newline character, and if sufficiently long
+  # will have one or more embedded newline characters; see
+  # [Newlines](Base64.html#module-Base64-label-Newlines) above:
+  #
+  #     Base64.encode64('*') # => "Kg==\n"
+  #     Base64.encode64('*' * 46)
+  #     # => "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioq\nKg==\n"
+  #
+  # The string to be encoded may itself contain newlines, which will be encoded as
+  # ordinary Base64:
+  #
+  #     Base64.encode64("\n\n\n") # => "CgoK\n"
+  #     s = "This is line 1\nThis is line 2\n"
+  #     Base64.encode64(s) # => "VGhpcyBpcyBsaW5lIDEKVGhpcyBpcyBsaW5lIDIK\n"
+  #
+  def self?.encode64: (String bin) -> String
+
+  # <!--
+  #   rdoc-file=lib/base64.rb
+  #   - strict_decode64(str)
+  # -->
+  # Returns a string containing the decoding of an RFC-2045-compliant
+  # Base64-encoded string `str`:
+  #
+  #     s = "VGhpcyBpcyBsaW5lIDEKVGhpcyBpcyBsaW5lIDIK"
+  #     Base64.strict_decode64(s) # => "This is line 1\nThis is line 2\n"
+  #
+  # Non-Base64 characters in `str` not allowed; see [Encoding Character
+  # Set](Base64.html#module-Base64-label-Encoding+Character+Sets) above: these
+  # include newline characters and characters `-` and `/`:
+  #
+  #     Base64.strict_decode64("\n") # Raises ArgumentError
+  #     Base64.strict_decode64('-')  # Raises ArgumentError
+  #     Base64.strict_decode64('_')  # Raises ArgumentError
+  #
+  # Padding in `str`, if present, must be correct:
+  #
+  #     Base64.strict_decode64("MDEyMzQ1Njc")   # Raises ArgumentError
+  #     Base64.strict_decode64("MDEyMzQ1Njc=")  # => "01234567"
+  #     Base64.strict_decode64("MDEyMzQ1Njc==") # Raises ArgumentError
+  #
+  def self?.strict_decode64: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/base64.rb
+  #   - strict_encode64(bin)
+  # -->
+  # Returns a string containing the RFC-2045-compliant Base64-encoding of `bin`.
+  #
+  # Per RFC 2045, the returned string may contain the URL-unsafe characters `+` or
+  # `/`; see [Encoding Character
+  # Set](Base64.html#module-Base64-label-Encoding+Character+Sets) above:
+  #
+  #     Base64.strict_encode64("\xFB\xEF\xBE") # => "++++\n"
+  #     Base64.strict_encode64("\xFF\xFF\xFF") # => "////\n"
+  #
+  # The returned string may include padding; see
+  # [Padding](Base64.html#module-Base64-label-Padding) above.
+  #
+  #     Base64.strict_encode64('*') # => "Kg==\n"
+  #
+  # The returned string will have no newline characters, regardless of its length;
+  # see [Newlines](Base64.html#module-Base64-label-Newlines) above:
+  #
+  #     Base64.strict_encode64('*') # => "Kg=="
+  #     Base64.strict_encode64('*' * 46)
+  #     # => "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKg=="
+  #
+  # The string to be encoded may itself contain newlines, which will be encoded as
+  # ordinary Base64:
+  #
+  #     Base64.strict_encode64("\n\n\n") # => "CgoK"
+  #     s = "This is line 1\nThis is line 2\n"
+  #     Base64.strict_encode64(s) # => "VGhpcyBpcyBsaW5lIDEKVGhpcyBpcyBsaW5lIDIK"
+  #
+  def self?.strict_encode64: (String bin) -> String
+
+  # <!--
+  #   rdoc-file=lib/base64.rb
+  #   - urlsafe_decode64(str)
+  # -->
+  # Returns the decoding of an RFC-4648-compliant Base64-encoded string `str`:
+  #
+  # `str` may not contain non-Base64 characters; see [Encoding Character
+  # Set](Base64.html#module-Base64-label-Encoding+Character+Sets) above:
+  #
+  #     Base64.urlsafe_decode64('+')  # Raises ArgumentError.
+  #     Base64.urlsafe_decode64('/')  # Raises ArgumentError.
+  #     Base64.urlsafe_decode64("\n") # Raises ArgumentError.
+  #
+  # Padding in `str`, if present, must be correct: see
+  # [Padding](Base64.html#module-Base64-label-Padding), above:
+  #
+  #     Base64.urlsafe_decode64("MDEyMzQ1Njc") # => "01234567"
+  #     Base64.urlsafe_decode64("MDEyMzQ1Njc=") # => "01234567"
+  #     Base64.urlsafe_decode64("MDEyMzQ1Njc==") # Raises ArgumentError.
+  #
+  def self?.urlsafe_decode64: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/base64.rb
+  #   - urlsafe_encode64(bin, padding: true)
+  # -->
+  # Returns the RFC-4648-compliant Base64-encoding of `bin`.
+  #
+  # Per RFC 4648, the returned string will not contain the URL-unsafe characters
+  # `+` or `/`, but instead may contain the URL-safe characters `-` and `_`; see
+  # [Encoding Character
+  # Set](Base64.html#module-Base64-label-Encoding+Character+Sets) above:
+  #
+  #     Base64.urlsafe_encode64("\xFB\xEF\xBE") # => "----"
+  #     Base64.urlsafe_encode64("\xFF\xFF\xFF") # => "____"
+  #
+  # By default, the returned string may have padding; see
+  # [Padding](Base64.html#module-Base64-label-Padding), above:
+  #
+  #     Base64.urlsafe_encode64('*') # => "Kg=="
+  #
+  # Optionally, you can suppress padding:
+  #
+  #     Base64.urlsafe_encode64('*', padding: false) # => "Kg"
+  #
+  # The returned string will have no newline characters, regardless of its length;
+  # see [Newlines](Base64.html#module-Base64-label-Newlines) above:
+  #
+  #     Base64.urlsafe_encode64('*') # => "Kg=="
+  #     Base64.urlsafe_encode64('*' * 46)
+  #     # => "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKg=="
+  #
+  def self?.urlsafe_encode64: (String bin, ?padding: boolish) -> String
+end

--- a/gems/base64/_reviewers.yaml
+++ b/gems/base64/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/bigdecimal/.rubocop.yml
+++ b/gems/bigdecimal/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/bigdecimal/3.1/_test/test.rb
+++ b/gems/bigdecimal/3.1/_test/test.rb
@@ -1,0 +1,22 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "bigdecimal"
+require "bigdecimal/util"
+
+BigDecimal("1.23")
+
+BigDecimal("1.23") + BigDecimal("1.23")
+BigDecimal("1.23") - BigDecimal("1.23")
+BigDecimal("1.23") * BigDecimal("1.23")
+BigDecimal("1.23") / BigDecimal("1.23")
+
+BigDecimal("1.23").to_d
+BigDecimal("1.23").to_f
+BigDecimal("1.23").to_i
+BigDecimal("1.23").to_r
+
+123.to_d
+12.3.to_d
+12r.to_d(3)
+0i.to_d

--- a/gems/bigdecimal/3.1/_test/test.rb
+++ b/gems/bigdecimal/3.1/_test/test.rb
@@ -20,3 +20,8 @@ BigDecimal("1.23").to_r
 12.3.to_d
 12r.to_d(3)
 0i.to_d
+
+require "bigdecimal/math"
+
+BigMath.E(10)
+BigMath.PI(10)

--- a/gems/bigdecimal/3.1/bigdecimal-math.rbs
+++ b/gems/bigdecimal/3.1/bigdecimal-math.rbs
@@ -1,0 +1,119 @@
+# <!-- rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb -->
+# Provides mathematical functions.
+#
+# Example:
+#
+#     require "bigdecimal/math"
+#
+#     include BigMath
+#
+#     a = BigDecimal((PI(100)/2).to_s)
+#     puts sin(a,100) # => 0.99999999999999999999......e0
+#
+module BigMath
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb
+  #   - E(numeric) -> BigDecimal
+  # -->
+  # Computes e (the base of natural logarithms) to the specified number of digits
+  # of precision, `numeric`.
+  #
+  #     BigMath.E(10).to_s
+  #     #=> "0.271828182845904523536028752390026306410273e1"
+  #
+  def self?.E: (Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb
+  #   - PI(numeric) -> BigDecimal
+  # -->
+  # Computes the value of pi to the specified number of digits of precision,
+  # `numeric`.
+  #
+  #     BigMath.PI(10).to_s
+  #     #=> "0.3141592653589793238462643388813853786957412e1"
+  #
+  def self?.PI: (Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb
+  #   - atan(decimal, numeric) -> BigDecimal
+  # -->
+  # Computes the arctangent of `decimal` to the specified number of digits of
+  # precision, `numeric`.
+  #
+  # If `decimal` is NaN, returns NaN.
+  #
+  #     BigMath.atan(BigDecimal('-1'), 16).to_s
+  #     #=> "-0.785398163397448309615660845819878471907514682065e0"
+  #
+  def self?.atan: (BigDecimal x, Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb
+  #   - cos(decimal, numeric) -> BigDecimal
+  # -->
+  # Computes the cosine of `decimal` to the specified number of digits of
+  # precision, `numeric`.
+  #
+  # If `decimal` is Infinity or NaN, returns NaN.
+  #
+  #     BigMath.cos(BigMath.PI(4), 16).to_s
+  #     #=> "-0.999999999999999999999999999999856613163740061349e0"
+  #
+  def self?.cos: (BigDecimal x, Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigMath.exp(decimal, numeric)    -> BigDecimal
+  # -->
+  # Computes the value of e (the base of natural logarithms) raised to the power
+  # of `decimal`, to the specified number of digits of precision.
+  #
+  # If `decimal` is infinity, returns Infinity.
+  #
+  # If `decimal` is NaN, returns NaN.
+  #
+  def self?.exp: (BigDecimal, Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigMath.log(decimal, numeric)    -> BigDecimal
+  # -->
+  # Computes the natural logarithm of `decimal` to the specified number of digits
+  # of precision, `numeric`.
+  #
+  # If `decimal` is zero or negative, raises Math::DomainError.
+  #
+  # If `decimal` is positive infinity, returns Infinity.
+  #
+  # If `decimal` is NaN, returns NaN.
+  #
+  def self?.log: (BigDecimal, Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb
+  #   - sin(decimal, numeric) -> BigDecimal
+  # -->
+  # Computes the sine of `decimal` to the specified number of digits of precision,
+  # `numeric`.
+  #
+  # If `decimal` is Infinity or NaN, returns NaN.
+  #
+  #     BigMath.sin(BigMath.PI(5)/4, 5).to_s
+  #     #=> "0.70710678118654752440082036563292800375e0"
+  #
+  def self?.sin: (BigDecimal x, Numeric prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/math.rb
+  #   - sqrt(decimal, numeric) -> BigDecimal
+  # -->
+  # Computes the square root of `decimal` to the specified number of digits of
+  # precision, `numeric`.
+  #
+  #     BigMath.sqrt(BigDecimal('2'), 16).to_s
+  #     #=> "0.1414213562373095048801688724e1"
+  #
+  def self?.sqrt: (BigDecimal x, Numeric prec) -> BigDecimal
+end

--- a/gems/bigdecimal/3.1/bigdecimal.rbs
+++ b/gems/bigdecimal/3.1/bigdecimal.rbs
@@ -1,0 +1,1629 @@
+class BigDecimal < Numeric
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - _load(p1)
+  # -->
+  # Internal method used to provide marshalling support. See the Marshal module.
+  #
+  def self._load: (String) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal.double_fig -> integer
+  # -->
+  # Returns the number of digits a Float object is allowed to have; the result is
+  # system-dependent:
+  #
+  #     BigDecimal.double_fig # => 16
+  #
+  def self.double_fig: () -> Integer
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - interpret_loosely(p1)
+  # -->
+  #
+  def self.interpret_loosely: (string) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal.limit(digits)
+  # -->
+  # Limit the number of significant digits in newly created BigDecimal numbers to
+  # the specified value. Rounding is performed as necessary, as specified by
+  # BigDecimal.mode.
+  #
+  # A limit of 0, the default, means no upper limit.
+  #
+  # The limit specified by this method takes less priority over any limit
+  # specified to instance methods such as ceil, floor, truncate, or round.
+  #
+  def self.limit: (?Integer? digits) -> Integer
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal.mode(mode, setting = nil) -> integer
+  # -->
+  # Returns an integer representing the mode settings for exception handling and
+  # rounding.
+  #
+  # These modes control exception handling:
+  #
+  # *   BigDecimal::EXCEPTION_NaN.
+  # *   BigDecimal::EXCEPTION_INFINITY.
+  # *   BigDecimal::EXCEPTION_UNDERFLOW.
+  # *   BigDecimal::EXCEPTION_OVERFLOW.
+  # *   BigDecimal::EXCEPTION_ZERODIVIDE.
+  # *   BigDecimal::EXCEPTION_ALL.
+  #
+  # Values for `setting` for exception handling:
+  #
+  # *   `true`: sets the given `mode` to `true`.
+  # *   `false`: sets the given `mode` to `false`.
+  # *   `nil`: does not modify the mode settings.
+  #
+  # You can use method BigDecimal.save_exception_mode to temporarily change, and
+  # then automatically restore, exception modes.
+  #
+  # For clarity, some examples below begin by setting all exception modes to
+  # `false`.
+  #
+  # This mode controls the way rounding is to be performed:
+  #
+  # *   BigDecimal::ROUND_MODE
+  #
+  # You can use method BigDecimal.save_rounding_mode to temporarily change, and
+  # then automatically restore, the rounding mode.
+  #
+  # **NaNs**
+  #
+  # Mode BigDecimal::EXCEPTION_NaN controls behavior when a BigDecimal NaN is
+  # created.
+  #
+  # Settings:
+  #
+  # *   `false` (default): Returns `BigDecimal('NaN')`.
+  # *   `true`: Raises FloatDomainError.
+  #
+  # Examples:
+  #
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, false) # => 0
+  #     BigDecimal('NaN')                                 # => NaN
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, true)  # => 2
+  #     BigDecimal('NaN') # Raises FloatDomainError
+  #
+  # **Infinities**
+  #
+  # Mode BigDecimal::EXCEPTION_INFINITY controls behavior when a BigDecimal
+  # Infinity or -Infinity is created. Settings:
+  #
+  # *   `false` (default): Returns `BigDecimal('Infinity')` or
+  #     `BigDecimal('-Infinity')`.
+  # *   `true`: Raises FloatDomainError.
+  #
+  # Examples:
+  #
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, false)     # => 0
+  #     BigDecimal('Infinity')                                # => Infinity
+  #     BigDecimal('-Infinity')                               # => -Infinity
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, true) # => 1
+  #     BigDecimal('Infinity')  # Raises FloatDomainError
+  #     BigDecimal('-Infinity') # Raises FloatDomainError
+  #
+  # **Underflow**
+  #
+  # Mode BigDecimal::EXCEPTION_UNDERFLOW controls behavior when a BigDecimal
+  # underflow occurs. Settings:
+  #
+  # *   `false` (default): Returns `BigDecimal('0')` or `BigDecimal('-Infinity')`.
+  # *   `true`: Raises FloatDomainError.
+  #
+  # Examples:
+  #
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, false)      # => 0
+  #     def flow_under
+  #       x = BigDecimal('0.1')
+  #       100.times { x *= x }
+  #     end
+  #     flow_under                                             # => 100
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_UNDERFLOW, true) # => 4
+  #     flow_under # Raises FloatDomainError
+  #
+  # **Overflow**
+  #
+  # Mode BigDecimal::EXCEPTION_OVERFLOW controls behavior when a BigDecimal
+  # overflow occurs. Settings:
+  #
+  # *   `false` (default): Returns `BigDecimal('Infinity')` or
+  #     `BigDecimal('-Infinity')`.
+  # *   `true`: Raises FloatDomainError.
+  #
+  # Examples:
+  #
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, false)     # => 0
+  #     def flow_over
+  #       x = BigDecimal('10')
+  #       100.times { x *= x }
+  #     end
+  #     flow_over                                             # => 100
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, true) # => 1
+  #     flow_over # Raises FloatDomainError
+  #
+  # **Zero Division**
+  #
+  # Mode BigDecimal::EXCEPTION_ZERODIVIDE controls behavior when a zero-division
+  # occurs. Settings:
+  #
+  # *   `false` (default): Returns `BigDecimal('Infinity')` or
+  #     `BigDecimal('-Infinity')`.
+  # *   `true`: Raises FloatDomainError.
+  #
+  # Examples:
+  #
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, false)       # => 0
+  #     one = BigDecimal('1')
+  #     zero = BigDecimal('0')
+  #     one / zero                                              # => Infinity
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, true) # => 16
+  #     one / zero # Raises FloatDomainError
+  #
+  # **All Exceptions**
+  #
+  # Mode BigDecimal::EXCEPTION_ALL controls all of the above:
+  #
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, false) # => 0
+  #     BigDecimal.mode(BigDecimal::EXCEPTION_ALL, true)  # => 23
+  #
+  # **Rounding**
+  #
+  # Mode BigDecimal::ROUND_MODE controls the way rounding is to be performed; its
+  # `setting` values are:
+  #
+  # *   `ROUND_UP`: Round away from zero. Aliased as `:up`.
+  # *   `ROUND_DOWN`: Round toward zero. Aliased as `:down` and `:truncate`.
+  # *   `ROUND_HALF_UP`: Round toward the nearest neighbor; if the neighbors are
+  #     equidistant, round away from zero. Aliased as `:half_up` and `:default`.
+  # *   `ROUND_HALF_DOWN`: Round toward the nearest neighbor; if the neighbors are
+  #     equidistant, round toward zero. Aliased as `:half_down`.
+  # *   `ROUND_HALF_EVEN` (Banker's rounding): Round toward the nearest neighbor;
+  #     if the neighbors are equidistant, round toward the even neighbor. Aliased
+  #     as `:half_even` and `:banker`.
+  # *   `ROUND_CEILING`: Round toward positive infinity. Aliased as `:ceiling` and
+  #     `:ceil`.
+  # *   `ROUND_FLOOR`: Round toward negative infinity. Aliased as `:floor:`.
+  #
+  def self.mode: (Integer mode, ?Integer? value) -> Integer?
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal.save_exception_mode { ... }
+  # -->
+  # Execute the provided block, but preserve the exception mode
+  #
+  #     BigDecimal.save_exception_mode do
+  #       BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
+  #       BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
+  #
+  #       BigDecimal(BigDecimal('Infinity'))
+  #       BigDecimal(BigDecimal('-Infinity'))
+  #       BigDecimal(BigDecimal('NaN'))
+  #     end
+  #
+  # For use with the BigDecimal::EXCEPTION_*
+  #
+  # See BigDecimal.mode
+  #
+  def self.save_exception_mode: () { (?nil) -> void } -> void
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal.save_limit { ... }
+  # -->
+  # Execute the provided block, but preserve the precision limit
+  #
+  #     BigDecimal.limit(100)
+  #     puts BigDecimal.limit
+  #     BigDecimal.save_limit do
+  #         BigDecimal.limit(200)
+  #         puts BigDecimal.limit
+  #     end
+  #     puts BigDecimal.limit
+  #
+  def self.save_limit: () { (?nil) -> void } -> void
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal.save_rounding_mode { ... }
+  # -->
+  # Execute the provided block, but preserve the rounding mode
+  #
+  #     BigDecimal.save_rounding_mode do
+  #       BigDecimal.mode(BigDecimal::ROUND_MODE, :up)
+  #       puts BigDecimal.mode(BigDecimal::ROUND_MODE)
+  #     end
+  #
+  # For use with the BigDecimal::ROUND_*
+  #
+  # See BigDecimal.mode
+  #
+  def self.save_rounding_mode: () { (?nil) -> void } -> void
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - a % b
+  #   - a.modulo(b)
+  # -->
+  # Returns the modulus from dividing by b.
+  #
+  # See BigDecimal#divmod.
+  #
+  def %: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - *(p1)
+  # -->
+  #
+  def *: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self ** other -> bigdecimal
+  # -->
+  # Returns the BigDecimal value of `self` raised to power `other`:
+  #
+  #     b = BigDecimal('3.14')
+  #     b ** 2              # => 0.98596e1
+  #     b ** 2.0            # => 0.98596e1
+  #     b ** Rational(2, 1) # => 0.98596e1
+  #
+  # Related: BigDecimal#power.
+  #
+  def **: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self + value -> bigdecimal
+  # -->
+  # Returns the BigDecimal sum of `self` and `value`:
+  #
+  #     b = BigDecimal('111111.111') # => 0.111111111e6
+  #     b + 2                        # => 0.111113111e6
+  #     b + 2.0                      # => 0.111113111e6
+  #     b + Rational(2, 1)           # => 0.111113111e6
+  #     b + Complex(2, 0)            # => (0.111113111e6+0i)
+  #
+  # See the [Note About
+  # Precision](BigDecimal.html#class-BigDecimal-label-A+Note+About+Precision).
+  #
+  def +: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - +big_decimal -> self
+  # -->
+  # Returns `self`:
+  #
+  #     +BigDecimal(5)  # => 0.5e1
+  #     +BigDecimal(-5) # => -0.5e1
+  #
+  def +@: () -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self - value -> bigdecimal
+  # -->
+  # Returns the BigDecimal difference of `self` and `value`:
+  #
+  #     b = BigDecimal('333333.333') # => 0.333333333e6
+  #     b - 2                        # => 0.333331333e6
+  #     b - 2.0                      # => 0.333331333e6
+  #     b - Rational(2, 1)           # => 0.333331333e6
+  #     b - Complex(2, 0)            # => (0.333331333e6+0i)
+  #
+  # See the [Note About
+  # Precision](BigDecimal.html#class-BigDecimal-label-A+Note+About+Precision).
+  #
+  def -: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - -self -> bigdecimal
+  # -->
+  # Returns the BigDecimal negation of self:
+  #
+  #     b0 = BigDecimal('1.5')
+  #     b1 = -b0 # => -0.15e1
+  #     b2 = -b1 # => 0.15e1
+  #
+  def -@: () -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - a / b   -> bigdecimal
+  # -->
+  # Divide by the specified value.
+  #
+  # The result precision will be the precision of the larger operand, but its
+  # minimum is 2*Float::DIG.
+  #
+  # See BigDecimal#div. See BigDecimal#quo.
+  #
+  def /: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self < other -> true or false
+  # -->
+  # Returns `true` if `self` is less than `other`, `false` otherwise:
+  #
+  #     b = BigDecimal('1.5') # => 0.15e1
+  #     b < 2                 # => true
+  #     b < 2.0               # => true
+  #     b < Rational(2, 1)    # => true
+  #     b < 1.5               # => false
+  #
+  # Raises an exception if the comparison cannot be made.
+  #
+  def <: (Numeric) -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self <= other -> true or false
+  # -->
+  # Returns `true` if `self` is less or equal to than `other`, `false` otherwise:
+  #
+  #     b = BigDecimal('1.5') # => 0.15e1
+  #     b <= 2                # => true
+  #     b <= 2.0              # => true
+  #     b <= Rational(2, 1)   # => true
+  #     b <= 1.5              # => true
+  #     b < 1                 # => false
+  #
+  # Raises an exception if the comparison cannot be made.
+  #
+  def <=: (Numeric) -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - <=>(p1)
+  # -->
+  # The comparison operator. a <=> b is 0 if a == b, 1 if a > b, -1 if a < b.
+  #
+  def <=>: (untyped) -> Integer?
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - ==(p1)
+  # -->
+  # Tests for value equality; returns true if the values are equal.
+  #
+  # The == and === operators and the eql? method have the same implementation for
+  # BigDecimal.
+  #
+  # Values may be coerced to perform the comparison:
+  #
+  #     BigDecimal('1.0') == 1.0  #=> true
+  #
+  def ==: (untyped) -> bool
+
+  # <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+  # Tests for value equality; returns true if the values are equal.
+  #
+  # The == and === operators and the eql? method have the same implementation for
+  # BigDecimal.
+  #
+  # Values may be coerced to perform the comparison:
+  #
+  #     BigDecimal('1.0') == 1.0  #=> true
+  #
+  def ===: (untyped) -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self > other -> true or false
+  # -->
+  # Returns `true` if `self` is greater than `other`, `false` otherwise:
+  #
+  #     b = BigDecimal('1.5')
+  #     b > 1              # => true
+  #     b > 1.0            # => true
+  #     b > Rational(1, 1) # => true
+  #     b > 2              # => false
+  #
+  # Raises an exception if the comparison cannot be made.
+  #
+  def >: (Numeric) -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - self >= other -> true or false
+  # -->
+  # Returns `true` if `self` is greater than or equal to `other`, `false`
+  # otherwise:
+  #
+  #     b = BigDecimal('1.5')
+  #     b >= 1              # => true
+  #     b >= 1.0            # => true
+  #     b >= Rational(1, 1) # => true
+  #     b >= 1.5            # => true
+  #     b > 2               # => false
+  #
+  # Raises an exception if the comparison cannot be made.
+  #
+  def >=: (Numeric) -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - _dump -> string
+  # -->
+  # Returns a string representing the marshalling of `self`. See module Marshal.
+  #
+  #     inf = BigDecimal('Infinity') # => Infinity
+  #     dumped = inf._dump           # => "9:Infinity"
+  #     BigDecimal._load(dumped)     # => Infinity
+  #
+  def _dump: (?untyped) -> String
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - abs -> bigdecimal
+  # -->
+  # Returns the BigDecimal absolute value of `self`:
+  #
+  #     BigDecimal('5').abs  # => 0.5e1
+  #     BigDecimal('-3').abs # => 0.3e1
+  #
+  def abs: () -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - add(value, ndigits) -> new_bigdecimal
+  # -->
+  # Returns the BigDecimal sum of `self` and `value` with a precision of `ndigits`
+  # decimal digits.
+  #
+  # When `ndigits` is less than the number of significant digits in the sum, the
+  # sum is rounded to that number of digits, according to the current rounding
+  # mode; see BigDecimal.mode.
+  #
+  # Examples:
+  #
+  #     # Set the rounding mode.
+  #     BigDecimal.mode(BigDecimal::ROUND_MODE, :half_up)
+  #     b = BigDecimal('111111.111')
+  #     b.add(1, 0)               # => 0.111112111e6
+  #     b.add(1, 3)               # => 0.111e6
+  #     b.add(1, 6)               # => 0.111112e6
+  #     b.add(1, 15)              # => 0.111112111e6
+  #     b.add(1.0, 15)            # => 0.111112111e6
+  #     b.add(Rational(1, 1), 15) # => 0.111112111e6
+  #
+  def add: (Numeric value, Integer digits) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - ceil(n)
+  # -->
+  # Return the smallest integer greater than or equal to the value, as a
+  # BigDecimal.
+  #
+  #     BigDecimal('3.14159').ceil #=> 4
+  #     BigDecimal('-9.1').ceil #=> -9
+  #
+  # If n is specified and positive, the fractional part of the result has no more
+  # than that many digits.
+  #
+  # If n is specified and negative, at least that many digits to the left of the
+  # decimal point will be 0 in the result.
+  #
+  #     BigDecimal('3.14159').ceil(3) #=> 3.142
+  #     BigDecimal('13345.234').ceil(-2) #=> 13400.0
+  #
+  def ceil: () -> Integer
+          | (int n) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - clone()
+  # -->
+  #
+  def clone: () -> self
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - coerce(p1)
+  # -->
+  # The coerce method provides support for Ruby type coercion. It is not enabled
+  # by default.
+  #
+  # This means that binary operations like + * / or - can often be performed on a
+  # BigDecimal and an object of another type, if the other object can be coerced
+  # into a BigDecimal value.
+  #
+  # e.g.
+  #     a = BigDecimal("1.0")
+  #     b = a / 2.0 #=> 0.5
+  #
+  # Note that coercing a String to a BigDecimal is not supported by default; it
+  # requires a special compile-time option when building Ruby.
+  #
+  def coerce: (Numeric) -> [ BigDecimal, BigDecimal ]
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - div(value)  -> integer
+  #   - div(value, digits)  -> bigdecimal or integer
+  # -->
+  # Divide by the specified value.
+  #
+  # digits
+  # :   If specified and less than the number of significant digits of the result,
+  #     the result is rounded to that number of digits, according to
+  #     BigDecimal.mode.
+  #
+  #     If digits is 0, the result is the same as for the / operator or #quo.
+  #
+  #     If digits is not specified, the result is an integer, by analogy with
+  #     Float#div; see also BigDecimal#divmod.
+  #
+  #
+  # See BigDecimal#/. See BigDecimal#quo.
+  #
+  # Examples:
+  #
+  #     a = BigDecimal("4")
+  #     b = BigDecimal("3")
+  #
+  #     a.div(b, 3)  # => 0.133e1
+  #
+  #     a.div(b, 0)  # => 0.1333333333333333333e1
+  #     a / b        # => 0.1333333333333333333e1
+  #     a.quo(b)     # => 0.1333333333333333333e1
+  #
+  #     a.div(b)     # => 1
+  #
+  def div: (Numeric value) -> Integer
+         | (Numeric value, int digits) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - divmod(value)
+  # -->
+  # Divides by the specified value, and returns the quotient and modulus as
+  # BigDecimal numbers. The quotient is rounded towards negative infinity.
+  #
+  # For example:
+  #
+  #     require 'bigdecimal'
+  #
+  #     a = BigDecimal("42")
+  #     b = BigDecimal("9")
+  #
+  #     q, m = a.divmod(b)
+  #
+  #     c = q * b + m
+  #
+  #     a == c  #=> true
+  #
+  # The quotient q is (a/b).floor, and the modulus is the amount that must be
+  # added to q * b to get a.
+  #
+  def divmod: (Numeric) -> [ BigDecimal, BigDecimal ]
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - dup()
+  # -->
+  #
+  def dup: () -> self
+
+  # <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+  # Tests for value equality; returns true if the values are equal.
+  #
+  # The == and === operators and the eql? method have the same implementation for
+  # BigDecimal.
+  #
+  # Values may be coerced to perform the comparison:
+  #
+  #     BigDecimal('1.0') == 1.0  #=> true
+  #
+  def eql?: (untyped) -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - exponent()
+  # -->
+  # Returns the exponent of the BigDecimal number, as an Integer.
+  #
+  # If the number can be represented as 0.xxxxxx*10**n where xxxxxx is a string of
+  # digits with no leading zeros, then n is the exponent.
+  #
+  def exponent: () -> Integer
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - finite?()
+  # -->
+  # Returns True if the value is finite (not NaN or infinite).
+  #
+  def finite?: () -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - fix()
+  # -->
+  # Return the integer part of the number, as a BigDecimal.
+  #
+  def fix: () -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - floor(n)
+  # -->
+  # Return the largest integer less than or equal to the value, as a BigDecimal.
+  #
+  #     BigDecimal('3.14159').floor #=> 3
+  #     BigDecimal('-9.1').floor #=> -10
+  #
+  # If n is specified and positive, the fractional part of the result has no more
+  # than that many digits.
+  #
+  # If n is specified and negative, at least that many digits to the left of the
+  # decimal point will be 0 in the result.
+  #
+  #     BigDecimal('3.14159').floor(3) #=> 3.141
+  #     BigDecimal('13345.234').floor(-2) #=> 13300.0
+  #
+  def floor: () -> Integer
+           | (int n) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - frac()
+  # -->
+  # Return the fractional part of the number, as a BigDecimal.
+  #
+  def frac: () -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - hash -> integer
+  # -->
+  # Returns the integer hash value for `self`.
+  #
+  # Two instances of BigDecimal have the same hash value if and only if they have
+  # equal:
+  #
+  # *   Sign.
+  # *   Fractional part.
+  # *   Exponent.
+  #
+  def hash: () -> Integer
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - infinite?()
+  # -->
+  # Returns nil, -1, or +1 depending on whether the value is finite, -Infinity, or
+  # +Infinity.
+  #
+  def infinite?: () -> Integer?
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - inspect()
+  # -->
+  # Returns a string representation of self.
+  #
+  #     BigDecimal("1234.5678").inspect
+  #       #=> "0.12345678e4"
+  #
+  def inspect: () -> String
+
+  # <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+  # Returns the modulus from dividing by b.
+  #
+  # See BigDecimal#divmod.
+  #
+  def modulo: (Numeric b) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - mult(other, ndigits) -> bigdecimal
+  # -->
+  # Returns the BigDecimal product of `self` and `value` with a precision of
+  # `ndigits` decimal digits.
+  #
+  # When `ndigits` is less than the number of significant digits in the sum, the
+  # sum is rounded to that number of digits, according to the current rounding
+  # mode; see BigDecimal.mode.
+  #
+  # Examples:
+  #
+  #     # Set the rounding mode.
+  #     BigDecimal.mode(BigDecimal::ROUND_MODE, :half_up)
+  #     b = BigDecimal('555555.555')
+  #     b.mult(3, 0)              # => 0.1666666665e7
+  #     b.mult(3, 3)              # => 0.167e7
+  #     b.mult(3, 6)              # => 0.166667e7
+  #     b.mult(3, 15)             # => 0.1666666665e7
+  #     b.mult(3.0, 0)            # => 0.1666666665e7
+  #     b.mult(Rational(3, 1), 0) # => 0.1666666665e7
+  #     b.mult(Complex(3, 0), 0)  # => (0.1666666665e7+0.0i)
+  #
+  def mult: (Numeric value, int digits) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - nan?()
+  # -->
+  # Returns True if the value is Not a Number.
+  #
+  def nan?: () -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - nonzero?()
+  # -->
+  # Returns self if the value is non-zero, nil otherwise.
+  #
+  def nonzero?: () -> self?
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - power(n)
+  #   - power(n, prec)
+  # -->
+  # Returns the value raised to the power of n.
+  #
+  # Note that n must be an Integer.
+  #
+  # Also available as the operator **.
+  #
+  def power: (Numeric n, int prec) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - precs -> array
+  # -->
+  # Returns an Array of two Integer values that represent platform-dependent
+  # internal storage properties.
+  #
+  # This method is deprecated and will be removed in the future. Instead, use
+  # BigDecimal#n_significant_digits for obtaining the number of significant digits
+  # in scientific notation, and BigDecimal#precision for obtaining the number of
+  # digits in decimal notation.
+  #
+  def precs: () -> [ Integer, Integer ]
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - quo(value)  -> bigdecimal
+  #   - quo(value, digits)  -> bigdecimal
+  # -->
+  # Divide by the specified value.
+  #
+  # digits
+  # :   If specified and less than the number of significant digits of the result,
+  #     the result is rounded to the given number of digits, according to the
+  #     rounding mode indicated by BigDecimal.mode.
+  #
+  #     If digits is 0 or omitted, the result is the same as for the / operator.
+  #
+  #
+  # See BigDecimal#/. See BigDecimal#div.
+  #
+  def quo: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - remainder(value)
+  # -->
+  # Returns the remainder from dividing by the value.
+  #
+  # x.remainder(y) means x-y*(x/y).truncate
+  #
+  def remainder: (Numeric) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - round(n, mode)
+  # -->
+  # Round to the nearest integer (by default), returning the result as a
+  # BigDecimal if n is specified, or as an Integer if it isn't.
+  #
+  #     BigDecimal('3.14159').round #=> 3
+  #     BigDecimal('8.7').round #=> 9
+  #     BigDecimal('-9.9').round #=> -10
+  #
+  #     BigDecimal('3.14159').round(2).class.name #=> "BigDecimal"
+  #     BigDecimal('3.14159').round.class.name #=> "Integer"
+  #
+  # If n is specified and positive, the fractional part of the result has no more
+  # than that many digits.
+  #
+  # If n is specified and negative, at least that many digits to the left of the
+  # decimal point will be 0 in the result, and return value will be an Integer.
+  #
+  #     BigDecimal('3.14159').round(3) #=> 3.142
+  #     BigDecimal('13345.234').round(-2) #=> 13300
+  #
+  # The value of the optional mode argument can be used to determine how rounding
+  # is performed; see BigDecimal.mode.
+  #
+  def round: () -> Integer
+           | (Numeric n, ?Integer mode) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - sign()
+  # -->
+  # Returns the sign of the value.
+  #
+  # Returns a positive value if > 0, a negative value if < 0. It behaves the same
+  # with zeros - it returns a positive value for a positive zero (BigDecimal('0'))
+  # and a negative value for a negative zero (BigDecimal('-0')).
+  #
+  # The specific value returned indicates the type and sign of the BigDecimal, as
+  # follows:
+  #
+  # BigDecimal::SIGN_NaN
+  # :   value is Not a Number
+  #
+  # BigDecimal::SIGN_POSITIVE_ZERO
+  # :   value is +0
+  #
+  # BigDecimal::SIGN_NEGATIVE_ZERO
+  # :   value is -0
+  #
+  # BigDecimal::SIGN_POSITIVE_INFINITE
+  # :   value is +Infinity
+  #
+  # BigDecimal::SIGN_NEGATIVE_INFINITE
+  # :   value is -Infinity
+  #
+  # BigDecimal::SIGN_POSITIVE_FINITE
+  # :   value is positive
+  #
+  # BigDecimal::SIGN_NEGATIVE_FINITE
+  # :   value is negative
+  #
+  def sign: () -> Integer
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - split()
+  # -->
+  # Splits a BigDecimal number into four parts, returned as an array of values.
+  #
+  # The first value represents the sign of the BigDecimal, and is -1 or 1, or 0 if
+  # the BigDecimal is Not a Number.
+  #
+  # The second value is a string representing the significant digits of the
+  # BigDecimal, with no leading zeros.
+  #
+  # The third value is the base used for arithmetic (currently always 10) as an
+  # Integer.
+  #
+  # The fourth value is an Integer exponent.
+  #
+  # If the BigDecimal can be represented as 0.xxxxxx*10**n, then xxxxxx is the
+  # string of significant digits with no leading zeros, and n is the exponent.
+  #
+  # From these values, you can translate a BigDecimal to a float as follows:
+  #
+  #     sign, significant_digits, base, exponent = a.split
+  #     f = sign * "0.#{significant_digits}".to_f * (base ** exponent)
+  #
+  # (Note that the to_f method is provided as a more convenient way to translate a
+  # BigDecimal to a Float.)
+  #
+  def split: () -> [ Integer, String, Integer, Integer ]
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - sqrt(n)
+  # -->
+  # Returns the square root of the value.
+  #
+  # Result has at least n significant digits.
+  #
+  def sqrt: (int n) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - sub(value, digits)  -> bigdecimal
+  # -->
+  # Subtract the specified value.
+  #
+  # e.g.
+  #     c = a.sub(b,n)
+  #
+  # digits
+  # :   If specified and less than the number of significant digits of the result,
+  #     the result is rounded to that number of digits, according to
+  #     BigDecimal.mode.
+  #
+  def sub: (Numeric value, int digits) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - to_f()
+  # -->
+  # Returns a new Float object having approximately the same value as the
+  # BigDecimal number. Normal accuracy limits and built-in errors of binary Float
+  # arithmetic apply.
+  #
+  def to_f: () -> Float
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - to_i()
+  # -->
+  # Returns the value as an Integer.
+  #
+  # If the BigDecimal is infinity or NaN, raises FloatDomainError.
+  #
+  def to_i: () -> Integer
+
+  # <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+  # Returns the value as an Integer.
+  #
+  # If the BigDecimal is infinity or NaN, raises FloatDomainError.
+  #
+  def to_int: () -> Integer
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - to_r()
+  # -->
+  # Converts a BigDecimal to a Rational.
+  #
+  def to_r: () -> Rational
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - to_s(s)
+  # -->
+  # Converts the value to a string.
+  #
+  # The default format looks like  0.xxxxEnn.
+  #
+  # The optional parameter s consists of either an integer; or an optional '+' or
+  # ' ', followed by an optional number, followed by an optional 'E' or 'F'.
+  #
+  # If there is a '+' at the start of s, positive values are returned with a
+  # leading '+'.
+  #
+  # A space at the start of s returns positive values with a leading space.
+  #
+  # If s contains a number, a space is inserted after each group of that many
+  # digits, starting from '.' and counting outwards.
+  #
+  # If s ends with an 'E', engineering notation (0.xxxxEnn) is used.
+  #
+  # If s ends with an 'F', conventional floating point notation is used.
+  #
+  # Examples:
+  #
+  #     BigDecimal('-1234567890123.45678901234567890').to_s('5F')
+  #       #=> '-123 45678 90123.45678 90123 45678 9'
+  #
+  #     BigDecimal('1234567890123.45678901234567890').to_s('+8F')
+  #       #=> '+12345 67890123.45678901 23456789'
+  #
+  #     BigDecimal('1234567890123.45678901234567890').to_s(' F')
+  #       #=> ' 1234567890123.4567890123456789'
+  #
+  def to_s: (?String | int s) -> String
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - truncate(n)
+  # -->
+  # Truncate to the nearest integer (by default), returning the result as a
+  # BigDecimal.
+  #
+  #     BigDecimal('3.14159').truncate #=> 3
+  #     BigDecimal('8.7').truncate #=> 8
+  #     BigDecimal('-9.9').truncate #=> -9
+  #
+  # If n is specified and positive, the fractional part of the result has no more
+  # than that many digits.
+  #
+  # If n is specified and negative, at least that many digits to the left of the
+  # decimal point will be 0 in the result.
+  #
+  #     BigDecimal('3.14159').truncate(3) #=> 3.141
+  #     BigDecimal('13345.234').truncate(-2) #=> 13300.0
+  #
+  def truncate: () -> Integer
+              | (int n) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - zero?()
+  # -->
+  # Returns True if the value is zero.
+  #
+  def zero?: () -> bool
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - a.to_d -> bigdecimal
+  # -->
+  # Returns self.
+  #
+  #     require 'bigdecimal/util'
+  #
+  #     d = BigDecimal("3.14")
+  #     d.to_d                       # => 0.314e1
+  #
+  def to_d: () -> BigDecimal
+
+  private
+
+  def initialize_copy: (self) -> self
+end
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Base value used in internal calculations.  On a 32 bit system, BASE is 10000,
+# indicating that calculation is done in groups of 4 digits. (If it were larger,
+# BASE**2 wouldn't fit in 32 bits, so you couldn't guarantee that two groups
+# could always be multiplied together without overflow.)
+#
+BigDecimal::BASE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines whether overflow, underflow or zero divide result in an exception
+# being thrown. See BigDecimal.mode.
+#
+BigDecimal::EXCEPTION_ALL: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines what happens when the result of a computation is infinity.  See
+# BigDecimal.mode.
+#
+BigDecimal::EXCEPTION_INFINITY: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines what happens when the result of a computation is not a number
+# (NaN). See BigDecimal.mode.
+#
+BigDecimal::EXCEPTION_NaN: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines what happens when the result of a computation is an overflow (a
+# result too large to be represented). See BigDecimal.mode.
+#
+BigDecimal::EXCEPTION_OVERFLOW: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines what happens when the result of a computation is an underflow (a
+# result too small to be represented). See BigDecimal.mode.
+#
+BigDecimal::EXCEPTION_UNDERFLOW: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines what happens when a division by zero is performed. See
+# BigDecimal.mode.
+#
+BigDecimal::EXCEPTION_ZERODIVIDE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Special value constants
+#
+BigDecimal::INFINITY: BigDecimal
+
+BigDecimal::NAN: BigDecimal
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Round towards +Infinity. See BigDecimal.mode.
+#
+BigDecimal::ROUND_CEILING: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that values should be rounded towards zero. See BigDecimal.mode.
+#
+BigDecimal::ROUND_DOWN: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Round towards -Infinity. See BigDecimal.mode.
+#
+BigDecimal::ROUND_FLOOR: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that digits >= 6 should be rounded up, others rounded down. See
+# BigDecimal.mode.
+#
+BigDecimal::ROUND_HALF_DOWN: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Round towards the even neighbor. See BigDecimal.mode.
+#
+BigDecimal::ROUND_HALF_EVEN: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that digits >= 5 should be rounded up, others rounded down. See
+# BigDecimal.mode.
+#
+BigDecimal::ROUND_HALF_UP: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Determines what happens when a result must be rounded in order to fit in the
+# appropriate number of significant digits. See BigDecimal.mode.
+#
+BigDecimal::ROUND_MODE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that values should be rounded away from zero. See BigDecimal.mode.
+#
+BigDecimal::ROUND_UP: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is negative and finite. See BigDecimal.sign.
+#
+BigDecimal::SIGN_NEGATIVE_FINITE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is negative and infinite. See BigDecimal.sign.
+#
+BigDecimal::SIGN_NEGATIVE_INFINITE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is -0. See BigDecimal.sign.
+#
+BigDecimal::SIGN_NEGATIVE_ZERO: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is not a number. See BigDecimal.sign.
+#
+BigDecimal::SIGN_NaN: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is positive and finite. See BigDecimal.sign.
+#
+BigDecimal::SIGN_POSITIVE_FINITE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is positive and infinite. See BigDecimal.sign.
+#
+BigDecimal::SIGN_POSITIVE_INFINITE: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# Indicates that a value is +0. See BigDecimal.sign.
+#
+BigDecimal::SIGN_POSITIVE_ZERO: Integer
+
+# <!-- rdoc-file=ext/bigdecimal/bigdecimal.c -->
+# The version of bigdecimal library
+#
+BigDecimal::VERSION: String
+
+%a{annotate:rdoc:skip}
+module Kernel
+  private
+
+  # <!--
+  #   rdoc-file=ext/bigdecimal/bigdecimal.c
+  #   - BigDecimal(value, exception: true) -> bigdecimal
+  #   - BigDecimal(value, ndigits, exception: true) -> bigdecimal
+  # -->
+  # Returns the BigDecimal converted from `value` with a precision of `ndigits`
+  # decimal digits.
+  #
+  # When `ndigits` is less than the number of significant digits in the value, the
+  # result is rounded to that number of digits, according to the current rounding
+  # mode; see BigDecimal.mode.
+  #
+  # When `ndigits` is 0, the number of digits to correctly represent a float
+  # number is determined automatically.
+  #
+  # Returns `value` converted to a BigDecimal, depending on the type of `value`:
+  #
+  # *   Integer, Float, Rational, Complex, or BigDecimal: converted directly:
+  #
+  #         # Integer, Complex, or BigDecimal value does not require ndigits; ignored if given.
+  #         BigDecimal(2)                     # => 0.2e1
+  #         BigDecimal(Complex(2, 0))         # => 0.2e1
+  #         BigDecimal(BigDecimal(2))         # => 0.2e1
+  #         # Float or Rational value requires ndigits.
+  #         BigDecimal(2.0, 0)                # => 0.2e1
+  #         BigDecimal(Rational(2, 1), 0)     # => 0.2e1
+  #
+  # *   String: converted by parsing if it contains an integer or floating-point
+  #     literal; leading and trailing whitespace is ignored:
+  #
+  #         # String does not require ndigits; ignored if given.
+  #         BigDecimal('2')     # => 0.2e1
+  #         BigDecimal('2.0')   # => 0.2e1
+  #         BigDecimal('0.2e1') # => 0.2e1
+  #         BigDecimal(' 2.0 ') # => 0.2e1
+  #
+  # *   Other type that responds to method `:to_str`: first converted to a string,
+  #     then converted to a BigDecimal, as above.
+  #
+  # *   Other type:
+  #
+  #     *   Raises an exception if keyword argument `exception` is `true`.
+  #     *   Returns `nil` if keyword argument `exception` is `false`.
+  #
+  # Raises an exception if `value` evaluates to a Float and `digits` is larger
+  # than Float::DIG + 1.
+  #
+  def self?.BigDecimal: (real | string | BigDecimal initial, ?int digits, ?exception: bool) -> BigDecimal
+end
+
+%a{annotate:rdoc:skip}
+class Integer
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - int.to_d  -> bigdecimal
+  # -->
+  # Returns the value of `int` as a BigDecimal.
+  #
+  #     require 'bigdecimal'
+  #     require 'bigdecimal/util'
+  #
+  #     42.to_d   # => 0.42e2
+  #
+  # See also Kernel.BigDecimal.
+  #
+  def to_d: () -> BigDecimal
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self / numeric -> numeric_result
+  # -->
+  # Performs division; for integer `numeric`, truncates the result to an integer:
+  #
+  #      4 / 3              # => 1
+  #      4 / -3             # => -2
+  #      -4 / 3             # => -2
+  #      -4 / -3            # => 1
+  #
+  #     For other +numeric+, returns non-integer result:
+  #
+  #      4 / 3.0            # => 1.3333333333333333
+  #      4 / Rational(3, 1) # => (4/3)
+  #      4 / Complex(3, 0)  # => ((4/3)+0i)
+  #
+  def /: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self * numeric -> numeric_result
+  # -->
+  # Performs multiplication:
+  #
+  #     4 * 2              # => 8
+  #     4 * -2             # => -8
+  #     -4 * 2             # => -8
+  #     4 * 2.0            # => 8.0
+  #     4 * Rational(1, 3) # => (4/3)
+  #     4 * Complex(2, 0)  # => (8+0i)
+  #
+  def *: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self + numeric -> numeric_result
+  # -->
+  # Performs addition:
+  #
+  #     2 + 2              # => 4
+  #     -2 + 2             # => 0
+  #     -2 + -2            # => -4
+  #     2 + 2.0            # => 4.0
+  #     2 + Rational(2, 1) # => (4/1)
+  #     2 + Complex(2, 0)  # => (4+0i)
+  #
+  def +: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self - numeric -> numeric_result
+  # -->
+  # Performs subtraction:
+  #
+  #     4 - 2              # => 2
+  #     -4 - 2             # => -6
+  #     -4 - -2            # => -2
+  #     4 - 2.0            # => 2.0
+  #     4 - Rational(2, 1) # => (2/1)
+  #     4 - Complex(2, 0)  # => (2+0i)
+  #
+  def -: (BigDecimal) -> BigDecimal
+    | ...
+end
+
+%a{annotate:rdoc:skip}
+class Float
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - float.to_d             -> bigdecimal
+  #   - float.to_d(precision)  -> bigdecimal
+  # -->
+  # Returns the value of `float` as a BigDecimal. The `precision` parameter is
+  # used to determine the number of significant digits for the result. When
+  # `precision` is set to `0`, the number of digits to represent the float being
+  # converted is determined automatically. The default `precision` is `0`.
+  #
+  #     require 'bigdecimal'
+  #     require 'bigdecimal/util'
+  #
+  #     0.5.to_d         # => 0.5e0
+  #     1.234.to_d       # => 0.1234e1
+  #     1.234.to_d(2)    # => 0.12e1
+  #
+  # See also Kernel.BigDecimal.
+  #
+  def to_d: (?Integer precision) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self / other -> numeric
+  # -->
+  # Returns a new Float which is the result of dividing `self` by `other`:
+  #
+  #     f = 3.14
+  #     f / 2              # => 1.57
+  #     f / 2.0            # => 1.57
+  #     f / Rational(2, 1) # => 1.57
+  #     f / Complex(2, 0)  # => (1.57+0.0i)
+  #
+  def /: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self * other -> numeric
+  # -->
+  # Returns a new Float which is the product of `self` and `other`:
+  #
+  #     f = 3.14
+  #     f * 2              # => 6.28
+  #     f * 2.0            # => 6.28
+  #     f * Rational(1, 2) # => 1.57
+  #     f * Complex(2, 0)  # => (6.28+0.0i)
+  #
+  def *: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self + other -> numeric
+  # -->
+  # Returns a new Float which is the sum of `self` and `other`:
+  #
+  #     f = 3.14
+  #     f + 1                 # => 4.140000000000001
+  #     f + 1.0               # => 4.140000000000001
+  #     f + Rational(1, 1)    # => 4.140000000000001
+  #     f + Complex(1, 0)     # => (4.140000000000001+0i)
+  #
+  def +: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - self - other -> numeric
+  # -->
+  # Returns a new Float which is the difference of `self` and `other`:
+  #
+  #     f = 3.14
+  #     f - 1                 # => 2.14
+  #     f - 1.0               # => 2.14
+  #     f - Rational(1, 1)    # => 2.14
+  #     f - Complex(1, 0)     # => (2.14+0i)
+  #
+  def -: (BigDecimal) -> BigDecimal
+    | ...
+end
+
+%a{annotate:rdoc:skip}
+class String
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - str.to_d  -> bigdecimal
+  # -->
+  # Returns the result of interpreting leading characters in `str` as a
+  # BigDecimal.
+  #
+  #     require 'bigdecimal'
+  #     require 'bigdecimal/util'
+  #
+  #     "0.5".to_d             # => 0.5e0
+  #     "123.45e1".to_d        # => 0.12345e4
+  #     "45.67 degrees".to_d   # => 0.4567e2
+  #
+  # See also Kernel.BigDecimal.
+  #
+  def to_d: () -> BigDecimal
+end
+
+%a{annotate:rdoc:skip}
+class Rational
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - rat.to_d(precision)  -> bigdecimal
+  # -->
+  # Returns the value as a BigDecimal.
+  #
+  # The required `precision` parameter is used to determine the number of
+  # significant digits for the result.
+  #
+  #     require 'bigdecimal'
+  #     require 'bigdecimal/util'
+  #
+  #     Rational(22, 7).to_d(3)   # => 0.314e1
+  #
+  # See also Kernel.BigDecimal.
+  #
+  def to_d: (Integer precision) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=rational.c
+  #   - rat / numeric     ->  numeric
+  #   - rat.quo(numeric)  ->  numeric
+  # -->
+  # Performs division.
+  #
+  #     Rational(2, 3)  / Rational(2, 3)   #=> (1/1)
+  #     Rational(900)   / Rational(1)      #=> (900/1)
+  #     Rational(-2, 9) / Rational(-9, 2)  #=> (4/81)
+  #     Rational(9, 8)  / 4                #=> (9/32)
+  #     Rational(20, 9) / 9.8              #=> 0.22675736961451246
+  #
+  def /: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=rational.c
+  #   - rat * numeric  ->  numeric
+  # -->
+  # Performs multiplication.
+  #
+  #     Rational(2, 3)  * Rational(2, 3)   #=> (4/9)
+  #     Rational(900)   * Rational(1)      #=> (900/1)
+  #     Rational(-2, 9) * Rational(-9, 2)  #=> (1/1)
+  #     Rational(9, 8)  * 4                #=> (9/2)
+  #     Rational(20, 9) * 9.8              #=> 21.77777777777778
+  #
+  def *: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=rational.c
+  #   - rat + numeric  ->  numeric
+  # -->
+  # Performs addition.
+  #
+  #     Rational(2, 3)  + Rational(2, 3)   #=> (4/3)
+  #     Rational(900)   + Rational(1)      #=> (901/1)
+  #     Rational(-2, 9) + Rational(-9, 2)  #=> (-85/18)
+  #     Rational(9, 8)  + 4                #=> (41/8)
+  #     Rational(20, 9) + 9.8              #=> 12.022222222222222
+  #
+  def +: (BigDecimal) -> BigDecimal
+    | ...
+
+  # <!--
+  #   rdoc-file=rational.c
+  #   - rat - numeric  ->  numeric
+  # -->
+  # Performs subtraction.
+  #
+  #     Rational(2, 3)  - Rational(2, 3)   #=> (0/1)
+  #     Rational(900)   - Rational(1)      #=> (899/1)
+  #     Rational(-2, 9) - Rational(-9, 2)  #=> (77/18)
+  #     Rational(9, 8)  - 4                #=> (-23/8)
+  #     Rational(20, 9) - 9.8              #=> -7.577777777777778
+  #
+  def -: (BigDecimal) -> BigDecimal
+    | ...
+end
+
+%a{annotate:rdoc:skip}
+class Complex
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - cmp.to_d             -> bigdecimal
+  #   - cmp.to_d(precision)  -> bigdecimal
+  # -->
+  # Returns the value as a BigDecimal.
+  #
+  # The `precision` parameter is required for a rational complex number. This
+  # parameter is used to determine the number of significant digits for the
+  # result.
+  #
+  #     require 'bigdecimal'
+  #     require 'bigdecimal/util'
+  #
+  #     Complex(0.1234567, 0).to_d(4)   # => 0.1235e0
+  #     Complex(Rational(22, 7), 0).to_d(3)   # => 0.314e1
+  #
+  # See also Kernel.BigDecimal.
+  #
+  def to_d: (*untyped args) -> BigDecimal
+
+  # <!--
+  #   rdoc-file=complex.c
+  #   - complex / numeric -> new_complex
+  # -->
+  # Returns the quotient of `self` and `numeric`:
+  #
+  #     Complex.rect(2, 3)  / Complex.rect(2, 3)  # => (1+0i)
+  #     Complex.rect(900)   / Complex.rect(1)     # => (900+0i)
+  #     Complex.rect(-2, 9) / Complex.rect(-9, 2) # => ((36/85)-(77/85)*i)
+  #     Complex.rect(9, 8)  / 4                   # => ((9/4)+2i)
+  #     Complex.rect(20, 9) / 9.8                 # => (2.0408163265306123+0.9183673469387754i)
+  #
+  def /: (BigDecimal) -> Complex
+    | ...
+
+  # <!--
+  #   rdoc-file=complex.c
+  #   - complex * numeric -> new_complex
+  # -->
+  # Returns the product of `self` and `numeric`:
+  #
+  #     Complex.rect(2, 3)  * Complex.rect(2, 3)  # => (-5+12i)
+  #     Complex.rect(900)   * Complex.rect(1)     # => (900+0i)
+  #     Complex.rect(-2, 9) * Complex.rect(-9, 2) # => (0-85i)
+  #     Complex.rect(9, 8)  * 4                   # => (36+32i)
+  #     Complex.rect(20, 9) * 9.8                 # => (196.0+88.2i)
+  #
+  def *: (BigDecimal) -> Complex
+    | ...
+
+  # <!--
+  #   rdoc-file=complex.c
+  #   - complex + numeric -> new_complex
+  # -->
+  # Returns the sum of `self` and `numeric`:
+  #
+  #     Complex.rect(2, 3)  + Complex.rect(2, 3)  # => (4+6i)
+  #     Complex.rect(900)   + Complex.rect(1)     # => (901+0i)
+  #     Complex.rect(-2, 9) + Complex.rect(-9, 2) # => (-11+11i)
+  #     Complex.rect(9, 8)  + 4                   # => (13+8i)
+  #     Complex.rect(20, 9) + 9.8                 # => (29.8+9i)
+  #
+  def +: (BigDecimal) -> Complex
+    | ...
+
+  # <!--
+  #   rdoc-file=complex.c
+  #   - complex - numeric -> new_complex
+  # -->
+  # Returns the difference of `self` and `numeric`:
+  #
+  #     Complex.rect(2, 3)  - Complex.rect(2, 3)  # => (0+0i)
+  #     Complex.rect(900)   - Complex.rect(1)     # => (899+0i)
+  #     Complex.rect(-2, 9) - Complex.rect(-9, 2) # => (7+7i)
+  #     Complex.rect(9, 8)  - 4                   # => (5+8i)
+  #     Complex.rect(20, 9) - 9.8                 # => (10.2+9i)
+  #
+  def -: (BigDecimal) -> Complex
+    | ...
+end
+
+%a{annotate:rdoc:skip}
+class NilClass
+  # <!--
+  #   rdoc-file=ext/bigdecimal/lib/bigdecimal/util.rb
+  #   - nil.to_d -> bigdecimal
+  # -->
+  # Returns nil represented as a BigDecimal.
+  #
+  #     require 'bigdecimal'
+  #     require 'bigdecimal/util'
+  #
+  #     nil.to_d   # => 0.0
+  #
+  def to_d: () -> BigDecimal
+end

--- a/gems/bigdecimal/_reviewers.yaml
+++ b/gems/bigdecimal/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/csv/.rubocop.yml
+++ b/gems/csv/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/csv/3.3/_test/test.rb
+++ b/gems/csv/3.3/_test/test.rb
@@ -1,0 +1,18 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "csv"
+
+csv = CSV.new("header1,header2\nrow1_1,row1_2")
+csv.headers
+
+csv = CSV.new("header1,header2\nrow1_1,row1_2", headers: true)
+csv.headers
+csv.read
+csv.headers
+
+[1, 2, 3].to_csv
+[1, 2, 3].to_csv(col_sep: '\t')
+
+"1,2,3".parse_csv
+"1,2,3".parse_csv(col_sep: '\t')

--- a/gems/csv/3.3/csv.rbs
+++ b/gems/csv/3.3/csv.rbs
@@ -1,0 +1,3776 @@
+# <!-- rdoc-file=lib/csv.rb -->
+# ## CSV
+#
+# ### CSV Data
+#
+# CSV (comma-separated values) data is a text representation of a table:
+# *   A *row* *separator* delimits table rows. A common row separator is the
+#     newline character `"\n"`.
+# *   A *column* *separator* delimits fields in a row. A common column separator
+#     is the comma character `","`.
+#
+# This CSV String, with row separator `"\n"` and column separator `","`, has
+# three rows and two columns:
+#     "foo,0\nbar,1\nbaz,2\n"
+#
+# Despite the name CSV, a CSV representation can use different separators.
+#
+# For more about tables, see the Wikipedia article "[Table
+# (information)](https://en.wikipedia.org/wiki/Table_(information))", especially
+# its section "[Simple
+# table](https://en.wikipedia.org/wiki/Table_(information)#Simple_table)"
+#
+# ## Class CSV
+#
+# Class CSV provides methods for:
+# *   Parsing CSV data from a String object, a File (via its file path), or an
+#     IO object.
+# *   Generating CSV data to a String object.
+#
+# To make CSV available:
+#     require 'csv'
+#
+# All examples here assume that this has been done.
+#
+# ## Keeping It Simple
+#
+# A CSV object has dozens of instance methods that offer fine-grained control of
+# parsing and generating CSV data. For many needs, though, simpler approaches
+# will do.
+#
+# This section summarizes the singleton methods in CSV that allow you to parse
+# and generate without explicitly creating CSV objects. For details, follow the
+# links.
+#
+# ### Simple Parsing
+#
+# Parsing methods commonly return either of:
+# *   An Array of Arrays of Strings:
+#     *   The outer Array is the entire "table".
+#     *   Each inner Array is a row.
+#     *   Each String is a field.
+# *   A CSV::Table object.  For details, see [\CSV with
+#     Headers](#class-CSV-label-CSV+with+Headers).
+#
+# #### Parsing a String
+#
+# The input to be parsed can be a string:
+#     string = "foo,0\nbar,1\nbaz,2\n"
+#
+# Method CSV.parse returns the entire CSV data:
+#     CSV.parse(string) # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Method CSV.parse_line returns only the first row:
+#     CSV.parse_line(string) # => ["foo", "0"]
+#
+# CSV extends class String with instance method String#parse_csv, which also
+# returns only the first row:
+#     string.parse_csv # => ["foo", "0"]
+#
+# #### Parsing Via a File Path
+#
+# The input to be parsed can be in a file:
+#     string = "foo,0\nbar,1\nbaz,2\n"
+#     path = 't.csv'
+#     File.write(path, string)
+#
+# Method CSV.read returns the entire CSV data:
+#     CSV.read(path) # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Method CSV.foreach iterates, passing each row to the given block:
+#     CSV.foreach(path) do |row|
+#       p row
+#     end
+#
+# Output:
+#     ["foo", "0"]
+#     ["bar", "1"]
+#     ["baz", "2"]
+#
+# Method CSV.table returns the entire CSV data as a CSV::Table object:
+#     CSV.table(path) # => #<CSV::Table mode:col_or_row row_count:3>
+#
+# #### Parsing from an Open IO Stream
+#
+# The input to be parsed can be in an open IO stream:
+#
+# Method CSV.read returns the entire CSV data:
+#     File.open(path) do |file|
+#       CSV.read(file)
+#     end # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# As does method CSV.parse:
+#     File.open(path) do |file|
+#       CSV.parse(file)
+#     end # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Method CSV.parse_line returns only the first row:
+#     File.open(path) do |file|
+#      CSV.parse_line(file)
+#     end # => ["foo", "0"]
+#
+# Method CSV.foreach iterates, passing each row to the given block:
+#     File.open(path) do |file|
+#       CSV.foreach(file) do |row|
+#         p row
+#       end
+#     end
+#
+# Output:
+#     ["foo", "0"]
+#     ["bar", "1"]
+#     ["baz", "2"]
+#
+# Method CSV.table returns the entire CSV data as a CSV::Table object:
+#     File.open(path) do |file|
+#       CSV.table(file)
+#     end # => #<CSV::Table mode:col_or_row row_count:3>
+#
+# ### Simple Generating
+#
+# Method CSV.generate returns a String; this example uses method CSV#<< to
+# append the rows that are to be generated:
+#     output_string = CSV.generate do |csv|
+#       csv << ['foo', 0]
+#       csv << ['bar', 1]
+#       csv << ['baz', 2]
+#     end
+#     output_string # => "foo,0\nbar,1\nbaz,2\n"
+#
+# Method CSV.generate_line returns a String containing the single row
+# constructed from an Array:
+#     CSV.generate_line(['foo', '0']) # => "foo,0\n"
+#
+# CSV extends class Array with instance method `Array#to_csv`, which forms an
+# Array into a String:
+#     ['foo', '0'].to_csv # => "foo,0\n"
+#
+# ### "Filtering" CSV
+#
+# Method CSV.filter provides a Unix-style filter for CSV data. The input data is
+# processed to form the output data:
+#     in_string = "foo,0\nbar,1\nbaz,2\n"
+#     out_string = ''
+#     CSV.filter(in_string, out_string) do |row|
+#       row[0] = row[0].upcase
+#       row[1] *= 4
+#     end
+#     out_string # => "FOO,0000\nBAR,1111\nBAZ,2222\n"
+#
+# ## CSV Objects
+#
+# There are three ways to create a CSV object:
+# *   Method CSV.new returns a new CSV object.
+# *   Method CSV.instance returns a new or cached CSV object.
+# *   Method CSV() also returns a new or cached CSV object.
+#
+# ### Instance Methods
+#
+# CSV has three groups of instance methods:
+# *   Its own internally defined instance methods.
+# *   Methods included by module Enumerable.
+# *   Methods delegated to class IO. See below.
+#
+# #### Delegated Methods
+#
+# For convenience, a CSV object will delegate to many methods in class IO. (A
+# few have wrapper "guard code" in CSV.) You may call:
+# *   IO#binmode
+# *   #binmode?
+# *   IO#close
+# *   IO#close_read
+# *   IO#close_write
+# *   IO#closed?
+# *   #eof
+# *   #eof?
+# *   IO#external_encoding
+# *   IO#fcntl
+# *   IO#fileno
+# *   #flock
+# *   IO#flush
+# *   IO#fsync
+# *   IO#internal_encoding
+# *   #ioctl
+# *   IO#isatty
+# *   #path
+# *   IO#pid
+# *   IO#pos
+# *   IO#pos=
+# *   IO#reopen
+# *   #rewind
+# *   IO#seek
+# *   #stat
+# *   IO#string
+# *   IO#sync
+# *   IO#sync=
+# *   IO#tell
+# *   #to_i
+# *   #to_io
+# *   IO#truncate
+# *   IO#tty?
+#
+# ### Options
+#
+# The default values for options are:
+#     DEFAULT_OPTIONS = {
+#       # For both parsing and generating.
+#       col_sep:            ",",
+#       row_sep:            :auto,
+#       quote_char:         '"',
+#       # For parsing.
+#       field_size_limit:   nil,
+#       converters:         nil,
+#       unconverted_fields: nil,
+#       headers:            false,
+#       return_headers:     false,
+#       header_converters:  nil,
+#       skip_blanks:        false,
+#       skip_lines:         nil,
+#       liberal_parsing:    false,
+#       nil_value:          nil,
+#       empty_value:        "",
+#       strip:              false,
+#       # For generating.
+#       write_headers:      nil,
+#       quote_empty:        true,
+#       force_quotes:       false,
+#       write_converters:   nil,
+#       write_nil_value:    nil,
+#       write_empty_value:  "",
+#     }
+#
+# #### Options for Parsing
+#
+# Options for parsing, described in detail below, include:
+# *   `row_sep`: Specifies the row separator; used to delimit rows.
+# *   `col_sep`: Specifies the column separator; used to delimit fields.
+# *   `quote_char`: Specifies the quote character; used to quote fields.
+# *   `field_size_limit`: Specifies the maximum field size + 1 allowed.
+#     Deprecated since 3.2.3. Use `max_field_size` instead.
+# *   `max_field_size`: Specifies the maximum field size allowed.
+# *   `converters`: Specifies the field converters to be used.
+# *   `unconverted_fields`: Specifies whether unconverted fields are to be
+#     available.
+# *   `headers`: Specifies whether data contains headers, or specifies the
+#     headers themselves.
+# *   `return_headers`: Specifies whether headers are to be returned.
+# *   `header_converters`: Specifies the header converters to be used.
+# *   `skip_blanks`: Specifies whether blanks lines are to be ignored.
+# *   `skip_lines`: Specifies how comments lines are to be recognized.
+# *   `strip`: Specifies whether leading and trailing whitespace are to be
+#     stripped from fields. This must be compatible with `col_sep`; if it is
+#     not, then an `ArgumentError` exception will be raised.
+# *   `liberal_parsing`: Specifies whether CSV should attempt to parse
+#     non-compliant data.
+# *   `nil_value`: Specifies the object that is to be substituted for each null
+#     (no-text) field.
+# *   `empty_value`: Specifies the object that is to be substituted for each
+#     empty field.
+#
+# ###### Option `row_sep`
+#
+# Specifies the row separator, a String or the Symbol `:auto` (see below), to be
+# used for both parsing and generating.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:row_sep) # => :auto
+#
+# ---
+#
+# When `row_sep` is a String, that String becomes the row separator. The String
+# will be transcoded into the data's Encoding before use.
+#
+# Using `"\n"`:
+#     row_sep = "\n"
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `|` (pipe):
+#     row_sep = '|'
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0|bar,1|baz,2|"
+#     ary = CSV.parse(str, row_sep: row_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `--` (two hyphens):
+#     row_sep = '--'
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0--bar,1--baz,2--"
+#     ary = CSV.parse(str, row_sep: row_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `''` (empty string):
+#     row_sep = ''
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0bar,1baz,2"
+#     ary = CSV.parse(str, row_sep: row_sep)
+#     ary # => [["foo", "0bar", "1baz", "2"]]
+#
+# ---
+#
+# When `row_sep` is the Symbol `:auto` (the default), generating uses `"\n"` as
+# the row separator:
+#     str = CSV.generate do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#
+# Parsing, on the other hand, invokes auto-discovery of the row separator.
+#
+# Auto-discovery reads ahead in the data looking for the next `\r\n`, `\n`, or
+# `\r` sequence. The sequence will be selected even if it occurs in a quoted
+# field, assuming that you would have the same line endings there.
+#
+# Example:
+#     str = CSV.generate do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# The default `$INPUT_RECORD_SEPARATOR` (`$/`) is used if any of the following
+# is true:
+# *   None of those sequences is found.
+# *   Data is `ARGF`, `STDIN`, `STDOUT`, or `STDERR`.
+# *   The stream is only available for output.
+#
+# Obviously, discovery takes a little time. Set manually if speed is important.
+# Also note that IO objects should be opened in binary mode on Windows if this
+# feature will be used as the line-ending translation can cause problems with
+# resetting the document position to where it was before the read ahead.
+#
+# ###### Option `col_sep`
+#
+# Specifies the String field separator to be used for both parsing and
+# generating. The String will be transcoded into the data's Encoding before use.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:col_sep) # => "," (comma)
+#
+# Using the default (comma):
+#     str = CSV.generate do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `:` (colon):
+#     col_sep = ':'
+#     str = CSV.generate(col_sep: col_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo:0\nbar:1\nbaz:2\n"
+#     ary = CSV.parse(str, col_sep: col_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `::` (two colons):
+#     col_sep = '::'
+#     str = CSV.generate(col_sep: col_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo::0\nbar::1\nbaz::2\n"
+#     ary = CSV.parse(str, col_sep: col_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `''` (empty string):
+#     col_sep = ''
+#     str = CSV.generate(col_sep: col_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo0\nbar1\nbaz2\n"
+#
+# ---
+#
+# Raises an exception if parsing with the empty String:
+#     col_sep = ''
+#     # Raises ArgumentError (:col_sep must be 1 or more characters: "")
+#     CSV.parse("foo0\nbar1\nbaz2\n", col_sep: col_sep)
+#
+# ###### Option `quote_char`
+#
+# Specifies the character (String of length 1) used used to quote fields in both
+# parsing and generating. This String will be transcoded into the data's
+# Encoding before use.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:quote_char) # => "\"" (double quote)
+#
+# This is useful for an application that incorrectly uses `'` (single-quote) to
+# quote fields, instead of the correct `"` (double-quote).
+#
+# Using the default (double quote):
+#     str = CSV.generate do |csv|
+#       csv << ['foo', 0]
+#       csv << ["'bar'", 1]
+#       csv << ['"baz"', 2]
+#     end
+#     str # => "foo,0\n'bar',1\n\"\"\"baz\"\"\",2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["'bar'", "1"], ["\"baz\"", "2"]]
+#
+# Using `'` (single-quote):
+#     quote_char = "'"
+#     str = CSV.generate(quote_char: quote_char) do |csv|
+#       csv << ['foo', 0]
+#       csv << ["'bar'", 1]
+#       csv << ['"baz"', 2]
+#     end
+#     str # => "foo,0\n'''bar''',1\n\"baz\",2\n"
+#     ary = CSV.parse(str, quote_char: quote_char)
+#     ary # => [["foo", "0"], ["'bar'", "1"], ["\"baz\"", "2"]]
+#
+# ---
+#
+# Raises an exception if the String length is greater than 1:
+#     # Raises ArgumentError (:quote_char has to be nil or a single character String)
+#     CSV.new('', quote_char: 'xx')
+#
+# Raises an exception if the value is not a String:
+#     # Raises ArgumentError (:quote_char has to be nil or a single character String)
+#     CSV.new('', quote_char: :foo)
+#
+# ###### Option `field_size_limit`
+#
+# Specifies the Integer field size limit.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:field_size_limit) # => nil
+#
+# This is a maximum size CSV will read ahead looking for the closing quote for a
+# field. (In truth, it reads to the first line ending beyond this size.) If a
+# quote cannot be found within the limit CSV will raise a MalformedCSVError,
+# assuming the data is faulty. You can use this limit to prevent what are
+# effectively DoS attacks on the parser. However, this limit can cause a
+# legitimate parse to fail; therefore the default value is `nil` (no limit).
+#
+# For the examples in this section:
+#     str = <<~EOT
+#       "a","b"
+#       "
+#       2345
+#       ",""
+#     EOT
+#     str # => "\"a\",\"b\"\n\"\n2345\n\",\"\"\n"
+#
+# Using the default `nil`:
+#     ary = CSV.parse(str)
+#     ary # => [["a", "b"], ["\n2345\n", ""]]
+#
+# Using `50`:
+#     field_size_limit = 50
+#     ary = CSV.parse(str, field_size_limit: field_size_limit)
+#     ary # => [["a", "b"], ["\n2345\n", ""]]
+#
+# ---
+#
+# Raises an exception if a field is too long:
+#     big_str = "123456789\n" * 1024
+#     # Raises CSV::MalformedCSVError (Field size exceeded in line 1.)
+#     CSV.parse('valid,fields,"' + big_str + '"', field_size_limit: 2048)
+#
+# ###### Option `converters`
+#
+# Specifies converters to be used in parsing fields. See [Field
+# Converters](#class-CSV-label-Field+Converters)
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:converters) # => nil
+#
+# The value may be a field converter name (see [Stored
+# Converters](#class-CSV-label-Stored+Converters)):
+#     str = '1,2,3'
+#     # Without a converter
+#     array = CSV.parse_line(str)
+#     array # => ["1", "2", "3"]
+#     # With built-in converter :integer
+#     array = CSV.parse_line(str, converters: :integer)
+#     array # => [1, 2, 3]
+#
+# The value may be a converter list (see [Converter
+# Lists](#class-CSV-label-Converter+Lists)):
+#     str = '1,3.14159'
+#     # Without converters
+#     array = CSV.parse_line(str)
+#     array # => ["1", "3.14159"]
+#     # With built-in converters
+#     array = CSV.parse_line(str, converters: [:integer, :float])
+#     array # => [1, 3.14159]
+#
+# The value may be a Proc custom converter: (see [Custom Field
+# Converters](#class-CSV-label-Custom+Field+Converters)):
+#     str = ' foo  ,  bar  ,  baz  '
+#     # Without a converter
+#     array = CSV.parse_line(str)
+#     array # => [" foo  ", "  bar  ", "  baz  "]
+#     # With a custom converter
+#     array = CSV.parse_line(str, converters: proc {|field| field.strip })
+#     array # => ["foo", "bar", "baz"]
+#
+# See also [Custom Field Converters](#class-CSV-label-Custom+Field+Converters)
+#
+# ---
+#
+# Raises an exception if the converter is not a converter name or a Proc:
+#     str = 'foo,0'
+#     # Raises NoMethodError (undefined method `arity' for nil:NilClass)
+#     CSV.parse(str, converters: :foo)
+#
+# ###### Option `unconverted_fields`
+#
+# Specifies the boolean that determines whether unconverted field values are to
+# be available.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:unconverted_fields) # => nil
+#
+# The unconverted field values are those found in the source data, prior to any
+# conversions performed via option `converters`.
+#
+# When option `unconverted_fields` is `true`, each returned row (Array or
+# CSV::Row) has an added method, `unconverted_fields`, that returns the
+# unconverted field values:
+#     str = <<-EOT
+#     foo,0
+#     bar,1
+#     baz,2
+#     EOT
+#     # Without unconverted_fields
+#     csv = CSV.parse(str, converters: :integer)
+#     csv # => [["foo", 0], ["bar", 1], ["baz", 2]]
+#     csv.first.respond_to?(:unconverted_fields) # => false
+#     # With unconverted_fields
+#     csv = CSV.parse(str, converters: :integer, unconverted_fields: true)
+#     csv # => [["foo", 0], ["bar", 1], ["baz", 2]]
+#     csv.first.respond_to?(:unconverted_fields) # => true
+#     csv.first.unconverted_fields # => ["foo", "0"]
+#
+# ###### Option `headers`
+#
+# Specifies a boolean, Symbol, Array, or String to be used to define column
+# headers.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:headers) # => false
+#
+# ---
+#
+# Without `headers`:
+#     str = <<-EOT
+#     Name,Count
+#     foo,0
+#     bar,1
+#     bax,2
+#     EOT
+#     csv = CSV.new(str)
+#     csv # => #<CSV io_type:StringIO encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\n" quote_char:"\"">
+#     csv.headers # => nil
+#     csv.shift # => ["Name", "Count"]
+#
+# ---
+#
+# If set to `true` or the Symbol `:first_row`, the first row of the data is
+# treated as a row of headers:
+#     str = <<-EOT
+#     Name,Count
+#     foo,0
+#     bar,1
+#     bax,2
+#     EOT
+#     csv = CSV.new(str, headers: true)
+#     csv # => #<CSV io_type:StringIO encoding:UTF-8 lineno:2 col_sep:"," row_sep:"\n" quote_char:"\"" headers:["Name", "Count"]>
+#     csv.headers # => ["Name", "Count"]
+#     csv.shift # => #<CSV::Row "Name":"bar" "Count":"1">
+#
+# ---
+#
+# If set to an Array, the Array elements are treated as headers:
+#     str = <<-EOT
+#     foo,0
+#     bar,1
+#     bax,2
+#     EOT
+#     csv = CSV.new(str, headers: ['Name', 'Count'])
+#     csv
+#     csv.headers # => ["Name", "Count"]
+#     csv.shift # => #<CSV::Row "Name":"bar" "Count":"1">
+#
+# ---
+#
+# If set to a String `str`, method `CSV::parse_line(str, options)` is called
+# with the current `options`, and the returned Array is treated as headers:
+#     str = <<-EOT
+#     foo,0
+#     bar,1
+#     bax,2
+#     EOT
+#     csv = CSV.new(str, headers: 'Name,Count')
+#     csv
+#     csv.headers # => ["Name", "Count"]
+#     csv.shift # => #<CSV::Row "Name":"bar" "Count":"1">
+#
+# ###### Option `return_headers`
+#
+# Specifies the boolean that determines whether method #shift returns or ignores
+# the header row.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:return_headers) # => false
+#
+# Examples:
+#     str = <<-EOT
+#     Name,Count
+#     foo,0
+#     bar,1
+#     bax,2
+#     EOT
+#     # Without return_headers first row is str.
+#     csv = CSV.new(str, headers: true)
+#     csv.shift # => #<CSV::Row "Name":"foo" "Count":"0">
+#     # With return_headers first row is headers.
+#     csv = CSV.new(str, headers: true, return_headers: true)
+#     csv.shift # => #<CSV::Row "Name":"Name" "Count":"Count">
+#
+# ###### Option `header_converters`
+#
+# Specifies converters to be used in parsing headers. See [Header
+# Converters](#class-CSV-label-Header+Converters)
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:header_converters) # => nil
+#
+# Identical in functionality to option
+# [converters](#class-CSV-label-Option+converters) except that:
+# *   The converters apply only to the header row.
+# *   The built-in header converters are `:downcase` and `:symbol`.
+#
+# This section assumes prior execution of:
+#     str = <<-EOT
+#     Name,Value
+#     foo,0
+#     bar,1
+#     baz,2
+#     EOT
+#     # With no header converter
+#     table = CSV.parse(str, headers: true)
+#     table.headers # => ["Name", "Value"]
+#
+# The value may be a header converter name (see [Stored
+# Converters](#class-CSV-label-Stored+Converters)):
+#     table = CSV.parse(str, headers: true, header_converters: :downcase)
+#     table.headers # => ["name", "value"]
+#
+# The value may be a converter list (see [Converter
+# Lists](#class-CSV-label-Converter+Lists)):
+#     header_converters = [:downcase, :symbol]
+#     table = CSV.parse(str, headers: true, header_converters: header_converters)
+#     table.headers # => [:name, :value]
+#
+# The value may be a Proc custom converter (see [Custom Header
+# Converters](#class-CSV-label-Custom+Header+Converters)):
+#     upcase_converter = proc {|field| field.upcase }
+#     table = CSV.parse(str, headers: true, header_converters: upcase_converter)
+#     table.headers # => ["NAME", "VALUE"]
+#
+# See also [Custom Header Converters](#class-CSV-label-Custom+Header+Converters)
+#
+# ###### Option `skip_blanks`
+#
+# Specifies a boolean that determines whether blank lines in the input will be
+# ignored; a line that contains a column separator is not considered to be
+# blank.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:skip_blanks) # => false
+#
+# See also option [skiplines](#class-CSV-label-Option+skip_lines).
+#
+# For examples in this section:
+#     str = <<-EOT
+#     foo,0
+#
+#     bar,1
+#     baz,2
+#
+#     ,
+#     EOT
+#
+# Using the default, `false`:
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], [], ["bar", "1"], ["baz", "2"], [], [nil, nil]]
+#
+# Using `true`:
+#     ary = CSV.parse(str, skip_blanks: true)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"], [nil, nil]]
+#
+# Using a truthy value:
+#     ary = CSV.parse(str, skip_blanks: :foo)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"], [nil, nil]]
+#
+# ###### Option `skip_lines`
+#
+# Specifies an object to use in identifying comment lines in the input that are
+# to be ignored:
+# *   If a Regexp, ignores lines that match it.
+# *   If a String, converts it to a Regexp, ignores lines that match it.
+# *   If `nil`, no lines are considered to be comments.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:skip_lines) # => nil
+#
+# For examples in this section:
+#     str = <<-EOT
+#     # Comment
+#     foo,0
+#     bar,1
+#     baz,2
+#     # Another comment
+#     EOT
+#     str # => "# Comment\nfoo,0\nbar,1\nbaz,2\n# Another comment\n"
+#
+# Using the default, `nil`:
+#     ary = CSV.parse(str)
+#     ary # => [["# Comment"], ["foo", "0"], ["bar", "1"], ["baz", "2"], ["# Another comment"]]
+#
+# Using a Regexp:
+#     ary = CSV.parse(str, skip_lines: /^#/)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using a String:
+#     ary = CSV.parse(str, skip_lines: '#')
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# ---
+#
+# Raises an exception if given an object that is not a Regexp, a String, or
+# `nil`:
+#     # Raises ArgumentError (:skip_lines has to respond to #match: 0)
+#     CSV.parse(str, skip_lines: 0)
+#
+# ###### Option `strip`
+#
+# Specifies the boolean value that determines whether whitespace is stripped
+# from each input field.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:strip) # => false
+#
+# With default value `false`:
+#     ary = CSV.parse_line(' a , b ')
+#     ary # => [" a ", " b "]
+#
+# With value `true`:
+#     ary = CSV.parse_line(' a , b ', strip: true)
+#     ary # => ["a", "b"]
+#
+# ###### Option `liberal_parsing`
+#
+# Specifies the boolean or hash value that determines whether CSV will attempt
+# to parse input not conformant with RFC 4180, such as double quotes in unquoted
+# fields.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:liberal_parsing) # => false
+#
+# For the next two examples:
+#     str = 'is,this "three, or four",fields'
+#
+# Without `liberal_parsing`:
+#     # Raises CSV::MalformedCSVError (Illegal quoting in str 1.)
+#     CSV.parse_line(str)
+#
+# With `liberal_parsing`:
+#     ary = CSV.parse_line(str, liberal_parsing: true)
+#     ary # => ["is", "this \"three", " or four\"", "fields"]
+#
+# Use the `backslash_quote` sub-option to parse values that use a backslash to
+# escape a double-quote character.  This causes the parser to treat `\"` as if
+# it were `""`.
+#
+# For the next two examples:
+#     str = 'Show,"Harry \"Handcuff\" Houdini, the one and only","Tampa Theater"'
+#
+# With `liberal_parsing`, but without the `backslash_quote` sub-option:
+#     # Incorrect interpretation of backslash; incorrectly interprets the quoted comma as a field separator.
+#     ary = CSV.parse_line(str, liberal_parsing: true)
+#     ary # => ["Show", "\"Harry \\\"Handcuff\\\" Houdini", " the one and only\"", "Tampa Theater"]
+#     puts ary[1] # => "Harry \"Handcuff\" Houdini
+#
+# With `liberal_parsing` and its `backslash_quote` sub-option:
+#     ary = CSV.parse_line(str, liberal_parsing: { backslash_quote: true })
+#     ary # => ["Show", "Harry \"Handcuff\" Houdini, the one and only", "Tampa Theater"]
+#     puts ary[1] # => Harry "Handcuff" Houdini, the one and only
+#
+# ###### Option `nil_value`
+#
+# Specifies the object that is to be substituted for each null (no-text) field.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:nil_value) # => nil
+#
+# With the default, `nil`:
+#     CSV.parse_line('a,,b,,c') # => ["a", nil, "b", nil, "c"]
+#
+# With a different object:
+#     CSV.parse_line('a,,b,,c', nil_value: 0) # => ["a", 0, "b", 0, "c"]
+#
+# ###### Option `empty_value`
+#
+# Specifies the object that is to be substituted for each field that has an
+# empty String.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:empty_value) # => "" (empty string)
+#
+# With the default, `""`:
+#     CSV.parse_line('a,"",b,"",c') # => ["a", "", "b", "", "c"]
+#
+# With a different object:
+#     CSV.parse_line('a,"",b,"",c', empty_value: 'x') # => ["a", "x", "b", "x", "c"]
+#
+# #### Options for Generating
+#
+# Options for generating, described in detail below, include:
+# *   `row_sep`: Specifies the row separator; used to delimit rows.
+# *   `col_sep`: Specifies the column separator; used to delimit fields.
+# *   `quote_char`: Specifies the quote character; used to quote fields.
+# *   `write_headers`: Specifies whether headers are to be written.
+# *   `force_quotes`: Specifies whether each output field is to be quoted.
+# *   `quote_empty`: Specifies whether each empty output field is to be quoted.
+# *   `write_converters`: Specifies the field converters to be used in writing.
+# *   `write_nil_value`: Specifies the object that is to be substituted for each
+#     `nil`-valued field.
+# *   `write_empty_value`: Specifies the object that is to be substituted for
+#     each empty field.
+#
+# ###### Option `row_sep`
+#
+# Specifies the row separator, a String or the Symbol `:auto` (see below), to be
+# used for both parsing and generating.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:row_sep) # => :auto
+#
+# ---
+#
+# When `row_sep` is a String, that String becomes the row separator. The String
+# will be transcoded into the data's Encoding before use.
+#
+# Using `"\n"`:
+#     row_sep = "\n"
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `|` (pipe):
+#     row_sep = '|'
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0|bar,1|baz,2|"
+#     ary = CSV.parse(str, row_sep: row_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `--` (two hyphens):
+#     row_sep = '--'
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0--bar,1--baz,2--"
+#     ary = CSV.parse(str, row_sep: row_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `''` (empty string):
+#     row_sep = ''
+#     str = CSV.generate(row_sep: row_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0bar,1baz,2"
+#     ary = CSV.parse(str, row_sep: row_sep)
+#     ary # => [["foo", "0bar", "1baz", "2"]]
+#
+# ---
+#
+# When `row_sep` is the Symbol `:auto` (the default), generating uses `"\n"` as
+# the row separator:
+#     str = CSV.generate do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#
+# Parsing, on the other hand, invokes auto-discovery of the row separator.
+#
+# Auto-discovery reads ahead in the data looking for the next `\r\n`, `\n`, or
+# `\r` sequence. The sequence will be selected even if it occurs in a quoted
+# field, assuming that you would have the same line endings there.
+#
+# Example:
+#     str = CSV.generate do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# The default `$INPUT_RECORD_SEPARATOR` (`$/`) is used if any of the following
+# is true:
+# *   None of those sequences is found.
+# *   Data is `ARGF`, `STDIN`, `STDOUT`, or `STDERR`.
+# *   The stream is only available for output.
+#
+# Obviously, discovery takes a little time. Set manually if speed is important.
+# Also note that IO objects should be opened in binary mode on Windows if this
+# feature will be used as the line-ending translation can cause problems with
+# resetting the document position to where it was before the read ahead.
+#
+# ###### Option `col_sep`
+#
+# Specifies the String field separator to be used for both parsing and
+# generating. The String will be transcoded into the data's Encoding before use.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:col_sep) # => "," (comma)
+#
+# Using the default (comma):
+#     str = CSV.generate do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `:` (colon):
+#     col_sep = ':'
+#     str = CSV.generate(col_sep: col_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo:0\nbar:1\nbaz:2\n"
+#     ary = CSV.parse(str, col_sep: col_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `::` (two colons):
+#     col_sep = '::'
+#     str = CSV.generate(col_sep: col_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo::0\nbar::1\nbaz::2\n"
+#     ary = CSV.parse(str, col_sep: col_sep)
+#     ary # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Using `''` (empty string):
+#     col_sep = ''
+#     str = CSV.generate(col_sep: col_sep) do |csv|
+#       csv << [:foo, 0]
+#       csv << [:bar, 1]
+#       csv << [:baz, 2]
+#     end
+#     str # => "foo0\nbar1\nbaz2\n"
+#
+# ---
+#
+# Raises an exception if parsing with the empty String:
+#     col_sep = ''
+#     # Raises ArgumentError (:col_sep must be 1 or more characters: "")
+#     CSV.parse("foo0\nbar1\nbaz2\n", col_sep: col_sep)
+#
+# ###### Option `quote_char`
+#
+# Specifies the character (String of length 1) used used to quote fields in both
+# parsing and generating. This String will be transcoded into the data's
+# Encoding before use.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:quote_char) # => "\"" (double quote)
+#
+# This is useful for an application that incorrectly uses `'` (single-quote) to
+# quote fields, instead of the correct `"` (double-quote).
+#
+# Using the default (double quote):
+#     str = CSV.generate do |csv|
+#       csv << ['foo', 0]
+#       csv << ["'bar'", 1]
+#       csv << ['"baz"', 2]
+#     end
+#     str # => "foo,0\n'bar',1\n\"\"\"baz\"\"\",2\n"
+#     ary = CSV.parse(str)
+#     ary # => [["foo", "0"], ["'bar'", "1"], ["\"baz\"", "2"]]
+#
+# Using `'` (single-quote):
+#     quote_char = "'"
+#     str = CSV.generate(quote_char: quote_char) do |csv|
+#       csv << ['foo', 0]
+#       csv << ["'bar'", 1]
+#       csv << ['"baz"', 2]
+#     end
+#     str # => "foo,0\n'''bar''',1\n\"baz\",2\n"
+#     ary = CSV.parse(str, quote_char: quote_char)
+#     ary # => [["foo", "0"], ["'bar'", "1"], ["\"baz\"", "2"]]
+#
+# ---
+#
+# Raises an exception if the String length is greater than 1:
+#     # Raises ArgumentError (:quote_char has to be nil or a single character String)
+#     CSV.new('', quote_char: 'xx')
+#
+# Raises an exception if the value is not a String:
+#     # Raises ArgumentError (:quote_char has to be nil or a single character String)
+#     CSV.new('', quote_char: :foo)
+#
+# ###### Option `write_headers`
+#
+# Specifies the boolean that determines whether a header row is included in the
+# output; ignored if there are no headers.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:write_headers) # => nil
+#
+# Without `write_headers`:
+#     file_path = 't.csv'
+#     CSV.open(file_path,'w',
+#         :headers => ['Name','Value']
+#       ) do |csv|
+#         csv << ['foo', '0']
+#     end
+#     CSV.open(file_path) do |csv|
+#       csv.shift
+#     end # => ["foo", "0"]
+#
+# With `write_headers`":
+#     CSV.open(file_path,'w',
+#         :write_headers => true,
+#         :headers => ['Name','Value']
+#       ) do |csv|
+#         csv << ['foo', '0']
+#     end
+#     CSV.open(file_path) do |csv|
+#       csv.shift
+#     end # => ["Name", "Value"]
+#
+# ###### Option `force_quotes`
+#
+# Specifies the boolean that determines whether each output field is to be
+# double-quoted.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:force_quotes) # => false
+#
+# For examples in this section:
+#     ary = ['foo', 0, nil]
+#
+# Using the default, `false`:
+#     str = CSV.generate_line(ary)
+#     str # => "foo,0,\n"
+#
+# Using `true`:
+#     str = CSV.generate_line(ary, force_quotes: true)
+#     str # => "\"foo\",\"0\",\"\"\n"
+#
+# ###### Option `quote_empty`
+#
+# Specifies the boolean that determines whether an empty value is to be
+# double-quoted.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:quote_empty) # => true
+#
+# With the default `true`:
+#     CSV.generate_line(['"', ""]) # => "\"\"\"\",\"\"\n"
+#
+# With `false`:
+#     CSV.generate_line(['"', ""], quote_empty: false) # => "\"\"\"\",\n"
+#
+# ###### Option `write_converters`
+#
+# Specifies converters to be used in generating fields. See [Write
+# Converters](#class-CSV-label-Write+Converters)
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:write_converters) # => nil
+#
+# With no write converter:
+#     str = CSV.generate_line(["\na\n", "\tb\t", " c "])
+#     str # => "\"\na\n\",\tb\t, c \n"
+#
+# With a write converter:
+#     strip_converter = proc {|field| field.strip }
+#     str = CSV.generate_line(["\na\n", "\tb\t", " c "], write_converters: strip_converter)
+#     str # => "a,b,c\n"
+#
+# With two write converters (called in order):
+#     upcase_converter = proc {|field| field.upcase }
+#     downcase_converter = proc {|field| field.downcase }
+#     write_converters = [upcase_converter, downcase_converter]
+#     str = CSV.generate_line(['a', 'b', 'c'], write_converters: write_converters)
+#     str # => "a,b,c\n"
+#
+# See also [Write Converters](#class-CSV-label-Write+Converters)
+#
+# ###### Option `write_nil_value`
+#
+# Specifies the object that is to be substituted for each `nil`-valued field.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:write_nil_value) # => nil
+#
+# Without the option:
+#     str = CSV.generate_line(['a', nil, 'c', nil])
+#     str # => "a,,c,\n"
+#
+# With the option:
+#     str = CSV.generate_line(['a', nil, 'c', nil], write_nil_value: "x")
+#     str # => "a,x,c,x\n"
+#
+# ###### Option `write_empty_value`
+#
+# Specifies the object that is to be substituted for each field that has an
+# empty String.
+#
+# Default value:
+#     CSV::DEFAULT_OPTIONS.fetch(:write_empty_value) # => ""
+#
+# Without the option:
+#     str = CSV.generate_line(['a', '', 'c', ''])
+#     str # => "a,\"\",c,\"\"\n"
+#
+# With the option:
+#     str = CSV.generate_line(['a', '', 'c', ''], write_empty_value: "x")
+#     str # => "a,x,c,x\n"
+#
+# ### CSV with Headers
+#
+# CSV allows to specify column names of CSV file, whether they are in data, or
+# provided separately. If headers are specified, reading methods return an
+# instance of CSV::Table, consisting of CSV::Row.
+#
+#     # Headers are part of data
+#     data = CSV.parse(<<~ROWS, headers: true)
+#       Name,Department,Salary
+#       Bob,Engineering,1000
+#       Jane,Sales,2000
+#       John,Management,5000
+#     ROWS
+#
+#     data.class      #=> CSV::Table
+#     data.first      #=> #<CSV::Row "Name":"Bob" "Department":"Engineering" "Salary":"1000">
+#     data.first.to_h #=> {"Name"=>"Bob", "Department"=>"Engineering", "Salary"=>"1000"}
+#
+#     # Headers provided by developer
+#     data = CSV.parse('Bob,Engineering,1000', headers: %i[name department salary])
+#     data.first      #=> #<CSV::Row name:"Bob" department:"Engineering" salary:"1000">
+#
+# ### Converters
+#
+# By default, each value (field or header) parsed by CSV is formed into a
+# String. You can use a *field* *converter* or  *header* *converter* to
+# intercept and modify the parsed values:
+# *   See [Field Converters](#class-CSV-label-Field+Converters).
+# *   See [Header Converters](#class-CSV-label-Header+Converters).
+#
+# Also by default, each value to be written during generation is written
+# 'as-is'. You can use a *write* *converter* to modify values before writing.
+# *   See [Write Converters](#class-CSV-label-Write+Converters).
+#
+# #### Specifying Converters
+#
+# You can specify converters for parsing or generating in the `options` argument
+# to various CSV methods:
+# *   Option `converters` for converting parsed field values.
+# *   Option `header_converters` for converting parsed header values.
+# *   Option `write_converters` for converting values to be written (generated).
+#
+# There are three forms for specifying converters:
+# *   A converter proc: executable code to be used for conversion.
+# *   A converter name: the name of a stored converter.
+# *   A converter list: an array of converter procs, converter names, and
+#     converter lists.
+#
+# ##### Converter Procs
+#
+# This converter proc, `strip_converter`, accepts a value `field` and returns
+# `field.strip`:
+#     strip_converter = proc {|field| field.strip }
+#
+# In this call to `CSV.parse`, the keyword argument `converters:
+# string_converter` specifies that:
+# *   Proc `string_converter` is to be called for each parsed field.
+# *   The converter's return value is to replace the `field` value.
+# Example:
+#     string = " foo , 0 \n bar , 1 \n baz , 2 \n"
+#     array = CSV.parse(string, converters: strip_converter)
+#     array # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# A converter proc can receive a second argument, `field_info`, that contains
+# details about the field. This modified `strip_converter` displays its
+# arguments:
+#     strip_converter = proc do |field, field_info|
+#       p [field, field_info]
+#       field.strip
+#     end
+#     string = " foo , 0 \n bar , 1 \n baz , 2 \n"
+#     array = CSV.parse(string, converters: strip_converter)
+#     array # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# Output:
+#     [" foo ", #<struct CSV::FieldInfo index=0, line=1, header=nil>]
+#     [" 0 ", #<struct CSV::FieldInfo index=1, line=1, header=nil>]
+#     [" bar ", #<struct CSV::FieldInfo index=0, line=2, header=nil>]
+#     [" 1 ", #<struct CSV::FieldInfo index=1, line=2, header=nil>]
+#     [" baz ", #<struct CSV::FieldInfo index=0, line=3, header=nil>]
+#     [" 2 ", #<struct CSV::FieldInfo index=1, line=3, header=nil>]
+#
+# Each CSV::FieldInfo object shows:
+# *   The 0-based field index.
+# *   The 1-based line index.
+# *   The field header, if any.
+#
+# ##### Stored Converters
+#
+# A converter may be given a name and stored in a structure where the parsing
+# methods can find it by name.
+#
+# The storage structure for field converters is the Hash CSV::Converters. It has
+# several built-in converter procs:
+# *   `:integer`: converts each String-embedded integer into a true Integer.
+# *   `:float`: converts each String-embedded float into a true Float.
+# *   `:date`: converts each String-embedded date into a true Date.
+# *   `:date_time`: converts each String-embedded date-time into a true DateTime
+# . This example creates a converter proc, then stores it:
+#     strip_converter = proc {|field| field.strip }
+#     CSV::Converters[:strip] = strip_converter
+#
+# Then the parsing method call can refer to the converter by its name, `:strip`:
+#     string = " foo , 0 \n bar , 1 \n baz , 2 \n"
+#     array = CSV.parse(string, converters: :strip)
+#     array # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# The storage structure for header converters is the Hash CSV::HeaderConverters,
+# which works in the same way. It also has built-in converter procs:
+# *   `:downcase`: Downcases each header.
+# *   `:symbol`: Converts each header to a Symbol.
+#
+# There is no such storage structure for write headers.
+#
+# In order for the parsing methods to access stored converters in
+# non-main-Ractors, the storage structure must be made shareable first.
+# Therefore, `Ractor.make_shareable(CSV::Converters)` and
+# `Ractor.make_shareable(CSV::HeaderConverters)` must be called before the
+# creation of Ractors that use the converters stored in these structures. (Since
+# making the storage structures shareable involves freezing them, any custom
+# converters that are to be used must be added first.)
+#
+# ##### Converter Lists
+#
+# A *converter* *list* is an Array that may include any assortment of:
+# *   Converter procs.
+# *   Names of stored converters.
+# *   Nested converter lists.
+#
+# Examples:
+#     numeric_converters = [:integer, :float]
+#     date_converters = [:date, :date_time]
+#     [numeric_converters, strip_converter]
+#     [strip_converter, date_converters, :float]
+#
+# Like a converter proc, a converter list may be named and stored in either
+# CSV::Converters or CSV::HeaderConverters:
+#     CSV::Converters[:custom] = [strip_converter, date_converters, :float]
+#     CSV::HeaderConverters[:custom] = [:downcase, :symbol]
+#
+# There are two built-in converter lists:
+#     CSV::Converters[:numeric] # => [:integer, :float]
+#     CSV::Converters[:all] # => [:date_time, :numeric]
+#
+# #### Field Converters
+#
+# With no conversion, all parsed fields in all rows become Strings:
+#     string = "foo,0\nbar,1\nbaz,2\n"
+#     ary = CSV.parse(string)
+#     ary # => # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# When you specify a field converter, each parsed field is passed to the
+# converter; its return value becomes the stored value for the field. A
+# converter might, for example, convert an integer embedded in a String into a
+# true Integer. (In fact, that's what built-in field converter `:integer` does.)
+#
+# There are three ways to use field converters.
+#
+# *   Using option [converters](#class-CSV-label-Option+converters) with a
+#     parsing method:
+#         ary = CSV.parse(string, converters: :integer)
+#         ary # => [0, 1, 2] # => [["foo", 0], ["bar", 1], ["baz", 2]]
+#
+# *   Using option [converters](#class-CSV-label-Option+converters) with a new
+#     CSV instance:
+#         csv = CSV.new(string, converters: :integer)
+#         # Field converters in effect:
+#         csv.converters # => [:integer]
+#         csv.read # => [["foo", 0], ["bar", 1], ["baz", 2]]
+#
+# *   Using method #convert to add a field converter to a CSV instance:
+#         csv = CSV.new(string)
+#         # Add a converter.
+#         csv.convert(:integer)
+#         csv.converters # => [:integer]
+#         csv.read # => [["foo", 0], ["bar", 1], ["baz", 2]]
+#
+# Installing a field converter does not affect already-read rows:
+#     csv = CSV.new(string)
+#     csv.shift # => ["foo", "0"]
+#     # Add a converter.
+#     csv.convert(:integer)
+#     csv.converters # => [:integer]
+#     csv.read # => [["bar", 1], ["baz", 2]]
+#
+# There are additional built-in converters, and custom converters are also
+# supported.
+#
+# ##### Built-In Field Converters
+#
+# The built-in field converters are in Hash CSV::Converters:
+# *   Each key is a field converter name.
+# *   Each value is one of:
+#     *   A Proc field converter.
+#     *   An Array of field converter names.
+#
+# Display:
+#     CSV::Converters.each_pair do |name, value|
+#       if value.kind_of?(Proc)
+#         p [name, value.class]
+#       else
+#         p [name, value]
+#       end
+#     end
+#
+# Output:
+#     [:integer, Proc]
+#     [:float, Proc]
+#     [:numeric, [:integer, :float]]
+#     [:date, Proc]
+#     [:date_time, Proc]
+#     [:all, [:date_time, :numeric]]
+#
+# Each of these converters transcodes values to UTF-8 before attempting
+# conversion. If a value cannot be transcoded to UTF-8 the conversion will fail
+# and the value will remain unconverted.
+#
+# Converter `:integer` converts each field that Integer() accepts:
+#     data = '0,1,2,x'
+#     # Without the converter
+#     csv = CSV.parse_line(data)
+#     csv # => ["0", "1", "2", "x"]
+#     # With the converter
+#     csv = CSV.parse_line(data, converters: :integer)
+#     csv # => [0, 1, 2, "x"]
+#
+# Converter `:float` converts each field that Float() accepts:
+#     data = '1.0,3.14159,x'
+#     # Without the converter
+#     csv = CSV.parse_line(data)
+#     csv # => ["1.0", "3.14159", "x"]
+#     # With the converter
+#     csv = CSV.parse_line(data, converters: :float)
+#     csv # => [1.0, 3.14159, "x"]
+#
+# Converter `:numeric` converts with both `:integer` and `:float`..
+#
+# Converter `:date` converts each field that Date::parse accepts:
+#     data = '2001-02-03,x'
+#     # Without the converter
+#     csv = CSV.parse_line(data)
+#     csv # => ["2001-02-03", "x"]
+#     # With the converter
+#     csv = CSV.parse_line(data, converters: :date)
+#     csv # => [#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>, "x"]
+#
+# Converter `:date_time` converts each field that DateTime::parse accepts:
+#     data = '2020-05-07T14:59:00-05:00,x'
+#     # Without the converter
+#     csv = CSV.parse_line(data)
+#     csv # => ["2020-05-07T14:59:00-05:00", "x"]
+#     # With the converter
+#     csv = CSV.parse_line(data, converters: :date_time)
+#     csv # => [#<DateTime: 2020-05-07T14:59:00-05:00 ((2458977j,71940s,0n),-18000s,2299161j)>, "x"]
+#
+# Converter `:numeric` converts with both `:date_time` and `:numeric`..
+#
+# As seen above, method #convert adds converters to a CSV instance, and method
+# #converters returns an Array of the converters in effect:
+#     csv = CSV.new('0,1,2')
+#     csv.converters # => []
+#     csv.convert(:integer)
+#     csv.converters # => [:integer]
+#     csv.convert(:date)
+#     csv.converters # => [:integer, :date]
+#
+# ##### Custom Field Converters
+#
+# You can define a custom field converter:
+#     strip_converter = proc {|field| field.strip }
+#     string = " foo , 0 \n bar , 1 \n baz , 2 \n"
+#     array = CSV.parse(string, converters: strip_converter)
+#     array # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# You can register the converter in Converters Hash, which allows you to refer
+# to it by name:
+#     CSV::Converters[:strip] = strip_converter
+#     string = " foo , 0 \n bar , 1 \n baz , 2 \n"
+#     array = CSV.parse(string, converters: :strip)
+#     array # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+#
+# #### Header Converters
+#
+# Header converters operate only on headers (and not on other rows).
+#
+# There are three ways to use header converters; these examples use built-in
+# header converter `:downcase`, which downcases each parsed header.
+#
+# *   Option `header_converters` with a singleton parsing method:
+#         string = "Name,Count\nFoo,0\n,Bar,1\nBaz,2"
+#         tbl = CSV.parse(string, headers: true, header_converters: :downcase)
+#         tbl.class # => CSV::Table
+#         tbl.headers # => ["name", "count"]
+#
+# *   Option `header_converters` with a new CSV instance:
+#         csv = CSV.new(string, header_converters: :downcase)
+#         # Header converters in effect:
+#         csv.header_converters # => [:downcase]
+#         tbl = CSV.parse(string, headers: true)
+#         tbl.headers # => ["Name", "Count"]
+#
+# *   Method #header_convert adds a header converter to a CSV instance:
+#         csv = CSV.new(string)
+#         # Add a header converter.
+#         csv.header_convert(:downcase)
+#         csv.header_converters # => [:downcase]
+#         tbl = CSV.parse(string, headers: true)
+#         tbl.headers # => ["Name", "Count"]
+#
+# ##### Built-In Header Converters
+#
+# The built-in header converters are in Hash CSV::HeaderConverters. The keys
+# there are the names of the converters:
+#     CSV::HeaderConverters.keys # => [:downcase, :symbol]
+#
+# Converter `:downcase` converts each header by downcasing it:
+#     string = "Name,Count\nFoo,0\n,Bar,1\nBaz,2"
+#     tbl = CSV.parse(string, headers: true, header_converters: :downcase)
+#     tbl.class # => CSV::Table
+#     tbl.headers # => ["name", "count"]
+#
+# Converter `:symbol` converts each header by making it into a Symbol:
+#     string = "Name,Count\nFoo,0\n,Bar,1\nBaz,2"
+#     tbl = CSV.parse(string, headers: true, header_converters: :symbol)
+#     tbl.headers # => [:name, :count]
+#
+# Details:
+# *   Strips leading and trailing whitespace.
+# *   Downcases the header.
+# *   Replaces embedded spaces with underscores.
+# *   Removes non-word characters.
+# *   Makes the string into a Symbol.
+#
+# ##### Custom Header Converters
+#
+# You can define a custom header converter:
+#     upcase_converter = proc {|header| header.upcase }
+#     string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(string, headers: true, header_converters: upcase_converter)
+#     table # => #<CSV::Table mode:col_or_row row_count:4>
+#     table.headers # => ["NAME", "VALUE"]
+#
+# You can register the converter in HeaderConverters Hash, which allows you to
+# refer to it by name:
+#     CSV::HeaderConverters[:upcase] = upcase_converter
+#     table = CSV.parse(string, headers: true, header_converters: :upcase)
+#     table # => #<CSV::Table mode:col_or_row row_count:4>
+#     table.headers # => ["NAME", "VALUE"]
+#
+# ##### Write Converters
+#
+# When you specify a write converter for generating CSV, each field to be
+# written is passed to the converter; its return value becomes the new value for
+# the field. A converter might, for example, strip whitespace from a field.
+#
+# Using no write converter (all fields unmodified):
+#     output_string = CSV.generate do |csv|
+#       csv << [' foo ', 0]
+#       csv << [' bar ', 1]
+#       csv << [' baz ', 2]
+#     end
+#     output_string # => " foo ,0\n bar ,1\n baz ,2\n"
+#
+# Using option `write_converters` with two custom write converters:
+#     strip_converter = proc {|field| field.respond_to?(:strip) ? field.strip : field }
+#     upcase_converter = proc {|field| field.respond_to?(:upcase) ? field.upcase : field }
+#     write_converters = [strip_converter, upcase_converter]
+#     output_string = CSV.generate(write_converters: write_converters) do |csv|
+#       csv << [' foo ', 0]
+#       csv << [' bar ', 1]
+#       csv << [' baz ', 2]
+#     end
+#     output_string # => "FOO,0\nBAR,1\nBAZ,2\n"
+#
+# ### Character Encodings (M17n or Multilingualization)
+#
+# This new CSV parser is m17n savvy.  The parser works in the Encoding of the IO
+# or String object being read from or written to. Your data is never transcoded
+# (unless you ask Ruby to transcode it for you) and will literally be parsed in
+# the Encoding it is in. Thus CSV will return Arrays or Rows of Strings in the
+# Encoding of your data. This is accomplished by transcoding the parser itself
+# into your Encoding.
+#
+# Some transcoding must take place, of course, to accomplish this multiencoding
+# support. For example, `:col_sep`, `:row_sep`, and `:quote_char` must be
+# transcoded to match your data.  Hopefully this makes the entire process feel
+# transparent, since CSV's defaults should just magically work for your data.
+# However, you can set these values manually in the target Encoding to avoid the
+# translation.
+#
+# It's also important to note that while all of CSV's core parser is now
+# Encoding agnostic, some features are not. For example, the built-in converters
+# will try to transcode data to UTF-8 before making conversions. Again, you can
+# provide custom converters that are aware of your Encodings to avoid this
+# translation. It's just too hard for me to support native conversions in all of
+# Ruby's Encodings.
+#
+# Anyway, the practical side of this is simple: make sure IO and String objects
+# passed into CSV have the proper Encoding set and everything should just work.
+# CSV methods that allow you to open IO objects (CSV::foreach(), CSV::open(),
+# CSV::read(), and CSV::readlines()) do allow you to specify the Encoding.
+#
+# One minor exception comes when generating CSV into a String with an Encoding
+# that is not ASCII compatible. There's no existing data for CSV to use to
+# prepare itself and thus you will probably need to manually specify the desired
+# Encoding for most of those cases. It will try to guess using the fields in a
+# row of output though, when using CSV::generate_line() or Array#to_csv().
+#
+# I try to point out any other Encoding issues in the documentation of methods
+# as they come up.
+#
+# This has been tested to the best of my ability with all non-"dummy" Encodings
+# Ruby ships with. However, it is brave new code and may have some bugs. Please
+# feel free to [report](mailto:james@grayproductions.net) any issues you find
+# with it.
+#
+class CSV < Object
+  include Enumerable[untyped]
+  extend Forwardable
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - foreach(path_or_io, mode='r', **options) {|row| ... )
+  #   - foreach(path_or_io, mode='r', **options) -> new_enumerator
+  # -->
+  # Calls the block with each row read from source `path_or_io`.
+  #
+  # Path input without headers:
+  #
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     in_path = 't.csv'
+  #     File.write(in_path, string)
+  #     CSV.foreach(in_path) {|row| p row }
+  #
+  # Output:
+  #
+  #     ["foo", "0"]
+  #     ["bar", "1"]
+  #     ["baz", "2"]
+  #
+  # Path input with headers:
+  #
+  #     string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     in_path = 't.csv'
+  #     File.write(in_path, string)
+  #     CSV.foreach(in_path, headers: true) {|row| p row }
+  #
+  # Output:
+  #
+  #     <CSV::Row "Name":"foo" "Value":"0">
+  #     <CSV::Row "Name":"bar" "Value":"1">
+  #     <CSV::Row "Name":"baz" "Value":"2">
+  #
+  # IO stream input without headers:
+  #
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     File.open('t.csv') do |in_io|
+  #       CSV.foreach(in_io) {|row| p row }
+  #     end
+  #
+  # Output:
+  #
+  #     ["foo", "0"]
+  #     ["bar", "1"]
+  #     ["baz", "2"]
+  #
+  # IO stream input with headers:
+  #
+  #     string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     File.open('t.csv') do |in_io|
+  #       CSV.foreach(in_io, headers: true) {|row| p row }
+  #     end
+  #
+  # Output:
+  #
+  #     <CSV::Row "Name":"foo" "Value":"0">
+  #     <CSV::Row "Name":"bar" "Value":"1">
+  #     <CSV::Row "Name":"baz" "Value":"2">
+  #
+  # With no block given, returns an Enumerator:
+  #
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     CSV.foreach(path) # => #<Enumerator: CSV:foreach("t.csv", "r")>
+  #
+  # Arguments:
+  # *   Argument `path_or_io` must be a file path or an IO stream.
+  # *   Argument `mode`, if given, must be a File mode. See [Access
+  #     Modes](rdoc-ref:File@Access+Modes).
+  # *   Arguments `**options` must be keyword options. See [Options for
+  #     Parsing](#class-CSV-label-Options+for+Parsing).
+  # *   This method optionally accepts an additional `:encoding` option that you
+  #     can use to specify the Encoding of the data read from `path` or `io`. You
+  #     must provide this unless your data is in the encoding given by
+  #     `Encoding::default_external`. Parsing will use this to determine how to
+  #     parse the data. You may provide a second Encoding to have the data
+  #     transcoded as it is read. For example,
+  #         encoding: 'UTF-32BE:UTF-8'
+  #
+  #     would read `UTF-32BE` data from the file but transcode it to `UTF-8`
+  #     before parsing.
+  #
+  def self.foreach: (String | IO path, ?String mode, headers: true | :first_row | Array[untyped] | String, **untyped options) { (::CSV::Row arg0) -> void } -> void
+                  | (String | IO path, ?String mode, headers: true | :first_row | Array[untyped] | String, **untyped options) -> Enumerator[::CSV::Row, void]
+                  | (String | IO path, ?String mode, **untyped options) { (::Array[String?] arg0) -> void } -> void
+                  | (String | IO path, ?String mode, **untyped options) -> Enumerator[::Array[String?], void]
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - CSV.new(string)
+  #   - CSV.new(io)
+  #   - CSV.new(string, **options)
+  #   - CSV.new(io, **options)
+  # -->
+  # Returns the new CSV object created using `string` or `io` and the specified
+  # `options`.
+  #
+  # *   Argument `string` should be a String object; it will be put into a new
+  #     StringIO object positioned at the beginning.
+  # *   Argument `io` should be an IO object that is:
+  #     *   Open for reading; on return, the IO object will be closed.
+  #     *   Positioned at the beginning. To position at the end, for appending,
+  #         use method CSV.generate. For any other positioning, pass a preset
+  #         StringIO object instead.
+  # *   Argument `options`: See:
+  #     *   [Options for Parsing](#class-CSV-label-Options+for+Parsing)
+  #     *   [Options for Generating](#class-CSV-label-Options+for+Generating)
+  #     For performance reasons, the options cannot be overridden in a CSV object,
+  #     so those specified here will endure.
+  #
+  # In addition to the CSV instance methods, several IO methods are delegated. See
+  # [Delegated Methods](#class-CSV-label-Delegated+Methods).
+  #
+  # ---
+  #
+  # Create a CSV object from a String object:
+  #     csv = CSV.new('foo,0')
+  #     csv # => #<CSV io_type:StringIO encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\n" quote_char:"\"">
+  #
+  # Create a CSV object from a File object:
+  #     File.write('t.csv', 'foo,0')
+  #     csv = CSV.new(File.open('t.csv'))
+  #     csv # => #<CSV io_type:File io_path:"t.csv" encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\n" quote_char:"\"">
+  #
+  # ---
+  #
+  # Raises an exception if the argument is `nil`:
+  #     # Raises ArgumentError (Cannot parse nil as CSV):
+  #     CSV.new(nil)
+  #
+  def initialize: (?String | IO | StringIO io, ?::Hash[Symbol, untyped] options) -> void
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - parse(string) -> array_of_arrays
+  #   - parse(io) -> array_of_arrays
+  #   - parse(string, headers: ..., **options) -> csv_table
+  #   - parse(io, headers: ..., **options) -> csv_table
+  #   - parse(string, **options) {|row| ... }
+  #   - parse(io, **options) {|row| ... }
+  # -->
+  # Parses `string` or `io` using the specified `options`.
+  #
+  # *   Argument `string` should be a String object; it will be put into a new
+  #     StringIO object positioned at the beginning.
+  # *   Argument `io` should be an IO object that is:
+  #     *   Open for reading; on return, the IO object will be closed.
+  #     *   Positioned at the beginning. To position at the end, for appending,
+  #         use method CSV.generate. For any other positioning, pass a preset
+  #         StringIO object instead.
+  # *   Argument `options`: see [Options for
+  #     Parsing](#class-CSV-label-Options+for+Parsing)
+  #
+  # ###### Without Option `headers`
+  #
+  # Without {option `headers`[}](#class-CSV-label-Option+headers) case.
+  #
+  # These examples assume prior execution of:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #
+  # ---
+  #
+  # With no block given, returns an Array of Arrays formed from the source.
+  #
+  # Parse a String:
+  #     a_of_a = CSV.parse(string)
+  #     a_of_a # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # Parse an open File:
+  #     a_of_a = File.open(path) do |file|
+  #       CSV.parse(file)
+  #     end
+  #     a_of_a # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # ---
+  #
+  # With a block given, calls the block with each parsed row:
+  #
+  # Parse a String:
+  #     CSV.parse(string) {|row| p row }
+  #
+  # Output:
+  #     ["foo", "0"]
+  #     ["bar", "1"]
+  #     ["baz", "2"]
+  #
+  # Parse an open File:
+  #     File.open(path) do |file|
+  #       CSV.parse(file) {|row| p row }
+  #     end
+  #
+  # Output:
+  #     ["foo", "0"]
+  #     ["bar", "1"]
+  #     ["baz", "2"]
+  #
+  # ###### With Option `headers`
+  #
+  # With {option `headers`[}](#class-CSV-label-Option+headers) case.
+  #
+  # These examples assume prior execution of:
+  #     string = "Name,Count\nfoo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #
+  # ---
+  #
+  # With no block given, returns a CSV::Table object formed from the source.
+  #
+  # Parse a String:
+  #     csv_table = CSV.parse(string, headers: ['Name', 'Count'])
+  #     csv_table # => #<CSV::Table mode:col_or_row row_count:5>
+  #
+  # Parse an open File:
+  #     csv_table = File.open(path) do |file|
+  #       CSV.parse(file, headers: ['Name', 'Count'])
+  #     end
+  #     csv_table # => #<CSV::Table mode:col_or_row row_count:4>
+  #
+  # ---
+  #
+  # With a block given, calls the block with each parsed row, which has been
+  # formed into a CSV::Row object:
+  #
+  # Parse a String:
+  #     CSV.parse(string, headers: ['Name', 'Count']) {|row| p row }
+  #
+  # Output:
+  #     # <CSV::Row "Name":"foo" "Count":"0">
+  #     # <CSV::Row "Name":"bar" "Count":"1">
+  #     # <CSV::Row "Name":"baz" "Count":"2">
+  #
+  # Parse an open File:
+  #     File.open(path) do |file|
+  #       CSV.parse(file, headers: ['Name', 'Count']) {|row| p row }
+  #     end
+  #
+  # Output:
+  #     # <CSV::Row "Name":"foo" "Count":"0">
+  #     # <CSV::Row "Name":"bar" "Count":"1">
+  #     # <CSV::Row "Name":"baz" "Count":"2">
+  #
+  # ---
+  #
+  # Raises an exception if the argument is not a String object or IO object:
+  #     # Raises NoMethodError (undefined method `close' for :foo:Symbol)
+  #     CSV.parse(:foo)
+  #
+  def self.parse: (String str, ?::Hash[Symbol, untyped] options) ?{ (::Array[String?] arg0) -> void } -> ::Array[::Array[String?]]?
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - CSV.parse_line(string) -> new_array or nil
+  #   - CSV.parse_line(io) -> new_array or nil
+  #   - CSV.parse_line(string, **options) -> new_array or nil
+  #   - CSV.parse_line(io, **options) -> new_array or nil
+  #   - CSV.parse_line(string, headers: true, **options) -> csv_row or nil
+  #   - CSV.parse_line(io, headers: true, **options) -> csv_row or nil
+  # -->
+  # Returns the data created by parsing the first line of `string` or `io` using
+  # the specified `options`.
+  #
+  # *   Argument `string` should be a String object; it will be put into a new
+  #     StringIO object positioned at the beginning.
+  # *   Argument `io` should be an IO object that is:
+  #     *   Open for reading; on return, the IO object will be closed.
+  #     *   Positioned at the beginning. To position at the end, for appending,
+  #         use method CSV.generate. For any other positioning, pass a preset
+  #         StringIO object instead.
+  # *   Argument `options`: see [Options for
+  #     Parsing](#class-CSV-label-Options+for+Parsing)
+  #
+  # ###### Without Option `headers`
+  #
+  # Without option `headers`, returns the first row as a new Array.
+  #
+  # These examples assume prior execution of:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #
+  # Parse the first line from a String object:
+  #     CSV.parse_line(string) # => ["foo", "0"]
+  #
+  # Parse the first line from a File object:
+  #     File.open(path) do |file|
+  #       CSV.parse_line(file) # => ["foo", "0"]
+  #     end # => ["foo", "0"]
+  #
+  # Returns `nil` if the argument is an empty String:
+  #     CSV.parse_line('') # => nil
+  #
+  # ###### With Option `headers`
+  #
+  # With {option `headers`[}](#class-CSV-label-Option+headers), returns the first
+  # row as a CSV::Row object.
+  #
+  # These examples assume prior execution of:
+  #     string = "Name,Count\nfoo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #
+  # Parse the first line from a String object:
+  #     CSV.parse_line(string, headers: true) # => #<CSV::Row "Name":"foo" "Count":"0">
+  #
+  # Parse the first line from a File object:
+  #     File.open(path) do |file|
+  #       CSV.parse_line(file, headers: true)
+  #     end # => #<CSV::Row "Name":"foo" "Count":"0">
+  #
+  # ---
+  #
+  # Raises an exception if the argument is `nil`:
+  #     # Raises ArgumentError (Cannot parse nil as CSV):
+  #     CSV.parse_line(nil)
+  #
+  def self.parse_line: (String str, ?::Hash[Symbol, untyped] options) -> ::Array[String?]?
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - csv.read -> array or csv_table
+  # -->
+  # Forms the remaining rows from `self` into:
+  # *   A CSV::Table object, if headers are in use.
+  # *   An Array of Arrays, otherwise.
+  #
+  # The data source must be opened for reading.
+  #
+  # Without headers:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     csv = CSV.open(path)
+  #     csv.read # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # With headers:
+  #     string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     csv = CSV.open(path, headers: true)
+  #     csv.read # => #<CSV::Table mode:col_or_row row_count:4>
+  #
+  # ---
+  #
+  # Raises an exception if the source is not opened for reading:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     csv = CSV.new(string)
+  #     csv.close
+  #     # Raises IOError (not opened for reading)
+  #     csv.read
+  #
+  def read: () -> ::Array[::Array[String?]]
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - readline()
+  # -->
+  #
+  def readline: () -> ::Array[String?]?
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - read(source, **options) -> array_of_arrays
+  #   - read(source, headers: true, **options) -> csv_table
+  # -->
+  # Opens the given `source` with the given `options` (see CSV.open), reads the
+  # source (see CSV#read), and returns the result, which will be either an Array
+  # of Arrays or a CSV::Table.
+  #
+  # Without headers:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     CSV.read(path) # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # With headers:
+  #     string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     path = 't.csv'
+  #     File.write(path, string)
+  #     CSV.read(path, headers: true) # => #<CSV::Table mode:col_or_row row_count:4>
+  #
+  def self.read: (String | IO path, headers: true | :first_row | Array[untyped] | String, **untyped options) -> ::CSV::Table[CSV::Row]
+               | (String | IO path, ?::Hash[Symbol, untyped] options) -> ::Array[::Array[String?]]
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - csv << row -> self
+  # -->
+  # Appends a row to `self`.
+  #
+  # *   Argument `row` must be an Array object or a CSV::Row object.
+  # *   The output stream must be open for writing.
+  #
+  # ---
+  #
+  # Append Arrays:
+  #     CSV.generate do |csv|
+  #       csv << ['foo', 0]
+  #       csv << ['bar', 1]
+  #       csv << ['baz', 2]
+  #     end # => "foo,0\nbar,1\nbaz,2\n"
+  #
+  # Append CSV::Rows:
+  #     headers = []
+  #     CSV.generate do |csv|
+  #       csv << CSV::Row.new(headers, ['foo', 0])
+  #       csv << CSV::Row.new(headers, ['bar', 1])
+  #       csv << CSV::Row.new(headers, ['baz', 2])
+  #     end # => "foo,0\nbar,1\nbaz,2\n"
+  #
+  # Headers in CSV::Row objects are not appended:
+  #     headers = ['Name', 'Count']
+  #     CSV.generate do |csv|
+  #       csv << CSV::Row.new(headers, ['foo', 0])
+  #       csv << CSV::Row.new(headers, ['bar', 1])
+  #       csv << CSV::Row.new(headers, ['baz', 2])
+  #     end # => "foo,0\nbar,1\nbaz,2\n"
+  #
+  # ---
+  #
+  # Raises an exception if `row` is not an Array or CSV::Row:
+  #     CSV.generate do |csv|
+  #       # Raises NoMethodError (undefined method `collect' for :foo:Symbol)
+  #       csv << :foo
+  #     end
+  #
+  # Raises an exception if the output stream is not opened for writing:
+  #     path = 't.csv'
+  #     File.write(path, '')
+  #     File.open(path) do |file|
+  #       CSV.open(file) do |csv|
+  #         # Raises IOError (not opened for writing)
+  #         csv << ['foo', 0]
+  #       end
+  #     end
+  #
+  def <<: (::Array[untyped] | CSV::Row row) -> void
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - generate(csv_string, **options) {|csv| ... }
+  #   - generate(**options) {|csv| ... }
+  # -->
+  # *   Argument `csv_string`, if given, must be a String object; defaults to a
+  #     new empty String.
+  # *   Arguments `options`, if given, should be generating options. See [Options
+  #     for Generating](#class-CSV-label-Options+for+Generating).
+  #
+  # ---
+  #
+  # Creates a new CSV object via `CSV.new(csv_string, **options)`; calls the block
+  # with the CSV object, which the block may modify; returns the String generated
+  # from the CSV object.
+  #
+  # Note that a passed String **is** modified by this method. Pass
+  # `csv_string`.dup if the String must be preserved.
+  #
+  # This method has one additional option: `:encoding`, which sets the base
+  # Encoding for the output if no no `str` is specified. CSV needs this hint if
+  # you plan to output non-ASCII compatible data.
+  #
+  # ---
+  #
+  # Add lines:
+  #     input_string = "foo,0\nbar,1\nbaz,2\n"
+  #     output_string = CSV.generate(input_string) do |csv|
+  #       csv << ['bat', 3]
+  #       csv << ['bam', 4]
+  #     end
+  #     output_string # => "foo,0\nbar,1\nbaz,2\nbat,3\nbam,4\n"
+  #     input_string # => "foo,0\nbar,1\nbaz,2\nbat,3\nbam,4\n"
+  #     output_string.equal?(input_string) # => true # Same string, modified
+  #
+  # Add lines into new string, preserving old string:
+  #     input_string = "foo,0\nbar,1\nbaz,2\n"
+  #     output_string = CSV.generate(input_string.dup) do |csv|
+  #       csv << ['bat', 3]
+  #       csv << ['bam', 4]
+  #     end
+  #     output_string # => "foo,0\nbar,1\nbaz,2\nbat,3\nbam,4\n"
+  #     input_string # => "foo,0\nbar,1\nbaz,2\n"
+  #     output_string.equal?(input_string) # => false # Different strings
+  #
+  # Create lines from nothing:
+  #     output_string = CSV.generate do |csv|
+  #       csv << ['foo', 0]
+  #       csv << ['bar', 1]
+  #       csv << ['baz', 2]
+  #     end
+  #     output_string # => "foo,0\nbar,1\nbaz,2\n"
+  #
+  # ---
+  #
+  # Raises an exception if `csv_string` is not a String object:
+  #     # Raises TypeError (no implicit conversion of Integer into String)
+  #     CSV.generate(0)
+  #
+  def self.generate: (?String str, **untyped options) { (CSV csv) -> void } -> String
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - csv.each -> enumerator
+  #   - csv.each {|row| ...}
+  # -->
+  # Calls the block with each successive row. The data source must be opened for
+  # reading.
+  #
+  # Without headers:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     csv = CSV.new(string)
+  #     csv.each do |row|
+  #       p row
+  #     end
+  #
+  # Output:
+  #     ["foo", "0"]
+  #     ["bar", "1"]
+  #     ["baz", "2"]
+  #
+  # With headers:
+  #     string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     csv = CSV.new(string, headers: true)
+  #     csv.each do |row|
+  #       p row
+  #     end
+  #
+  # Output:
+  #     <CSV::Row "Name":"foo" "Value":"0">
+  #     <CSV::Row "Name":"bar" "Value":"1">
+  #     <CSV::Row "Name":"baz" "Value":"2">
+  #
+  # ---
+  #
+  # Raises an exception if the source is not opened for reading:
+  #     string = "foo,0\nbar,1\nbaz,2\n"
+  #     csv = CSV.new(string)
+  #     csv.close
+  #     # Raises IOError (not opened for reading)
+  #     csv.each do |row|
+  #       p row
+  #     end
+  #
+  def each: () -> Enumerator[untyped, Integer]
+          | () { (untyped) -> void } -> Integer
+
+  # <!--
+  #   rdoc-file=lib/csv.rb
+  #   - csv.headers -> object
+  # -->
+  # Returns the value that determines whether headers are used; used for parsing;
+  # see {Option `headers`[}](#class-CSV-label-Option+headers):
+  #     CSV.new('').headers # => nil
+  #
+  def headers: () -> (Array[String] | true | nil)
+end
+
+# <!-- rdoc-file=lib/csv.rb -->
+# Default values for method options.
+#
+CSV::DEFAULT_OPTIONS: ::Hash[untyped, untyped]
+
+# <!-- rdoc-file=lib/csv/version.rb -->
+# The version of the installed library.
+#
+CSV::VERSION: String
+
+# <!-- rdoc-file=lib/csv/row.rb -->
+# # CSV::Row
+# A CSV::Row instance represents a CSV table row. (see [class
+# CSV](../CSV.html)).
+#
+# The instance may have:
+# *   Fields: each is an object, not necessarily a String.
+# *   Headers: each serves a key, and also need not be a String.
+#
+# ### Instance Methods
+#
+# CSV::Row has three groups of instance methods:
+# *   Its own internally defined instance methods.
+# *   Methods included by module Enumerable.
+# *   Methods delegated to class Array.:
+#     *   Array#empty?
+#     *   Array#length
+#     *   Array#size
+#
+# ## Creating a CSV::Row Instance
+#
+# Commonly, a new CSV::Row instance is created by parsing CSV source that has
+# headers:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     table.each {|row| p row }
+#
+# Output:
+#     #<CSV::Row "Name":"foo" "Value":"0">
+#     #<CSV::Row "Name":"bar" "Value":"1">
+#     #<CSV::Row "Name":"baz" "Value":"2">
+#
+# You can also create a row directly. See ::new.
+#
+# ## Headers
+#
+# Like a CSV::Table, a CSV::Row has headers.
+#
+# A CSV::Row that was created by parsing CSV source inherits its headers from
+# the table:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     row = table.first
+#     row.headers # => ["Name", "Value"]
+#
+# You can also create a new row with headers; like the keys in a Hash, the
+# headers need not be Strings:
+#     row = CSV::Row.new([:name, :value], ['foo', 0])
+#     row.headers # => [:name, :value]
+#
+# The new row retains its headers even if added to a table that has headers:
+#     table << row # => #<CSV::Table mode:col_or_row row_count:5>
+#     row.headers # => [:name, :value]
+#     row[:name] # => "foo"
+#     row['Name'] # => nil
+#
+# ## Accessing Fields
+#
+# You may access a field in a CSV::Row with either its Integer index
+# (Array-style) or its header (Hash-style).
+#
+# Fetch a field using method #[]:
+#     row = CSV::Row.new(['Name', 'Value'], ['foo', 0])
+#     row[1] # => 0
+#     row['Value'] # => 0
+#
+# Set a field using method #[]=:
+#     row = CSV::Row.new(['Name', 'Value'], ['foo', 0])
+#     row # => #<CSV::Row "Name":"foo" "Value":0>
+#     row[0] = 'bar'
+#     row['Value'] = 1
+#     row # => #<CSV::Row "Name":"bar" "Value":1>
+#
+class CSV::Row < Object
+  include Enumerable[Array[String]]
+  extend Forwardable
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - CSV::Row.new(headers, fields, header_row = false) -> csv_row
+  # -->
+  # Returns the new CSV::Row instance constructed from arguments `headers` and
+  # `fields`; both should be Arrays; note that the fields need not be Strings:
+  #     row = CSV::Row.new(['Name', 'Value'], ['foo', 0])
+  #     row # => #<CSV::Row "Name":"foo" "Value":0>
+  #
+  # If the Array lengths are different, the shorter is `nil`-filled:
+  #     row = CSV::Row.new(['Name', 'Value', 'Date', 'Size'], ['foo', 0])
+  #     row # => #<CSV::Row "Name":"foo" "Value":0 "Date":nil "Size":nil>
+  #
+  # Each CSV::Row object is either a *field row* or a *header row*; by default, a
+  # new row is a field row;  for the row created above:
+  #     row.field_row? # => true
+  #     row.header_row? # => false
+  #
+  # If the optional argument `header_row` is given as `true`, the created row is a
+  # header row:
+  #     row = CSV::Row.new(['Name', 'Value'], ['foo', 0], header_row = true)
+  #     row # => #<CSV::Row "Name":"foo" "Value":0>
+  #     row.field_row? # => false
+  #     row.header_row? # => true
+  #
+  def initialize: (Array[untyped] headers, Array[untyped] fields, ?header_row: bool) -> void
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row << [header, value] -> self
+  #   - row << hash -> self
+  #   - row << value -> self
+  # -->
+  # Adds a field to `self`; returns `self`:
+  #
+  # If the argument is a 2-element Array `[header, value]`, a field is added with
+  # the given `header` and `value`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row << ['NAME', 'Bat']
+  #     row # => #<CSV::Row "Name":"Foo" "Name":"Bar" "Name":"Baz" "NAME":"Bat">
+  #
+  # If the argument is a Hash, each `key-value` pair is added as a field with
+  # header `key` and value `value`.
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row << {NAME: 'Bat', name: 'Bam'}
+  #     row # => #<CSV::Row "Name":"Foo" "Name":"Bar" "Name":"Baz" NAME:"Bat" name:"Bam">
+  #
+  # Otherwise, the given `value` is added as a field with no header.
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row << 'Bag'
+  #     row # => #<CSV::Row "Name":"Foo" "Name":"Bar" "Name":"Baz" nil:"Bag">
+  #
+  def <<: (untyped arg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row == other -> true or false
+  # -->
+  # Returns `true` if `other` is a /CSV::Row that has the same fields (headers and
+  # values) in the same order as `self`; otherwise returns `false`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     other_row = table[0]
+  #     row == other_row # => true
+  #     other_row = table[1]
+  #     row == other_row # => false
+  #
+  def ==: (untyped other) -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - [](header_or_index, minimum_index = 0)
+  # -->
+  #
+  alias [] field
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row[index] = value -> value
+  #   - row[header, offset] = value -> value
+  #   - row[header] = value -> value
+  # -->
+  # Assigns the field value for the given `index` or `header`; returns `value`.
+  #
+  # ---
+  #
+  # Assign field value by Integer index:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row[0] = 'Bat'
+  #     row[1] = 3
+  #     row # => #<CSV::Row "Name":"Bat" "Value":3>
+  #
+  # Counts backward from the last column if `index` is negative:
+  #     row[-1] = 4
+  #     row[-2] = 'Bam'
+  #     row # => #<CSV::Row "Name":"Bam" "Value":4>
+  #
+  # Extends the row with `nil:nil` if positive `index` is not in the row:
+  #     row[4] = 5
+  #     row # => #<CSV::Row "Name":"bad" "Value":4 nil:nil nil:nil nil:5>
+  #
+  # Raises IndexError if negative `index` is too small (too far from zero).
+  #
+  # ---
+  #
+  # Assign field value by header (first found):
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row['Name'] = 'Bat'
+  #     row # => #<CSV::Row "Name":"Bat" "Name":"Bar" "Name":"Baz">
+  #
+  # Assign field value by header, ignoring `offset` leading fields:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row['Name', 2] = 4
+  #     row # => #<CSV::Row "Name":"Foo" "Name":"Bar" "Name":4>
+  #
+  # Append new field by (new) header:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row['New'] = 6
+  #     row# => #<CSV::Row "Name":"foo" "Value":"0" "New":6>
+  #
+  def []=: (*untyped args) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - delete(index) -> [header, value] or nil
+  #   - delete(header) -> [header, value] or empty_array
+  #   - delete(header, offset) -> [header, value] or empty_array
+  # -->
+  # Removes a specified field from `self`; returns the 2-element Array `[header,
+  # value]` if the field exists.
+  #
+  # If an Integer argument `index` is given, removes and returns the field at
+  # offset `index`, or returns `nil` if the field does not exist:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.delete(1) # => ["Name", "Bar"]
+  #     row.delete(50) # => nil
+  #
+  # Otherwise, if the single argument `header` is given, removes and returns the
+  # first-found field with the given header, of returns a new empty Array if the
+  # field does not exist:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.delete('Name') # => ["Name", "Foo"]
+  #     row.delete('NAME') # => []
+  #
+  # If argument `header` and Integer argument `offset` are given, removes and
+  # returns the first-found field with the given header whose `index` is at least
+  # as large as `offset`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.delete('Name', 1) # => ["Name", "Bar"]
+  #     row.delete('NAME', 1) # => []
+  #
+  def delete: (untyped header_or_index, ?untyped minimum_index) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.delete_if {|header, value| ... } -> self
+  # -->
+  # Removes fields from `self` as selected by the block; returns `self`.
+  #
+  # Removes each field for which the block returns a truthy value:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.delete_if {|header, value| value.start_with?('B') } # => true
+  #     row # => #<CSV::Row "Name":"Foo">
+  #     row.delete_if {|header, value| header.start_with?('B') } # => false
+  #
+  # If no block is given, returns a new Enumerator:
+  #     row.delete_if # => #<Enumerator: #<CSV::Row "Name":"Foo">:delete_if>
+  #
+  def delete_if: () { (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.dig(index_or_header, *identifiers) -> object
+  # -->
+  # Finds and returns the object in nested object that is specified by
+  # `index_or_header` and `specifiers`.
+  #
+  # The nested objects may be instances of various classes. See [Dig
+  # Methods](rdoc-ref:dig_methods.rdoc).
+  #
+  # Examples:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.dig(1) # => "0"
+  #     row.dig('Value') # => "0"
+  #     row.dig(5) # => nil
+  #
+  def dig: (untyped index_or_header, *untyped indexes) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.each {|header, value| ... } -> self
+  # -->
+  # Calls the block with each header-value pair; returns `self`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.each {|header, value| p [header, value] }
+  #
+  # Output:
+  #     ["Name", "Foo"]
+  #     ["Name", "Bar"]
+  #     ["Name", "Baz"]
+  #
+  # If no block is given, returns a new Enumerator:
+  #     row.each # => #<Enumerator: #<CSV::Row "Name":"Foo" "Name":"Bar" "Name":"Baz">:each>
+  #
+  def each: () -> Enumerator[Array[String], self]
+          | () { (Array[String]) -> void } -> self
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - each_pair(&block)
+  # -->
+  #
+  alias each_pair each
+
+  def empty?: (*untyped args) { (*untyped) -> untyped } -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - fetch(header) -> value
+  #   - fetch(header, default) -> value
+  #   - fetch(header) {|row| ... } -> value
+  # -->
+  # Returns the field value as specified by `header`.
+  #
+  # ---
+  #
+  # With the single argument `header`, returns the field value for that header
+  # (first found):
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.fetch('Name') # => "Foo"
+  #
+  # Raises exception `KeyError` if the header does not exist.
+  #
+  # ---
+  #
+  # With arguments `header` and `default` given, returns the field value for the
+  # header (first found) if the header exists, otherwise returns `default`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.fetch('Name', '') # => "Foo"
+  #     row.fetch(:nosuch, '') # => ""
+  #
+  # ---
+  #
+  # With argument `header` and a block given, returns the field value for the
+  # header (first found) if the header exists; otherwise calls the block and
+  # returns its return value:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.fetch('Name') {|header| fail 'Cannot happen' } # => "Foo"
+  #     row.fetch(:nosuch) {|header| "Header '#{header} not found'" } # => "Header 'nosuch not found'"
+  #
+  def fetch: (untyped header, *untyped varargs) ?{ (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - field(index) -> value
+  #   - field(header) -> value
+  #   - field(header, offset) -> value
+  # -->
+  # Returns the field value for the given `index` or `header`.
+  #
+  # ---
+  #
+  # Fetch field value by Integer index:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.field(0) # => "foo"
+  #     row.field(1) # => "bar"
+  #
+  # Counts backward from the last column if `index` is negative:
+  #     row.field(-1) # => "0"
+  #     row.field(-2) # => "foo"
+  #
+  # Returns `nil` if `index` is out of range:
+  #     row.field(2) # => nil
+  #     row.field(-3) # => nil
+  #
+  # ---
+  #
+  # Fetch field value by header (first found):
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.field('Name') # => "Foo"
+  #
+  # Fetch field value by header, ignoring `offset` leading fields:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.field('Name', 2) # => "Baz"
+  #
+  # Returns `nil` if the header does not exist.
+  #
+  def field: (untyped header_or_index, ?untyped minimum_index) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.field?(value) -> true or false
+  # -->
+  # Returns `true` if `value` is a field in this row, `false` otherwise:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.field?('Bar') # => true
+  #     row.field?('BAR') # => false
+  #
+  def field?: (untyped data) -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.field_row? -> true or false
+  # -->
+  # Returns `true` if this is a field row, `false` otherwise.
+  #
+  def field_row?: () -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - self.fields(*specifiers) -> array_of_fields
+  # -->
+  # Returns field values per the given `specifiers`, which may be any mixture of:
+  # *   Integer index.
+  # *   Range of Integer indexes.
+  # *   2-element Array containing a header and offset.
+  # *   Header.
+  # *   Range of headers.
+  #
+  # For `specifier` in one of the first four cases above, returns the result of
+  # `self.field(specifier)`;  see #field.
+  #
+  # Although there may be any number of `specifiers`, the examples here will
+  # illustrate one at a time.
+  #
+  # When the specifier is an Integer `index`, returns `self.field(index)`L
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.fields(1) # => ["Bar"]
+  #
+  # When the specifier is a Range of Integers `range`, returns
+  # `self.field(range)`:
+  #     row.fields(1..2) # => ["Bar", "Baz"]
+  #
+  # When the specifier is a 2-element Array `array`, returns `self.field(array)`L
+  #     row.fields('Name', 1) # => ["Foo", "Bar"]
+  #
+  # When the specifier is a header `header`, returns `self.field(header)`L
+  #     row.fields('Name') # => ["Foo"]
+  #
+  # When the specifier is a Range of headers `range`, forms a new Range
+  # `new_range` from the indexes of `range.start` and `range.end`, and returns
+  # `self.field(new_range)`:
+  #     source = "Name,NAME,name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.fields('Name'..'NAME') # => ["Foo", "Bar"]
+  #
+  # Returns all fields if no argument given:
+  #     row.fields # => ["Foo", "Bar", "Baz"]
+  #
+  def fields: (*untyped headers_and_or_indices) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.has_key?(header) -> true or false
+  # -->
+  # Returns `true` if there is a field with the given `header`, `false` otherwise.
+  #
+  def has_key?: (untyped header) -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - header?(header)
+  # -->
+  #
+  alias header? has_key?
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.header_row? -> true or false
+  # -->
+  # Returns `true` if this is a header row, `false` otherwise.
+  #
+  def header_row?: () -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.headers -> array_of_headers
+  # -->
+  # Returns the headers for this row:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table.first
+  #     row.headers # => ["Name", "Value"]
+  #
+  def headers: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - include?(header)
+  # -->
+  #
+  alias include? has_key?
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - index(header) -> index
+  #   - index(header, offset) -> index
+  # -->
+  # Returns the index for the given header, if it exists; otherwise returns `nil`.
+  #
+  # With the single argument `header`, returns the index of the first-found field
+  # with the given `header`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.index('Name') # => 0
+  #     row.index('NAME') # => nil
+  #
+  # With arguments `header` and `offset`, returns the index of the first-found
+  # field with given `header`, but ignoring the first `offset` fields:
+  #     row.index('Name', 1) # => 1
+  #     row.index('Name', 3) # => nil
+  #
+  def index: (untyped header, ?untyped minimum_index) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.inspect -> string
+  # -->
+  # Returns an ASCII-compatible String showing:
+  # *   Class CSV::Row.
+  # *   Header-value pairs.
+  # Example:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.inspect # => "#<CSV::Row \"Name\":\"foo\" \"Value\":\"0\">"
+  #
+  def inspect: () -> String
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - key?(header)
+  # -->
+  #
+  alias key? has_key?
+
+  def length: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - member?(header)
+  # -->
+  #
+  alias member? has_key?
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.push(*values) -> self
+  # -->
+  # Appends each of the given `values` to `self` as a field; returns `self`:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.push('Bat', 'Bam')
+  #     row # => #<CSV::Row "Name":"Foo" "Name":"Bar" "Name":"Baz" nil:"Bat" nil:"Bam">
+  #
+  def push: (*untyped args) -> untyped
+
+  def size: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.to_csv -> csv_string
+  # -->
+  # Returns the row as a CSV String. Headers are not included:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.to_csv # => "foo,0\n"
+  #
+  def to_csv: (**untyped) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - row.to_h -> hash
+  # -->
+  # Returns the new Hash formed by adding each header-value pair in `self` as a
+  # key-value pair in the Hash.
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.to_h # => {"Name"=>"foo", "Value"=>"0"}
+  #
+  # Header order is preserved, but repeated headers are ignored:
+  #     source = "Name,Name,Name\nFoo,Bar,Baz\n"
+  #     table = CSV.parse(source, headers: true)
+  #     row = table[0]
+  #     row.to_h # => {"Name"=>"Foo"}
+  #
+  def to_h: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - to_hash()
+  # -->
+  #
+  alias to_hash to_h
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - to_s(**options)
+  # -->
+  #
+  alias to_s to_csv
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
+  #   - values_at(*headers_and_or_indices)
+  # -->
+  #
+  alias values_at fields
+end
+
+class CSV::FieldInfo < Struct[untyped]
+end
+
+# <!-- rdoc-file=lib/csv.rb -->
+# The error thrown when the parser encounters illegal CSV formatting.
+#
+class CSV::MalformedCSVError < RuntimeError
+end
+
+# <!-- rdoc-file=lib/csv/table.rb -->
+# # CSV::Table
+# A CSV::Table instance represents CSV data. (see [class CSV](../CSV.html)).
+#
+# The instance may have:
+# *   Rows: each is a Table::Row object.
+# *   Headers: names for the columns.
+#
+# ### Instance Methods
+#
+# CSV::Table has three groups of instance methods:
+# *   Its own internally defined instance methods.
+# *   Methods included by module Enumerable.
+# *   Methods delegated to class Array.:
+#     *   Array#empty?
+#     *   Array#length
+#     *   Array#size
+#
+# ## Creating a CSV::Table Instance
+#
+# Commonly, a new CSV::Table instance is created by parsing CSV source using
+# headers:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     table.class # => CSV::Table
+#
+# You can also create an instance directly. See ::new.
+#
+# ## Headers
+#
+# If a table has headers, the headers serve as labels for the columns of data.
+# Each header serves as the label for its column.
+#
+# The headers for a CSV::Table object are stored as an Array of Strings.
+#
+# Commonly, headers are defined in the first row of CSV source:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     table.headers # => ["Name", "Value"]
+#
+# If no headers are defined, the Array is empty:
+#     table = CSV::Table.new([])
+#     table.headers # => []
+#
+# ## Access Modes
+#
+# CSV::Table provides three modes for accessing table data:
+# *   Row mode.
+# *   Column mode.
+# *   Mixed mode (the default for a new table).
+#
+# The access mode for aCSV::Table instance affects the behavior of some of its
+# instance methods:
+# *   #[]
+# *   #[]=
+# *   #delete
+# *   #delete_if
+# *   #each
+# *   #values_at
+#
+# ### Row Mode
+#
+# Set a table to row mode with method #by_row!:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     table.by_row! # => #<CSV::Table mode:row row_count:4>
+#
+# Specify a single row by an Integer index:
+#     # Get a row.
+#     table[1] # => #<CSV::Row "Name":"bar" "Value":"1">
+#     # Set a row, then get it.
+#     table[1] = CSV::Row.new(['Name', 'Value'], ['bam', 3])
+#     table[1] # => #<CSV::Row "Name":"bam" "Value":3>
+#
+# Specify a sequence of rows by a Range:
+#     # Get rows.
+#     table[1..2] # => [#<CSV::Row "Name":"bam" "Value":3>, #<CSV::Row "Name":"baz" "Value":"2">]
+#     # Set rows, then get them.
+#     table[1..2] = [
+#       CSV::Row.new(['Name', 'Value'], ['bat', 4]),
+#       CSV::Row.new(['Name', 'Value'], ['bad', 5]),
+#     ]
+#     table[1..2] # => [["Name", #<CSV::Row "Name":"bat" "Value":4>], ["Value", #<CSV::Row "Name":"bad" "Value":5>]]
+#
+# ### Column Mode
+#
+# Set a table to column mode with method #by_col!:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     table.by_col! # => #<CSV::Table mode:col row_count:4>
+#
+# Specify a column by an Integer index:
+#     # Get a column.
+#     table[0]
+#     # Set a column, then get it.
+#     table[0] = ['FOO', 'BAR', 'BAZ']
+#     table[0] # => ["FOO", "BAR", "BAZ"]
+#
+# Specify a column by its String header:
+#     # Get a column.
+#     table['Name'] # => ["FOO", "BAR", "BAZ"]
+#     # Set a column, then get it.
+#     table['Name'] = ['Foo', 'Bar', 'Baz']
+#     table['Name'] # => ["Foo", "Bar", "Baz"]
+#
+# ### Mixed Mode
+#
+# In mixed mode, you can refer to either rows or columns:
+# *   An Integer index refers to a row.
+# *   A Range index refers to multiple rows.
+# *   A String index refers to a column.
+#
+# Set a table to mixed mode with method #by_col_or_row!:
+#     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+#     table = CSV.parse(source, headers: true)
+#     table.by_col_or_row! # => #<CSV::Table mode:col_or_row row_count:4>
+#
+# Specify a single row by an Integer index:
+#     # Get a row.
+#     table[1] # => #<CSV::Row "Name":"bar" "Value":"1">
+#     # Set a row, then get it.
+#     table[1] = CSV::Row.new(['Name', 'Value'], ['bam', 3])
+#     table[1] # => #<CSV::Row "Name":"bam" "Value":3>
+#
+# Specify a sequence of rows by a Range:
+#     # Get rows.
+#     table[1..2] # => [#<CSV::Row "Name":"bam" "Value":3>, #<CSV::Row "Name":"baz" "Value":"2">]
+#     # Set rows, then get them.
+#     table[1] = CSV::Row.new(['Name', 'Value'], ['bat', 4])
+#     table[2] = CSV::Row.new(['Name', 'Value'], ['bad', 5])
+#     table[1..2] # => [["Name", #<CSV::Row "Name":"bat" "Value":4>], ["Value", #<CSV::Row "Name":"bad" "Value":5>]]
+#
+# Specify a column by its String header:
+#     # Get a column.
+#     table['Name'] # => ["foo", "bat", "bad"]
+#     # Set a column, then get it.
+#     table['Name'] = ['Foo', 'Bar', 'Baz']
+#     table['Name'] # => ["Foo", "Bar", "Baz"]
+#
+class CSV::Table[out Elem] < Object
+  include Enumerable[Elem]
+  extend Forwardable
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - CSV::Table.new(array_of_rows, headers = nil) -> csv_table
+  # -->
+  # Returns a new CSV::Table object.
+  #
+  # *   Argument `array_of_rows` must be an Array of CSV::Row objects.
+  # *   Argument `headers`, if given, may be an Array of Strings.
+  #
+  # ---
+  #
+  # Create an empty CSV::Table object:
+  #     table = CSV::Table.new([])
+  #     table # => #<CSV::Table mode:col_or_row row_count:1>
+  #
+  # Create a non-empty CSV::Table object:
+  #     rows = [
+  #       CSV::Row.new([], []),
+  #       CSV::Row.new([], []),
+  #       CSV::Row.new([], []),
+  #     ]
+  #     table  = CSV::Table.new(rows)
+  #     table # => #<CSV::Table mode:col_or_row row_count:4>
+  #
+  # ---
+  #
+  # If argument `headers` is an Array of Strings, those Strings become the table's
+  # headers:
+  #     table = CSV::Table.new([], headers: ['Name', 'Age'])
+  #     table.headers # => ["Name", "Age"]
+  #
+  # If argument `headers` is not given and the table has rows, the headers are
+  # taken from the first row:
+  #     rows = [
+  #       CSV::Row.new(['Foo', 'Bar'], []),
+  #       CSV::Row.new(['foo', 'bar'], []),
+  #       CSV::Row.new(['FOO', 'BAR'], []),
+  #     ]
+  #     table  = CSV::Table.new(rows)
+  #     table.headers # => ["Foo", "Bar"]
+  #
+  # If argument `headers` is not given and the table is empty (has no rows), the
+  # headers are also empty:
+  #     table  = CSV::Table.new([])
+  #     table.headers # => []
+  #
+  # ---
+  #
+  # Raises an exception if argument `array_of_rows` is not an Array object:
+  #     # Raises NoMethodError (undefined method `first' for :foo:Symbol):
+  #     CSV::Table.new(:foo)
+  #
+  # Raises an exception if an element of `array_of_rows` is not a CSV::Table
+  # object:
+  #     # Raises NoMethodError (undefined method `headers' for :foo:Symbol):
+  #     CSV::Table.new([:foo])
+  #
+  def initialize: (untyped array_of_rows, ?headers: untyped) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table << row_or_array -> self
+  # -->
+  # If `row_or_array` is a CSV::Row object, it is appended to the table:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table << CSV::Row.new(table.headers, ['bat', 3])
+  #     table[3] # => #<CSV::Row "Name":"bat" "Value":3>
+  #
+  # If `row_or_array` is an Array, it is used to create a new CSV::Row object
+  # which is then appended to the table:
+  #     table << ['bam', 4]
+  #     table[4] # => #<CSV::Row "Name":"bam" "Value":4>
+  #
+  def <<: (untyped row_or_array) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table == other_table -> true or false
+  # -->
+  # Returns `true` if all each row of `self` `==` the corresponding row of
+  # `other_table`, otherwise, `false`.
+  #
+  # The access mode does no affect the result.
+  #
+  # Equal tables:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     other_table = CSV.parse(source, headers: true)
+  #     table == other_table # => true
+  #
+  # Different row count:
+  #     other_table.delete(2)
+  #     table == other_table # => false
+  #
+  # Different last row:
+  #     other_table << ['bat', 3]
+  #     table == other_table # => false
+  #
+  def ==: (untyped other) -> bool
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table[n] -> row or column_data
+  #   - table[range] -> array_of_rows or array_of_column_data
+  #   - table[header] -> array_of_column_data
+  # -->
+  # Returns data from the table;  does not modify the table.
+  #
+  # ---
+  #
+  #
+  # Fetch a Row by Its Integer Index
+  # :
+  # *   Form: `table[n]`, `n` an integer.
+  # *   Access mode: `:row` or `:col_or_row`.
+  # *   Return value: *nth* row of the table, if that row exists; otherwise `nil`.
+  #
+  # Returns the *nth* row of the table if that row exists:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     table[1] # => #<CSV::Row "Name":"bar" "Value":"1">
+  #     table.by_col_or_row! # => #<CSV::Table mode:col_or_row row_count:4>
+  #     table[1] # => #<CSV::Row "Name":"bar" "Value":"1">
+  #
+  # Counts backward from the last row if `n` is negative:
+  #     table[-1] # => #<CSV::Row "Name":"baz" "Value":"2">
+  #
+  # Returns `nil` if `n` is too large or too small:
+  #     table[4] # => nil
+  #     table[-4] # => nil
+  #
+  # Raises an exception if the access mode is `:row` and `n` is not an Integer:
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     # Raises TypeError (no implicit conversion of String into Integer):
+  #     table['Name']
+  #
+  # ---
+  #
+  #
+  # Fetch a Column by Its Integer Index
+  # :
+  # *   Form: `table[n]`, `n` an Integer.
+  # *   Access mode: `:col`.
+  # *   Return value: *nth* column of the table, if that column exists; otherwise
+  #     an Array of `nil` fields of length `self.size`.
+  #
+  # Returns the *nth* column of the table if that column exists:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #     table[1] # => ["0", "1", "2"]
+  #
+  # Counts backward from the last column if `n` is negative:
+  #     table[-2] # => ["foo", "bar", "baz"]
+  #
+  # Returns an Array of `nil` fields if `n` is too large or too small:
+  #     table[4] # => [nil, nil, nil]
+  #     table[-4] # => [nil, nil, nil]
+  #
+  # ---
+  #
+  #
+  # Fetch Rows by Range
+  # :
+  # *   Form: `table[range]`, `range` a Range object.
+  # *   Access mode: `:row` or `:col_or_row`.
+  # *   Return value: rows from the table, beginning at row `range.start`, if
+  #     those rows exists.
+  #
+  # Returns rows from the table, beginning at row `range.first`, if those rows
+  # exist:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     rows = table[1..2] # => #<CSV::Row "Name":"bar" "Value":"1">
+  #     rows # => [#<CSV::Row "Name":"bar" "Value":"1">, #<CSV::Row "Name":"baz" "Value":"2">]
+  #     table.by_col_or_row! # => #<CSV::Table mode:col_or_row row_count:4>
+  #     rows = table[1..2] # => #<CSV::Row "Name":"bar" "Value":"1">
+  #     rows # => [#<CSV::Row "Name":"bar" "Value":"1">, #<CSV::Row "Name":"baz" "Value":"2">]
+  #
+  # If there are too few rows, returns all from `range.start` to the end:
+  #     rows = table[1..50] # => #<CSV::Row "Name":"bar" "Value":"1">
+  #     rows # => [#<CSV::Row "Name":"bar" "Value":"1">, #<CSV::Row "Name":"baz" "Value":"2">]
+  #
+  # Special case: if `range.start == table.size`, returns an empty Array:
+  #     table[table.size..50] # => []
+  #
+  # If `range.end` is negative, calculates the ending index from the end:
+  #     rows = table[0..-1]
+  #     rows # => [#<CSV::Row "Name":"foo" "Value":"0">, #<CSV::Row "Name":"bar" "Value":"1">, #<CSV::Row "Name":"baz" "Value":"2">]
+  #
+  # If `range.start` is negative, calculates the starting index from the end:
+  #     rows = table[-1..2]
+  #     rows # => [#<CSV::Row "Name":"baz" "Value":"2">]
+  #
+  # If `range.start` is larger than `table.size`, returns `nil`:
+  #     table[4..4] # => nil
+  #
+  # ---
+  #
+  #
+  # Fetch Columns by Range
+  # :
+  # *   Form: `table[range]`, `range` a Range object.
+  # *   Access mode: `:col`.
+  # *   Return value: column data from the table, beginning at column
+  #     `range.start`, if those columns exist.
+  #
+  # Returns column values from the table, if the column exists; the values are
+  # arranged by row:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_col!
+  #     table[0..1] # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # Special case: if `range.start == headers.size`, returns an Array (size:
+  # `table.size`) of empty Arrays:
+  #     table[table.headers.size..50] # => [[], [], []]
+  #
+  # If `range.end` is negative, calculates the ending index from the end:
+  #     table[0..-1] # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # If `range.start` is negative, calculates the starting index from the end:
+  #     table[-2..2] # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  # If `range.start` is larger than `table.size`, returns an Array of `nil`
+  # values:
+  #     table[4..4] # => [nil, nil, nil]
+  #
+  # ---
+  #
+  #
+  # Fetch a Column by Its String Header
+  # :
+  # *   Form: `table[header]`, `header` a String header.
+  # *   Access mode: `:col` or `:col_or_row`
+  # *   Return value: column data from the table, if that `header` exists.
+  #
+  # Returns column values from the table, if the column exists:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #     table['Name'] # => ["foo", "bar", "baz"]
+  #     table.by_col_or_row! # => #<CSV::Table mode:col_or_row row_count:4>
+  #     col = table['Name']
+  #     col # => ["foo", "bar", "baz"]
+  #
+  # Modifying the returned column values does not modify the table:
+  #     col[0] = 'bat'
+  #     col # => ["bat", "bar", "baz"]
+  #     table['Name'] # => ["foo", "bar", "baz"]
+  #
+  # Returns an Array of `nil` values if there is no such column:
+  #     table['Nosuch'] # => [nil, nil, nil]
+  #
+  def []: (untyped index_or_header) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table[n] = row -> row
+  #   - table[n] = field_or_array_of_fields -> field_or_array_of_fields
+  #   - table[header] = field_or_array_of_fields -> field_or_array_of_fields
+  # -->
+  # Puts data onto the table.
+  #
+  # ---
+  #
+  #
+  # Set a Row by Its Integer Index
+  # :
+  # *   Form: `table[n] = row`, `n` an Integer, `row` a CSV::Row instance or an
+  #     Array of fields.
+  # *   Access mode: `:row` or `:col_or_row`.
+  # *   Return value: `row`.
+  #
+  # If the row exists, it is replaced:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     new_row = CSV::Row.new(['Name', 'Value'], ['bat', 3])
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     return_value = table[0] = new_row
+  #     return_value.equal?(new_row) # => true # Returned the row
+  #     table[0].to_h # => {"Name"=>"bat", "Value"=>3}
+  #
+  # With access mode `:col_or_row`:
+  #     table.by_col_or_row! # => #<CSV::Table mode:col_or_row row_count:4>
+  #     table[0] = CSV::Row.new(['Name', 'Value'], ['bam', 4])
+  #     table[0].to_h # => {"Name"=>"bam", "Value"=>4}
+  #
+  # With an Array instead of a CSV::Row, inherits headers from the table:
+  #     array = ['bad', 5]
+  #     return_value = table[0] = array
+  #     return_value.equal?(array) # => true # Returned the array
+  #     table[0].to_h # => {"Name"=>"bad", "Value"=>5}
+  #
+  # If the row does not exist, extends the table by adding rows: assigns rows with
+  # `nil` as needed:
+  #     table.size # => 3
+  #     table[5] = ['bag', 6]
+  #     table.size # => 6
+  #     table[3] # => nil
+  #     table[4]# => nil
+  #     table[5].to_h # => {"Name"=>"bag", "Value"=>6}
+  #
+  # Note that the `nil` rows are actually `nil`, not a row of `nil` fields.
+  #
+  # ---
+  #
+  #
+  # Set a Column by Its Integer Index
+  # :
+  # *   Form: `table[n] = array_of_fields`, `n` an Integer, `array_of_fields` an
+  #     Array of String fields.
+  # *   Access mode: `:col`.
+  # *   Return value: `array_of_fields`.
+  #
+  # If the column exists, it is replaced:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     new_col = [3, 4, 5]
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #     return_value = table[1] = new_col
+  #     return_value.equal?(new_col) # => true # Returned the column
+  #     table[1] # => [3, 4, 5]
+  #     # The rows, as revised:
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     table[0].to_h # => {"Name"=>"foo", "Value"=>3}
+  #     table[1].to_h # => {"Name"=>"bar", "Value"=>4}
+  #     table[2].to_h # => {"Name"=>"baz", "Value"=>5}
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #
+  # If there are too few values, fills with `nil` values:
+  #     table[1] = [0]
+  #     table[1] # => [0, nil, nil]
+  #
+  # If there are too many values, ignores the extra values:
+  #     table[1] = [0, 1, 2, 3, 4]
+  #     table[1] # => [0, 1, 2]
+  #
+  # If a single value is given, replaces all fields in the column with that value:
+  #     table[1] = 'bat'
+  #     table[1] # => ["bat", "bat", "bat"]
+  #
+  # ---
+  #
+  #
+  # Set a Column by Its String Header
+  # :
+  # *   Form: `table[header] = field_or_array_of_fields`, `header` a String
+  #     header, `field_or_array_of_fields` a field value or an Array of String
+  #     fields.
+  # *   Access mode: `:col` or `:col_or_row`.
+  # *   Return value: `field_or_array_of_fields`.
+  #
+  # If the column exists, it is replaced:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     new_col = [3, 4, 5]
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #     return_value = table['Value'] = new_col
+  #     return_value.equal?(new_col) # => true # Returned the column
+  #     table['Value'] # => [3, 4, 5]
+  #     # The rows, as revised:
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     table[0].to_h # => {"Name"=>"foo", "Value"=>3}
+  #     table[1].to_h # => {"Name"=>"bar", "Value"=>4}
+  #     table[2].to_h # => {"Name"=>"baz", "Value"=>5}
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #
+  # If there are too few values, fills with `nil` values:
+  #     table['Value'] = [0]
+  #     table['Value'] # => [0, nil, nil]
+  #
+  # If there are too many values, ignores the extra values:
+  #     table['Value'] = [0, 1, 2, 3, 4]
+  #     table['Value'] # => [0, 1, 2]
+  #
+  # If the column does not exist, extends the table by adding columns:
+  #     table['Note'] = ['x', 'y', 'z']
+  #     table['Note'] # => ["x", "y", "z"]
+  #     # The rows, as revised:
+  #     table.by_row!
+  #     table[0].to_h # => {"Name"=>"foo", "Value"=>0, "Note"=>"x"}
+  #     table[1].to_h # => {"Name"=>"bar", "Value"=>1, "Note"=>"y"}
+  #     table[2].to_h # => {"Name"=>"baz", "Value"=>2, "Note"=>"z"}
+  #     table.by_col!
+  #
+  # If a single value is given, replaces all fields in the column with that value:
+  #     table['Value'] = 'bat'
+  #     table['Value'] # => ["bat", "bat", "bat"]
+  #
+  def []=: (untyped index_or_header, untyped value) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.by_col -> table_dup
+  # -->
+  # Returns a duplicate of `self`, in column mode (see [Column
+  # Mode](#class-CSV::Table-label-Column+Mode)):
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.mode # => :col_or_row
+  #     dup_table = table.by_col
+  #     dup_table.mode # => :col
+  #     dup_table.equal?(table) # => false # It's a dup
+  #
+  # This may be used to chain method calls without changing the mode (but also
+  # will affect performance and memory usage):
+  #     dup_table.by_col['Name']
+  #
+  # Also note that changes to the duplicate table will not affect the original.
+  #
+  def by_col: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.by_col! -> self
+  # -->
+  # Sets the mode for `self` to column mode (see [Column
+  # Mode](#class-CSV::Table-label-Column+Mode)); returns `self`:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.mode # => :col_or_row
+  #     table1 = table.by_col!
+  #     table.mode # => :col
+  #     table1.equal?(table) # => true # Returned self
+  #
+  def by_col!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.by_col_or_row -> table_dup
+  # -->
+  # Returns a duplicate of `self`, in mixed mode (see [Mixed
+  # Mode](#class-CSV::Table-label-Mixed+Mode)):
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true).by_col!
+  #     table.mode # => :col
+  #     dup_table = table.by_col_or_row
+  #     dup_table.mode # => :col_or_row
+  #     dup_table.equal?(table) # => false # It's a dup
+  #
+  # This may be used to chain method calls without changing the mode (but also
+  # will affect performance and memory usage):
+  #     dup_table.by_col_or_row['Name']
+  #
+  # Also note that changes to the duplicate table will not affect the original.
+  #
+  def by_col_or_row: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.by_col_or_row! -> self
+  # -->
+  # Sets the mode for `self` to mixed mode (see [Mixed
+  # Mode](#class-CSV::Table-label-Mixed+Mode)); returns `self`:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true).by_col!
+  #     table.mode # => :col
+  #     table1 = table.by_col_or_row!
+  #     table.mode # => :col_or_row
+  #     table1.equal?(table) # => true # Returned self
+  #
+  def by_col_or_row!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.by_row -> table_dup
+  # -->
+  # Returns a duplicate of `self`, in row mode (see [Row
+  # Mode](#class-CSV::Table-label-Row+Mode)):
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.mode # => :col_or_row
+  #     dup_table = table.by_row
+  #     dup_table.mode # => :row
+  #     dup_table.equal?(table) # => false # It's a dup
+  #
+  # This may be used to chain method calls without changing the mode (but also
+  # will affect performance and memory usage):
+  #     dup_table.by_row[1]
+  #
+  # Also note that changes to the duplicate table will not affect the original.
+  #
+  def by_row: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.by_row! -> self
+  # -->
+  # Sets the mode for `self` to row mode (see [Row
+  # Mode](#class-CSV::Table-label-Row+Mode)); returns `self`:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.mode # => :col_or_row
+  #     table1 = table.by_row!
+  #     table.mode # => :row
+  #     table1.equal?(table) # => true # Returned self
+  #
+  def by_row!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.delete(*indexes) -> deleted_values
+  #   - table.delete(*headers) -> deleted_values
+  # -->
+  # If the access mode is `:row` or `:col_or_row`, and each argument is either an
+  # Integer or a Range, returns deleted rows. Otherwise, returns deleted columns
+  # data.
+  #
+  # In either case, the returned values are in the order specified by the
+  # arguments.  Arguments may be repeated.
+  #
+  # ---
+  #
+  # Returns rows as an Array of CSV::Row objects.
+  #
+  # One index:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     deleted_values = table.delete(0)
+  #     deleted_values # => [#<CSV::Row "Name":"foo" "Value":"0">]
+  #
+  # Two indexes:
+  #     table = CSV.parse(source, headers: true)
+  #     deleted_values = table.delete(2, 0)
+  #     deleted_values # => [#<CSV::Row "Name":"baz" "Value":"2">, #<CSV::Row "Name":"foo" "Value":"0">]
+  #
+  # ---
+  #
+  # Returns columns data as column Arrays.
+  #
+  # One header:
+  #     table = CSV.parse(source, headers: true)
+  #     deleted_values = table.delete('Name')
+  #     deleted_values # => ["foo", "bar", "baz"]
+  #
+  # Two headers:
+  #     table = CSV.parse(source, headers: true)
+  #     deleted_values = table.delete('Value', 'Name')
+  #     deleted_values # => [["0", "1", "2"], ["foo", "bar", "baz"]]
+  #
+  def delete: (*untyped indexes_or_headers) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.delete_if {|row_or_column| ... } -> self
+  # -->
+  # Removes rows or columns for which the block returns a truthy value; returns
+  # `self`.
+  #
+  # Removes rows when the access mode is `:row` or `:col_or_row`; calls the block
+  # with each CSV::Row object:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     table.size # => 3
+  #     table.delete_if {|row| row['Name'].start_with?('b') }
+  #     table.size # => 1
+  #
+  # Removes columns when the access mode is `:col`; calls the block with each
+  # column as a 2-element array containing the header and an Array of column
+  # fields:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #     table.headers.size # => 2
+  #     table.delete_if {|column_data| column_data[1].include?('2') }
+  #     table.headers.size # => 1
+  #
+  # Returns a new Enumerator if no block is given:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.delete_if # => #<Enumerator: #<CSV::Table mode:col_or_row row_count:4>:delete_if>
+  #
+  def delete_if: () { (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - dig(index_or_header, *index_or_headers)
+  # -->
+  # Extracts the nested value specified by the sequence of `index` or `header`
+  # objects by calling dig at each step, returning nil if any intermediate step is
+  # nil.
+  #
+  def dig: (untyped index_or_header, *untyped index_or_headers) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.each {|row_or_column| ... ) -> self
+  # -->
+  # Calls the block with each row or column; returns `self`.
+  #
+  # When the access mode is `:row` or `:col_or_row`, calls the block with each
+  # CSV::Row object:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.by_row! # => #<CSV::Table mode:row row_count:4>
+  #     table.each {|row| p row }
+  #
+  # Output:
+  #     #<CSV::Row "Name":"foo" "Value":"0">
+  #     #<CSV::Row "Name":"bar" "Value":"1">
+  #     #<CSV::Row "Name":"baz" "Value":"2">
+  #
+  # When the access mode is `:col`, calls the block with each column as a
+  # 2-element array containing the header and an Array of column fields:
+  #     table.by_col! # => #<CSV::Table mode:col row_count:4>
+  #     table.each {|column_data| p column_data }
+  #
+  # Output:
+  #     ["Name", ["foo", "bar", "baz"]]
+  #     ["Value", ["0", "1", "2"]]
+  #
+  # Returns a new Enumerator if no block is given:
+  #     table.each # => #<Enumerator: #<CSV::Table mode:col row_count:4>:each>
+  #
+  def each: () -> Enumerator[Elem, self]
+          | () { (Elem) -> void } -> self
+          | () { (*untyped) -> void } -> self
+
+  def empty?: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.headers -> array_of_headers
+  # -->
+  # Returns a new Array containing the String headers for the table.
+  #
+  # If the table is not empty, returns the headers from the first row:
+  #     rows = [
+  #       CSV::Row.new(['Foo', 'Bar'], []),
+  #       CSV::Row.new(['FOO', 'BAR'], []),
+  #       CSV::Row.new(['foo', 'bar'], []),
+  #     ]
+  #     table  = CSV::Table.new(rows)
+  #     table.headers # => ["Foo", "Bar"]
+  #     table.delete(0)
+  #     table.headers # => ["FOO", "BAR"]
+  #     table.delete(0)
+  #     table.headers # => ["foo", "bar"]
+  #
+  # If the table is empty, returns a copy of the headers in the table itself:
+  #     table.delete(0)
+  #     table.headers # => ["Foo", "Bar"]
+  #
+  def headers: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.inspect => string
+  # -->
+  # Returns a `US-ASCII`-encoded String showing table:
+  # *   Class: `CSV::Table`.
+  # *   Access mode: `:row`, `:col`, or `:col_or_row`.
+  # *   Size:  Row count, including the header row.
+  #
+  # Example:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.inspect # => "#<CSV::Table mode:col_or_row row_count:4>\nName,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #
+  def inspect: () -> String
+
+  def length: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  # <!-- rdoc-file=lib/csv/table.rb -->
+  # The current access mode for indexing and iteration.
+  #
+  def mode: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.push(*rows_or_arrays) -> self
+  # -->
+  # A shortcut for appending multiple rows. Equivalent to:
+  #     rows.each {|row| self << row }
+  #
+  # Each argument may be either a CSV::Row object or an Array:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     rows = [
+  #       CSV::Row.new(table.headers, ['bat', 3]),
+  #       ['bam', 4]
+  #     ]
+  #     table.push(*rows)
+  #     table[3..4] # => [#<CSV::Row "Name":"bat" "Value":3>, #<CSV::Row "Name":"bam" "Value":4>]
+  #
+  def push: (*untyped rows) -> untyped
+
+  def size: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.to_a -> array_of_arrays
+  # -->
+  # Returns the table as an Array of Arrays; the headers are in the first row:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.to_a # => [["Name", "Value"], ["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  #
+  def to_a: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.to_csv(**options) -> csv_string
+  # -->
+  # Returns the table as CSV string. See [Options for
+  # Generating](../CSV.html#class-CSV-label-Options+for+Generating).
+  #
+  # Defaults option `write_headers` to `true`:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.to_csv # => "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #
+  # Omits the headers if option `write_headers` is given as `false` (see {Option
+  # `write_headers`[}](../CSV.html#class-CSV-label-Option+write_headers)):
+  #     table.to_csv(write_headers: false) # => "foo,0\nbar,1\nbaz,2\n"
+  #
+  # Limit rows if option `limit` is given like `2`:
+  #     table.to_csv(limit: 2) # => "Name,Value\nfoo,0\nbar,1\n"
+  #
+  def to_csv: (?write_headers: boolish, **untyped) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - to_s(write_headers: true, limit: nil, **options)
+  # -->
+  #
+  alias to_s to_csv
+
+  # <!--
+  #   rdoc-file=lib/csv/table.rb
+  #   - table.values_at(*indexes) -> array_of_rows
+  #   - table.values_at(*headers) -> array_of_columns_data
+  # -->
+  # If the access mode is `:row` or `:col_or_row`, and each argument is either an
+  # Integer or a Range, returns rows. Otherwise, returns columns data.
+  #
+  # In either case, the returned values are in the order specified by the
+  # arguments.  Arguments may be repeated.
+  #
+  # ---
+  #
+  # Returns rows as an Array of CSV::Row objects.
+  #
+  # No argument:
+  #     source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+  #     table = CSV.parse(source, headers: true)
+  #     table.values_at # => []
+  #
+  # One index:
+  #     values = table.values_at(0)
+  #     values # => [#<CSV::Row "Name":"foo" "Value":"0">]
+  #
+  # Two indexes:
+  #     values = table.values_at(2, 0)
+  #     values # => [#<CSV::Row "Name":"baz" "Value":"2">, #<CSV::Row "Name":"foo" "Value":"0">]
+  #
+  # One Range:
+  #     values = table.values_at(1..2)
+  #     values # => [#<CSV::Row "Name":"bar" "Value":"1">, #<CSV::Row "Name":"baz" "Value":"2">]
+  #
+  # Ranges and indexes:
+  #     values = table.values_at(0..1, 1..2, 0, 2)
+  #     pp values
+  #
+  # Output:
+  #     [#<CSV::Row "Name":"foo" "Value":"0">,
+  #      #<CSV::Row "Name":"bar" "Value":"1">,
+  #      #<CSV::Row "Name":"bar" "Value":"1">,
+  #      #<CSV::Row "Name":"baz" "Value":"2">,
+  #      #<CSV::Row "Name":"foo" "Value":"0">,
+  #      #<CSV::Row "Name":"baz" "Value":"2">]
+  #
+  # ---
+  #
+  # Returns columns data as row Arrays, each consisting of the specified columns
+  # data for that row:
+  #     values = table.values_at('Name')
+  #     values # => [["foo"], ["bar"], ["baz"]]
+  #     values = table.values_at('Value', 'Name')
+  #     values # => [["0", "foo"], ["1", "bar"], ["2", "baz"]]
+  #
+  def values_at: (*untyped indices_or_headers) -> untyped
+end
+
+%a{annotate:rdoc:skip}
+class Array[unchecked out Elem] < Object
+  # Equivalent to CSV::generate_line(self, options)
+  #
+  #   ["CSV", "data"].to_csv
+  #     #=> "CSV,data\n"
+  def to_csv: (**untyped options) -> String
+end
+
+%a{annotate:rdoc:skip}
+class String
+  # Equivalent to CSV::parse_line(self, options)
+  #
+  #   "CSV,data".parse_csv
+  #     #=> ["CSV", "data"]
+  def parse_csv: (**untyped options) -> ::Array[String?]?
+end

--- a/gems/csv/3.3/manifest.yaml
+++ b/gems/csv/3.3/manifest.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - name: forwardable
+  - name: stringio

--- a/gems/csv/_reviewers.yaml
+++ b/gems/csv/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/minitest/.rubocop.yml
+++ b/gems/minitest/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/minitest/5.25/_test/test.rb
+++ b/gems/minitest/5.25/_test/test.rb
@@ -1,0 +1,11 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "minitest"
+
+Minitest.clock_time
+Minitest.filter_backtrace(caller)
+Minitest.process_args
+Minitest.load_plugins
+Minitest.init_plugins({})
+Minitest.after_run do end

--- a/gems/minitest/5.25/minitest.rbs
+++ b/gems/minitest/5.25/minitest.rbs
@@ -1,0 +1,115 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# The top-level namespace for Minitest. Also the location of the main runtime.
+# See `Minitest.run` for more information.
+#
+module Minitest
+  @@installed_at_exit: untyped
+
+  @@after_run: untyped
+
+  self.@extensions: untyped
+
+  def self.cattr_accessor: (untyped name) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - autorun()
+  # -->
+  # Registers Minitest to run at process exit
+  #
+  def self.autorun: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - after_run(&block)
+  # -->
+  # A simple hook allowing you to run a block of code after everything is done
+  # running. Eg:
+  #
+  #     Minitest.after_run { p $debugging_info }
+  #
+  def self.after_run: () { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - register_plugin(name_or_mod)
+  # -->
+  # Register a plugin to be used. Does NOT require / load it.
+  #
+  def self.register_plugin: (untyped name_or_mod) -> nil
+
+  def self.load_plugins: () -> (nil | untyped)
+
+  def self.init_plugins: (untyped options) -> untyped
+
+  def self.process_args: (?untyped args) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - run(args = [])
+  # -->
+  # This is the top-level run method. Everything starts from here. It tells each
+  # Runnable sub-class to run, and each of those are responsible for doing
+  # whatever they do.
+  #
+  # The overall structure of a run looks like this:
+  #
+  #     Minitest.autorun
+  #       Minitest.run(args)
+  #         Minitest.load_plugins
+  #         Minitest.process_args
+  #         Minitest.init_plugins
+  #         Minitest.__run(reporter, options)
+  #           Runnable.runnables.each
+  #             runnable_klass.run(reporter, options)
+  #               self.runnable_methods.each
+  #                 self.run_one_method(self, runnable_method, reporter)
+  #                   Minitest.run_one_method(klass, runnable_method)
+  #                     klass.new(runnable_method).run
+  #
+  def self.run: (?untyped args) -> untyped
+
+  def self.empty_run!: (untyped options) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - __run(reporter, options)
+  # -->
+  # Internal run method. Responsible for telling all Runnable sub-classes to run.
+  #
+  def self.__run: (untyped reporter, untyped options) -> untyped
+
+  def self.filter_backtrace: (untyped bt) -> untyped
+
+  def self.run_one_method: (untyped klass, untyped method_name) -> untyped
+
+  def self.clock_time: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/manual_plugins.rb
+  #   - load(*names)
+  # -->
+  # Manually load plugins by name.
+  #
+  def self.load: (*untyped names) -> untyped
+
+  def self.plugin_pride_options: (untyped opts, untyped _options) -> untyped
+
+  def self.plugin_pride_init: (untyped options) -> (nil | untyped)
+
+  attr_accessor self.seed: untyped
+
+  attr_accessor self.parallel_executor: untyped
+
+  attr_accessor self.backtrace_filter: untyped
+
+  attr_accessor self.reporter: untyped
+
+  attr_accessor self.extensions: untyped
+
+  attr_accessor self.info_signal: untyped
+
+  attr_accessor self.allow_fork: untyped
+
+  VERSION: String
+end

--- a/gems/minitest/5.25/minitest/abstract_reporter.rbs
+++ b/gems/minitest/5.25/minitest/abstract_reporter.rbs
@@ -1,0 +1,52 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Defines the API for Reporters. Subclass this and override whatever you want.
+# Go nuts.
+#
+class Minitest::AbstractReporter
+  @mutex: untyped
+  def initialize: () -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - start()
+  # -->
+  # Starts reporting on the run.
+  #
+  def start: () -> nil
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - prerecord(klass, name)
+  # -->
+  # About to start running a test. This allows a reporter to show that it is
+  # starting or that we are in the middle of a test run.
+  #
+  def prerecord: (untyped klass, untyped name) -> nil
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - record(result)
+  # -->
+  # Output and record the result of the test. Call
+  # [result#result_code](rdoc-ref:Runnable#result_code) to get the result
+  # character string. Stores the result of the run if the run did not pass.
+  #
+  def record: (untyped result) -> nil
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - report()
+  # -->
+  # Outputs the summary of the run.
+  #
+  def report: () -> nil
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - passed?()
+  # -->
+  # Did this run pass?
+  #
+  def passed?: () -> true
+  def synchronize: () { (?) -> untyped } -> untyped
+end

--- a/gems/minitest/5.25/minitest/assertion.rbs
+++ b/gems/minitest/5.25/minitest/assertion.rbs
@@ -1,0 +1,17 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Represents run failures.
+#
+class Minitest::Assertion < ::Exception
+  def error: () -> self
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - location()
+  # -->
+  # Where was this run before an assertion was raised?
+  #
+  def location: () -> untyped
+  def result_code: () -> untyped
+  def result_label: () -> "Failure"
+  RE: Regexp
+end

--- a/gems/minitest/5.25/minitest/assertions.rbs
+++ b/gems/minitest/5.25/minitest/assertions.rbs
@@ -1,0 +1,590 @@
+# <!-- rdoc-file=lib/minitest/assertions.rb -->
+# Minitest Assertions.  All assertion methods accept a `msg` which is printed if
+# the assertion fails.
+#
+# Protocol: Nearly everything here boils up to `assert`, which expects to be
+# able to increment an instance accessor named `assertions`. This is not
+# provided by Assertions and must be provided by the thing including Assertions.
+# See Minitest::Runnable for an example.
+#
+module Minitest::Assertions
+  self.@diff: untyped
+
+  @skip: untyped
+
+  def self.inspect: () -> "UNDEFINED"
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - diff()
+  # -->
+  # Returns the diff command to use in #diff. Tries to intelligently figure out
+  # what diff to use.
+  #
+  def self.diff: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - diff=(o)
+  # -->
+  # Set the diff command to use in #diff.
+  #
+  def self.diff=: (untyped o) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - diff(exp, act)
+  # -->
+  # Returns a diff between `exp` and `act`. If there is no known diff command or
+  # if it doesn't make sense to diff the output (single line, short output), then
+  # it simply returns a basic comparison between the two.
+  #
+  # See `things_to_diff` for more info.
+  #
+  def diff: (untyped exp, untyped act) -> (::String | untyped)
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - things_to_diff(exp, act)
+  # -->
+  # Returns things to diff [expect, butwas], or [nil, nil] if nothing to diff.
+  #
+  # Criterion:
+  #
+  # 1.  Strings include newlines or escaped newlines, but not both.
+  # 2.  or:  String lengths are > 30 characters.
+  # 3.  or:  Strings are equal to each other (but maybe different encodings?).
+  # 4.  and: we found a diff executable.
+  #
+  def things_to_diff: (untyped exp, untyped act) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - mu_pp(obj)
+  # -->
+  # This returns a human-readable version of `obj`. By default #inspect is called.
+  # You can override this to use #pretty_inspect if you want.
+  #
+  # See Minitest::Test.make_my_diffs_pretty!
+  #
+  def mu_pp: (untyped obj) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - mu_pp_for_diff(obj)
+  # -->
+  # This returns a diff-able more human-readable version of `obj`. This differs
+  # from the regular mu_pp because it expands escaped newlines and makes
+  # hex-values (like object_ids) generic. This uses mu_pp to do the first pass and
+  # then cleans it up.
+  #
+  def mu_pp_for_diff: (untyped obj) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert(test, msg = nil)
+  # -->
+  # Fails unless `test` is truthy.
+  #
+  def assert: (untyped test, ?untyped? msg) -> true
+
+  def _synchronize: () { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_empty(obj, msg = nil)
+  # -->
+  # Fails unless `obj` is empty.
+  #
+  def assert_empty: (untyped obj, ?untyped? msg) -> untyped
+
+  def _where: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_equal(exp, act, msg = nil)
+  # -->
+  # Fails unless `exp == act` printing the difference between the two, if
+  # possible.
+  #
+  # If there is no visible difference but the assertion fails, you should suspect
+  # that your #== is buggy, or your inspect output is missing crucial details.
+  # For nicer structural diffing, set Minitest::Test.make_my_diffs_pretty!
+  #
+  # For floats use assert_in_delta.
+  #
+  # See also: Minitest::Assertions.diff
+  #
+  def assert_equal: (untyped exp, untyped act, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_in_delta(exp, act, delta = 0.001, msg = nil)
+  # -->
+  # For comparing Floats.  Fails unless `exp` and `act` are within `delta` of each
+  # other.
+  #
+  #     assert_in_delta Math::PI, (22.0 / 7.0), 0.01
+  #
+  def assert_in_delta: (untyped exp, untyped act, ?::Float delta, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_in_epsilon(exp, act, epsilon = 0.001, msg = nil)
+  # -->
+  # For comparing Floats.  Fails unless `exp` and `act` have a relative error less
+  # than `epsilon`.
+  #
+  def assert_in_epsilon: (untyped exp, untyped act, ?::Float epsilon, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_includes(collection, obj, msg = nil)
+  # -->
+  # Fails unless `collection` includes `obj`.
+  #
+  def assert_includes: (untyped collection, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_instance_of(cls, obj, msg = nil)
+  # -->
+  # Fails unless `obj` is an instance of `cls`.
+  #
+  def assert_instance_of: (untyped cls, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_kind_of(cls, obj, msg = nil)
+  # -->
+  # Fails unless `obj` is a kind of `cls`.
+  #
+  def assert_kind_of: (untyped cls, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_match(matcher, obj, msg = nil)
+  # -->
+  # Fails unless `matcher` `=~` `obj`.
+  #
+  def assert_match: (untyped matcher, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_nil(obj, msg = nil)
+  # -->
+  # Fails unless `obj` is nil
+  #
+  def assert_nil: (untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_operator(o1, op, o2 = UNDEFINED, msg = nil)
+  # -->
+  # For testing with binary operators. Eg:
+  #
+  #     assert_operator 5, :<=, 4
+  #
+  def assert_operator: (untyped o1, untyped op, ?untyped o2, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_output(stdout = nil, stderr = nil) { || ... }
+  # -->
+  # Fails if stdout or stderr do not output the expected results. Pass in nil if
+  # you don't care about that streams output. Pass in "" if you require it to be
+  # silent. Pass in a regexp if you want to pattern match.
+  #
+  #     assert_output(/hey/) { method_with_output }
+  #
+  # NOTE: this uses #capture_io, not #capture_subprocess_io.
+  #
+  # See also: #assert_silent
+  #
+  def assert_output: (?untyped? stdout, ?untyped? stderr) ?{ () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_path_exists(path, msg = nil)
+  # -->
+  # Fails unless `path` exists.
+  #
+  def assert_path_exists: (untyped path, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_pattern() { || ... }
+  # -->
+  # For testing with pattern matching (only supported with Ruby 3.0 and later)
+  #
+  #     # pass
+  #     assert_pattern { [1,2,3] => [Integer, Integer, Integer] }
+  #
+  #     # fail "length mismatch (given 3, expected 1)"
+  #     assert_pattern { [1,2,3] => [Integer] }
+  #
+  # The bare `=>` pattern will raise a NoMatchingPatternError on failure, which
+  # would normally be counted as a test error. This assertion rescues
+  # NoMatchingPatternError and generates a test failure. Any other exception will
+  # be raised as normal and generate a test error.
+  #
+  def assert_pattern: () ?{ () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_predicate(o1, op, msg = nil)
+  # -->
+  # For testing with predicates. Eg:
+  #
+  #     assert_predicate str, :empty?
+  #
+  # This is really meant for specs and is front-ended by assert_operator:
+  #
+  #     str.must_be :empty?
+  #
+  def assert_predicate: (untyped o1, untyped op, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_raises(*exp) { || ... }
+  # -->
+  # Fails unless the block raises one of `exp`. Returns the exception matched so
+  # you can check the message, attributes, etc.
+  #
+  # `exp` takes an optional message on the end to help explain failures and
+  # defaults to StandardError if no exception class is passed. Eg:
+  #
+  #     assert_raises(CustomError) { method_with_custom_error }
+  #
+  # With custom error message:
+  #
+  #     assert_raises(CustomError, 'This should have raised CustomError') { method_with_custom_error }
+  #
+  # Using the returned object:
+  #
+  #     error = assert_raises(CustomError) do
+  #       raise CustomError, 'This is really bad'
+  #     end
+  #
+  #     assert_equal 'This is really bad', error.message
+  #
+  def assert_raises: (*untyped exp) ?{ () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_respond_to(obj, meth, msg = nil, include_all: false)
+  # -->
+  # Fails unless `obj` responds to `meth`. include_all defaults to false to match
+  # Object#respond_to?
+  #
+  def assert_respond_to: (untyped obj, untyped meth, ?untyped? msg, ?include_all: bool) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_same(exp, act, msg = nil)
+  # -->
+  # Fails unless `exp` and `act` are #equal?
+  #
+  def assert_same: (untyped exp, untyped act, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_send(send_ary, m = nil)
+  # -->
+  # `send_ary` is a receiver, message and arguments.
+  #
+  # Fails unless the call returns a true value
+  #
+  def assert_send: (untyped send_ary, ?untyped? m) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_silent() { || ... }
+  # -->
+  # Fails if the block outputs anything to stderr or stdout.
+  #
+  # See also: #assert_output
+  #
+  def assert_silent: () { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - assert_throws(sym, msg = nil) { || ... }
+  # -->
+  # Fails unless the block throws `sym`
+  #
+  def assert_throws: (untyped sym, ?untyped? msg) { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - capture_io() { || ... }
+  # -->
+  # Captures $stdout and $stderr into strings:
+  #
+  #     out, err = capture_io do
+  #       puts "Some info"
+  #       warn "You did a bad thing"
+  #     end
+  #
+  #     assert_match %r%info%, out
+  #     assert_match %r%bad%, err
+  #
+  # NOTE: For efficiency, this method uses StringIO and does not capture IO for
+  # subprocesses. Use #capture_subprocess_io for that.
+  #
+  def capture_io: () { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - capture_subprocess_io() { || ... }
+  # -->
+  # Captures $stdout and $stderr into strings, using Tempfile to ensure that
+  # subprocess IO is captured as well.
+  #
+  #     out, err = capture_subprocess_io do
+  #       system "echo Some info"
+  #       system "echo You did a bad thing 1>&2"
+  #     end
+  #
+  #     assert_match %r%info%, out
+  #     assert_match %r%bad%, err
+  #
+  # NOTE: This method is approximately 10x slower than #capture_io so only use it
+  # when you need to test the output of a subprocess.
+  #
+  def capture_subprocess_io: () { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - exception_details(e, msg)
+  # -->
+  # Returns details for exception `e`
+  #
+  def exception_details: (untyped e, untyped msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - fail_after(y, m, d, msg)
+  # -->
+  # Fails after a given date (in the local time zone). This allows you to put
+  # time-bombs in your tests if you need to keep something around until a later
+  # date lest you forget about it.
+  #
+  def fail_after: (untyped y, untyped m, untyped d, untyped msg) -> (untyped | nil)
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - flunk(msg = nil)
+  # -->
+  # Fails with `msg`.
+  #
+  def flunk: (?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - message(msg = nil, ending = nil, &default)
+  # -->
+  # Returns a proc that will output `msg` along with the default message.
+  #
+  def message: (?untyped? msg, ?untyped? ending) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - pass(_msg = nil)
+  # -->
+  # used for counting assertions
+  #
+  def pass: (?untyped? _msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute(test, msg = nil)
+  # -->
+  # Fails if `test` is truthy.
+  #
+  def refute: (untyped test, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_empty(obj, msg = nil)
+  # -->
+  # Fails if `obj` is empty.
+  #
+  def refute_empty: (untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_equal(exp, act, msg = nil)
+  # -->
+  # Fails if `exp == act`.
+  #
+  # For floats use refute_in_delta.
+  #
+  def refute_equal: (untyped exp, untyped act, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_in_delta(exp, act, delta = 0.001, msg = nil)
+  # -->
+  # For comparing Floats.  Fails if `exp` is within `delta` of `act`.
+  #
+  #     refute_in_delta Math::PI, (22.0 / 7.0)
+  #
+  def refute_in_delta: (untyped exp, untyped act, ?::Float delta, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_in_epsilon(a, b, epsilon = 0.001, msg = nil)
+  # -->
+  # For comparing Floats.  Fails if `exp` and `act` have a relative error less
+  # than `epsilon`.
+  #
+  def refute_in_epsilon: (untyped a, untyped b, ?::Float epsilon, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_includes(collection, obj, msg = nil)
+  # -->
+  # Fails if `collection` includes `obj`.
+  #
+  def refute_includes: (untyped collection, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_instance_of(cls, obj, msg = nil)
+  # -->
+  # Fails if `obj` is an instance of `cls`.
+  #
+  def refute_instance_of: (untyped cls, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_kind_of(cls, obj, msg = nil)
+  # -->
+  # Fails if `obj` is a kind of `cls`.
+  #
+  def refute_kind_of: (untyped cls, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_match(matcher, obj, msg = nil)
+  # -->
+  # Fails if `matcher` `=~` `obj`.
+  #
+  def refute_match: (untyped matcher, untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_nil(obj, msg = nil)
+  # -->
+  # Fails if `obj` is nil.
+  #
+  def refute_nil: (untyped obj, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_pattern() { || ... }
+  # -->
+  # For testing with pattern matching (only supported with Ruby 3.0 and later)
+  #
+  #     # pass
+  #     refute_pattern { [1,2,3] => [String] }
+  #
+  #     # fail "NoMatchingPatternError expected, but nothing was raised."
+  #     refute_pattern { [1,2,3] => [Integer, Integer, Integer] }
+  #
+  # This assertion expects a NoMatchingPatternError exception, and will fail if
+  # none is raised. Any other exceptions will be raised as normal and generate a
+  # test error.
+  #
+  def refute_pattern: () ?{ () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_operator(o1, op, o2 = UNDEFINED, msg = nil)
+  # -->
+  # Fails if `o1` is not `op` `o2`. Eg:
+  #
+  #     refute_operator 1, :>, 2 #=> pass
+  #     refute_operator 1, :<, 2 #=> fail
+  #
+  def refute_operator: (untyped o1, untyped op, ?untyped o2, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_path_exists(path, msg = nil)
+  # -->
+  # Fails if `path` exists.
+  #
+  def refute_path_exists: (untyped path, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_predicate(o1, op, msg = nil)
+  # -->
+  # For testing with predicates.
+  #
+  #     refute_predicate str, :empty?
+  #
+  # This is really meant for specs and is front-ended by refute_operator:
+  #
+  #     str.wont_be :empty?
+  #
+  def refute_predicate: (untyped o1, untyped op, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_respond_to(obj, meth, msg = nil, include_all: false)
+  # -->
+  # Fails if `obj` responds to the message `meth`. include_all defaults to false
+  # to match Object#respond_to?
+  #
+  def refute_respond_to: (untyped obj, untyped meth, ?untyped? msg, ?include_all: bool) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - refute_same(exp, act, msg = nil)
+  # -->
+  # Fails if `exp` is the same (by object identity) as `act`.
+  #
+  def refute_same: (untyped exp, untyped act, ?untyped? msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - skip(msg = nil, _ignored = nil)
+  # -->
+  # Skips the current run. If run in verbose-mode, the skipped run gets listed at
+  # the end of the run but doesn't cause a failure exit code.
+  #
+  def skip: (?untyped? msg, ?untyped? _ignored) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - skip_until(y, m, d, msg)
+  # -->
+  # Skips the current run until a given date (in the local time zone). This allows
+  # you to put some fixes on hold until a later date, but still holds you
+  # accountable and prevents you from forgetting it.
+  #
+  def skip_until: (untyped y, untyped m, untyped d, untyped msg) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/assertions.rb
+  #   - skipped?()
+  # -->
+  # Was this testcase skipped? Meant for #teardown.
+  #
+  def skipped?: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/mock.rb
+  #   - assert_mock(mock)
+  # -->
+  # Assert that the mock verifies correctly.
+  #
+  def assert_mock: (untyped mock) -> untyped
+
+  E: String
+
+  UNDEFINED: Object
+end

--- a/gems/minitest/5.25/minitest/backtrace_filter.rbs
+++ b/gems/minitest/5.25/minitest/backtrace_filter.rbs
@@ -1,0 +1,23 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# The standard backtrace filter for minitest.
+#
+# See Minitest.backtrace_filter=.
+#
+class Minitest::BacktraceFilter
+  def initialize: (?untyped regexp) -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - filter(bt)
+  # -->
+  # Filter `bt` to something useful. Returns the whole thing if $DEBUG (ruby) or
+  # $MT_DEBUG (env).
+  #
+  def filter: (untyped bt) -> (::Array["No backtrace"] | untyped)
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # The regular expression to use to filter backtraces. Defaults to `MT_RE`.
+  #
+  attr_accessor regexp: untyped
+  MT_RE: Regexp
+end

--- a/gems/minitest/5.25/minitest/bench_spec.rbs
+++ b/gems/minitest/5.25/minitest/bench_spec.rbs
@@ -1,0 +1,102 @@
+# <!-- rdoc-file=lib/minitest/benchmark.rb -->
+# The spec version of Minitest::Benchmark.
+#
+class Minitest::BenchSpec < ::Minitest::Benchmark
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench(name, &block)
+  # -->
+  # This is used to define a new benchmark method. You usually don't use this
+  # directly and is intended for those needing to write new performance curve fits
+  # (eg: you need a specific polynomial fit).
+  #
+  # See ::bench_performance_linear for an example of how to use this.
+  #
+  def self.bench: (untyped name) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_range(&block)
+  # -->
+  # Specifies the ranges used for benchmarking for that class.
+  #
+  #     bench_range do
+  #       bench_exp(2, 16, 2)
+  #     end
+  #
+  # See Minitest::Benchmark#bench_range for more details.
+  #
+  def self.bench_range: () ?{ (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_performance_linear(name, threshold = 0.99, &work)
+  # -->
+  # Create a benchmark that verifies that the performance is linear.
+  #
+  #     describe "my class Bench" do
+  #       bench_performance_linear "fast_algorithm", 0.9999 do |n|
+  #         @obj.fast_algorithm(n)
+  #       end
+  #     end
+  #
+  def self.bench_performance_linear: (untyped name, ?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_performance_constant(name, threshold = 0.99, &work)
+  # -->
+  # Create a benchmark that verifies that the performance is constant.
+  #
+  #     describe "my class Bench" do
+  #       bench_performance_constant "zoom_algorithm!" do |n|
+  #         @obj.zoom_algorithm!(n)
+  #       end
+  #     end
+  #
+  def self.bench_performance_constant: (untyped name, ?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_performance_exponential(name, threshold = 0.99, &work)
+  # -->
+  # Create a benchmark that verifies that the performance is exponential.
+  #
+  #     describe "my class Bench" do
+  #       bench_performance_exponential "algorithm" do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def self.bench_performance_exponential: (untyped name, ?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_performance_logarithmic(name, threshold = 0.99, &work)
+  # -->
+  # Create a benchmark that verifies that the performance is logarithmic.
+  #
+  #     describe "my class Bench" do
+  #       bench_performance_logarithmic "algorithm" do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def self.bench_performance_logarithmic: (untyped name, ?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_performance_power(name, threshold = 0.99, &work)
+  # -->
+  # Create a benchmark that verifies that the performance is power.
+  #
+  #     describe "my class Bench" do
+  #       bench_performance_power "algorithm" do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def self.bench_performance_power: (untyped name, ?::Float threshold) { (?) -> untyped } -> untyped
+  extend Minitest::Spec::DSL
+  include Minitest::Spec::DSL::InstanceMethods
+end

--- a/gems/minitest/5.25/minitest/benchmark.rbs
+++ b/gems/minitest/5.25/minitest/benchmark.rbs
@@ -1,0 +1,259 @@
+# <!-- rdoc-file=lib/minitest/benchmark.rb -->
+# Subclass Benchmark to create your own benchmark runs. Methods starting with
+# "bench_" get executed on a per-class.
+#
+# See Minitest::Assertions
+#
+class Minitest::Benchmark < ::Minitest::Test
+  self.@io: untyped
+  def self.io: () -> untyped
+  def io: () -> untyped
+  def self.run: (untyped reporter, ?::Hash[untyped, untyped] options) -> untyped
+  def self.runnable_methods: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_exp(min, max, base = 10)
+  # -->
+  # Returns a set of ranges stepped exponentially from `min` to `max` by powers of
+  # `base`. Eg:
+  #
+  #     bench_exp(2, 16, 2) # => [2, 4, 8, 16]
+  #
+  def self.bench_exp: (untyped min, untyped max, ?::Integer base) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_linear(min, max, step = 10)
+  # -->
+  # Returns a set of ranges stepped linearly from `min` to `max` by `step`. Eg:
+  #
+  #     bench_linear(20, 40, 10) # => [20, 30, 40]
+  #
+  def self.bench_linear: (untyped min, untyped max, ?::Integer step) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - bench_range()
+  # -->
+  # Specifies the ranges used for benchmarking for that class. Defaults to
+  # exponential growth from 1 to 10k by powers of 10. Override if you need
+  # different ranges for your benchmarks.
+  #
+  # See also: ::bench_exp and ::bench_linear.
+  #
+  def self.bench_range: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - assert_performance(validation, &work)
+  # -->
+  # Runs the given `work`, gathering the times of each run. Range and times are
+  # then passed to a given `validation` proc. Outputs the benchmark name and times
+  # in tab-separated format, making it easy to paste into a spreadsheet for
+  # graphing or further analysis.
+  #
+  # Ranges are specified by ::bench_range.
+  #
+  # Eg:
+  #
+  #     def bench_algorithm
+  #       validation = proc { |x, y| ... }
+  #       assert_performance validation do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def assert_performance: (untyped validation) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - assert_performance_constant(threshold = 0.99, &work)
+  # -->
+  # Runs the given `work` and asserts that the times gathered fit to match a
+  # constant rate (eg, linear slope == 0) within a given `threshold`. Note:
+  # because we're testing for a slope of 0, R^2 is not a good determining factor
+  # for the fit, so the threshold is applied against the slope itself. As such,
+  # you probably want to tighten it from the default.
+  #
+  # See
+  # https://www.graphpad.com/guides/prism/8/curve-fitting/reg_intepretingnonlinr2.
+  # htm for more details.
+  #
+  # Fit is calculated by #fit_linear.
+  #
+  # Ranges are specified by ::bench_range.
+  #
+  # Eg:
+  #
+  #     def bench_algorithm
+  #       assert_performance_constant 0.9999 do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def assert_performance_constant: (?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - assert_performance_exponential(threshold = 0.99, &work)
+  # -->
+  # Runs the given `work` and asserts that the times gathered fit to match a
+  # exponential curve within a given error `threshold`.
+  #
+  # Fit is calculated by #fit_exponential.
+  #
+  # Ranges are specified by ::bench_range.
+  #
+  # Eg:
+  #
+  #     def bench_algorithm
+  #       assert_performance_exponential 0.9999 do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def assert_performance_exponential: (?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - assert_performance_logarithmic(threshold = 0.99, &work)
+  # -->
+  # Runs the given `work` and asserts that the times gathered fit to match a
+  # logarithmic curve within a given error `threshold`.
+  #
+  # Fit is calculated by #fit_logarithmic.
+  #
+  # Ranges are specified by ::bench_range.
+  #
+  # Eg:
+  #
+  #     def bench_algorithm
+  #       assert_performance_logarithmic 0.9999 do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def assert_performance_logarithmic: (?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - assert_performance_linear(threshold = 0.99, &work)
+  # -->
+  # Runs the given `work` and asserts that the times gathered fit to match a
+  # straight line within a given error `threshold`.
+  #
+  # Fit is calculated by #fit_linear.
+  #
+  # Ranges are specified by ::bench_range.
+  #
+  # Eg:
+  #
+  #     def bench_algorithm
+  #       assert_performance_linear 0.9999 do |n|
+  #         @obj.algorithm(n)
+  #       end
+  #     end
+  #
+  def assert_performance_linear: (?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - assert_performance_power(threshold = 0.99, &work)
+  # -->
+  # Runs the given `work` and asserts that the times gathered curve fit to match a
+  # power curve within a given error `threshold`.
+  #
+  # Fit is calculated by #fit_power.
+  #
+  # Ranges are specified by ::bench_range.
+  #
+  # Eg:
+  #
+  #     def bench_algorithm
+  #       assert_performance_power 0.9999 do |x|
+  #         @obj.algorithm
+  #       end
+  #     end
+  #
+  def assert_performance_power: (?::Float threshold) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - fit_error(xys) { |x| ... }
+  # -->
+  # Takes an array of x/y pairs and calculates the general R^2 value.
+  #
+  # See: https://en.wikipedia.org/wiki/Coefficient_of_determination
+  #
+  def fit_error: (untyped xys) { (untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - fit_exponential(xs, ys)
+  # -->
+  # To fit a functional form: y = ae^(bx).
+  #
+  # Takes x and y values and returns [a, b, r^2].
+  #
+  # See: https://mathworld.wolfram.com/LeastSquaresFittingExponential.html
+  #
+  def fit_exponential: (untyped xs, untyped ys) -> ::Array[untyped]
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - fit_logarithmic(xs, ys)
+  # -->
+  # To fit a functional form: y = a + b*ln(x).
+  #
+  # Takes x and y values and returns [a, b, r^2].
+  #
+  # See: https://mathworld.wolfram.com/LeastSquaresFittingLogarithmic.html
+  #
+  def fit_logarithmic: (untyped xs, untyped ys) -> ::Array[untyped]
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - fit_linear(xs, ys)
+  # -->
+  # Fits the functional form: a + bx.
+  #
+  # Takes x and y values and returns [a, b, r^2].
+  #
+  # See: https://mathworld.wolfram.com/LeastSquaresFitting.html
+  #
+  def fit_linear: (untyped xs, untyped ys) -> ::Array[untyped]
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - fit_power(xs, ys)
+  # -->
+  # To fit a functional form: y = ax^b.
+  #
+  # Takes x and y values and returns [a, b, r^2].
+  #
+  # See: https://mathworld.wolfram.com/LeastSquaresFittingPowerLaw.html
+  #
+  def fit_power: (untyped xs, untyped ys) -> ::Array[untyped]
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - sigma(enum, &block)
+  # -->
+  # Enumerates over `enum` mapping `block` if given, returning the sum of the
+  # result. Eg:
+  #
+  #     sigma([1, 2, 3])                # => 1 + 2 + 3 => 6
+  #     sigma([1, 2, 3]) { |n| n ** 2 } # => 1 + 4 + 9 => 14
+  #
+  def sigma: (untyped enum) ?{ (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/benchmark.rb
+  #   - validation_for_fit(msg, threshold)
+  # -->
+  # Returns a proc that calls the specified fit method and asserts that the error
+  # is within a tolerable threshold.
+  #
+  def validation_for_fit: (untyped msg, untyped threshold) -> untyped
+end

--- a/gems/minitest/5.25/minitest/composite_reporter.rbs
+++ b/gems/minitest/5.25/minitest/composite_reporter.rbs
@@ -1,0 +1,25 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Dispatch to multiple reporters as one.
+#
+class Minitest::CompositeReporter < ::Minitest::AbstractReporter
+  def initialize: (*untyped reporters) -> void
+  def io: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - <<(reporter)
+  # -->
+  # Add another reporter to the mix.
+  #
+  def <<: (untyped reporter) -> untyped
+  def passed?: () -> untyped
+  def start: () -> untyped
+  def prerecord: (untyped klass, untyped name) -> untyped
+  def record: (untyped result) -> untyped
+  def report: () -> untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # The list of reporters to dispatch to.
+  #
+  attr_accessor reporters: untyped
+end

--- a/gems/minitest/5.25/minitest/compress.rbs
+++ b/gems/minitest/5.25/minitest/compress.rbs
@@ -1,0 +1,13 @@
+# <!-- rdoc-file=lib/minitest/compress.rb -->
+# Compresses backtraces.
+#
+module Minitest::Compress
+  # <!--
+  #   rdoc-file=lib/minitest/compress.rb
+  #   - compress(orig)
+  # -->
+  # Takes a backtrace (array of strings) and compresses repeating cycles in it to
+  # make it more readable.
+  #
+  def compress: (untyped orig) -> untyped
+end

--- a/gems/minitest/5.25/minitest/error_on_warning.rbs
+++ b/gems/minitest/5.25/minitest/error_on_warning.rbs
@@ -1,0 +1,3 @@
+module Minitest::ErrorOnWarning
+  def warn: (untyped message, ?category: untyped?) -> untyped
+end

--- a/gems/minitest/5.25/minitest/expectation.rbs
+++ b/gems/minitest/5.25/minitest/expectation.rbs
@@ -1,0 +1,2 @@
+class Minitest::Expectation < ::Struct[untyped]
+end

--- a/gems/minitest/5.25/minitest/expectations.rbs
+++ b/gems/minitest/5.25/minitest/expectations.rbs
@@ -1,0 +1,21 @@
+# <!-- rdoc-file=lib/minitest/expectations.rb -->
+# It's where you hide your "assertions".
+#
+# Please note, because of the way that expectations are implemented, all
+# expectations (eg must_equal) are dependent upon a thread local variable
+# `:current_spec`. If your specs rely on mixing threads into the specs
+# themselves, you're better off using assertions or the new _(value) wrapper.
+# For example:
+#
+#     it "should still work in threads" do
+#       my_threaded_thingy do
+#         (1+1).must_equal 2                  # bad
+#         assert_equal 2, 1+1                 # good
+#         _(1 + 1).must_equal 2               # good
+#         value(1 + 1).must_equal 2           # good, also #expect
+#         _ { 1 + "1" }.must_raise TypeError  # good
+#       end
+#     end
+#
+module Minitest::Expectations
+end

--- a/gems/minitest/5.25/minitest/guard.rbs
+++ b/gems/minitest/5.25/minitest/guard.rbs
@@ -1,0 +1,64 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Provides a simple set of guards that you can use in your tests to skip
+# execution if it is not applicable. These methods are mixed into Test as both
+# instance and class methods so you can use them inside or outside of the test
+# methods.
+#
+#     def test_something_for_mri
+#       skip "bug 1234"  if jruby?
+#       # ...
+#     end
+#
+#     if windows? then
+#       # ... lots of test methods ...
+#     end
+#
+module Minitest::Guard
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - jruby?(platform = RUBY_PLATFORM)
+  # -->
+  # Is this running on jruby?
+  #
+  def jruby?: (?untyped platform) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - maglev?(platform = defined?(RUBY_ENGINE) && RUBY_ENGINE)
+  # -->
+  # Is this running on maglev?
+  #
+  def maglev?: (?untyped platform) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - mri?(platform = RUBY_DESCRIPTION)
+  # -->
+  # Is this running on mri?
+  #
+  def mri?: (?untyped platform) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - osx?(platform = RUBY_PLATFORM)
+  # -->
+  # Is this running on macOS?
+  #
+  def osx?: (?untyped platform) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - rubinius?(platform = defined?(RUBY_ENGINE) && RUBY_ENGINE)
+  # -->
+  # Is this running on rubinius?
+  #
+  def rubinius?: (?untyped platform) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - windows?(platform = RUBY_PLATFORM)
+  # -->
+  # Is this running on windows?
+  #
+  def windows?: (?untyped platform) -> untyped
+end

--- a/gems/minitest/5.25/minitest/mock.rbs
+++ b/gems/minitest/5.25/minitest/mock.rbs
@@ -1,0 +1,64 @@
+# <!-- rdoc-file=lib/minitest/mock.rb -->
+# A simple and clean mock object framework.
+#
+# All mock objects are an instance of Mock
+#
+class Minitest::Mock
+  @@KW_WARNED: untyped
+  @delegator: untyped
+  @expected_calls: untyped
+  @actual_calls: untyped
+  alias __respond_to? respond_to?
+  def initialize: (?untyped? delegator) -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/mock.rb
+  #   - expect(name, retval, args = [], **kwargs, &blk)
+  # -->
+  # Expect that method `name` is called, optionally with `args` (and `kwargs` or a
+  # `blk`), and returns `retval`.
+  #
+  #     @mock.expect(:meaning_of_life, 42)
+  #     @mock.meaning_of_life # => 42
+  #
+  #     @mock.expect(:do_something_with, true, [some_obj, true])
+  #     @mock.do_something_with(some_obj, true) # => true
+  #
+  #     @mock.expect(:do_something_else, true) do |a1, a2|
+  #       a1 == "buggs" && a2 == :bunny
+  #     end
+  #
+  # `args` is compared to the expected args using case equality (ie, the '==='
+  # operator), allowing for less specific expectations.
+  #
+  #     @mock.expect(:uses_any_string, true, [String])
+  #     @mock.uses_any_string("foo") # => true
+  #     @mock.verify  # => true
+  #
+  #     @mock.expect(:uses_one_string, true, ["foo"])
+  #     @mock.uses_one_string("bar") # => raises MockExpectationError
+  #
+  # If a method will be called multiple times, specify a new expect for each one.
+  # They will be used in the order you define them.
+  #
+  #     @mock.expect(:ordinal_increment, 'first')
+  #     @mock.expect(:ordinal_increment, 'second')
+  #
+  #     @mock.ordinal_increment # => 'first'
+  #     @mock.ordinal_increment # => 'second'
+  #     @mock.ordinal_increment # => raises MockExpectationError "No more expects available for :ordinal_increment"
+  #
+  def expect: (untyped name, untyped retval, ?untyped args, **untyped kwargs) ?{ (?) -> untyped } -> self
+  def __call: (untyped name, untyped data) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/mock.rb
+  #   - verify()
+  # -->
+  # Verify that all methods were called as expected. Raises `MockExpectationError`
+  # if the mock object was not called as expected.
+  #
+  def verify: () -> true
+  def method_missing: (untyped sym, *untyped args, **untyped kwargs) { (?) -> untyped } -> untyped
+  def respond_to?: (untyped sym, ?bool include_private) -> (true | untyped)
+end

--- a/gems/minitest/5.25/minitest/parallel.rbs
+++ b/gems/minitest/5.25/minitest/parallel.rbs
@@ -1,0 +1,2 @@
+module Minitest::Parallel
+end

--- a/gems/minitest/5.25/minitest/parallel/executor.rbs
+++ b/gems/minitest/5.25/minitest/parallel/executor.rbs
@@ -1,0 +1,46 @@
+# <!-- rdoc-file=lib/minitest/parallel.rb -->
+# The engine used to run multiple tests in parallel.
+#
+class Minitest::Parallel::Executor
+  @size: untyped
+  @queue: untyped
+  @pool: untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/parallel.rb
+  #   - new(size)
+  # -->
+  # Create a parallel test executor of with `size` workers.
+  #
+  def initialize: (untyped size) -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/parallel.rb
+  #   - start()
+  # -->
+  # Start the executor
+  #
+  def start: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/parallel.rb
+  #   - <<(work;)
+  # -->
+  # Add a job to the queue
+  #
+  def <<: (untyped work) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/parallel.rb
+  #   - shutdown()
+  # -->
+  # Shuts down the pool of workers by signalling them to quit and waiting for them
+  # all to finish what they're currently working on.
+  #
+  def shutdown: () -> untyped
+
+  # <!-- rdoc-file=lib/minitest/parallel.rb -->
+  # The size of the pool of workers.
+  #
+  attr_reader size: untyped
+end

--- a/gems/minitest/5.25/minitest/parallel/test.rbs
+++ b/gems/minitest/5.25/minitest/parallel/test.rbs
@@ -1,0 +1,3 @@
+module Minitest::Parallel::Test
+  def _synchronize: () { () -> untyped } -> untyped
+end

--- a/gems/minitest/5.25/minitest/parallel/test/class_methods.rbs
+++ b/gems/minitest/5.25/minitest/parallel/test/class_methods.rbs
@@ -1,0 +1,5 @@
+module Minitest::Parallel::Test::ClassMethods
+  def run_one_method: (untyped klass, untyped method_name, untyped reporter) -> untyped
+
+  def test_order: () -> :parallel
+end

--- a/gems/minitest/5.25/minitest/pride_io.rbs
+++ b/gems/minitest/5.25/minitest/pride_io.rbs
@@ -1,0 +1,62 @@
+# <!-- rdoc-file=lib/minitest/pride_plugin.rb -->
+# Show your testing pride!
+#
+class Minitest::PrideIO
+  self.@pride: untyped
+  @io: untyped
+  # stolen from /System/Library/Perl/5.10.0/Term/ANSIColor.pm
+  # also reference https://en.wikipedia.org/wiki/ANSI_escape_code
+  @colors: untyped
+  @size: untyped
+  @index: untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/pride_plugin.rb
+  #   - pride!()
+  # -->
+  # Activate the pride plugin. Called from both -p option and minitest/pride
+  #
+  def self.pride!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/pride_plugin.rb
+  #   - pride?()
+  # -->
+  # Are we showing our testing pride?
+  #
+  def self.pride?: () -> untyped
+  def initialize: (untyped io) -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/pride_plugin.rb
+  #   - print(o)
+  # -->
+  # Wrap print to colorize the output.
+  #
+  def print: (untyped o) -> untyped
+  def puts: (*untyped o) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/pride_plugin.rb
+  #   - pride(string)
+  # -->
+  # Color a string.
+  #
+  def pride: (untyped string) -> ::String
+  def method_missing: (untyped msg, *untyped args) -> untyped
+
+  # <!-- rdoc-file=lib/minitest/pride_plugin.rb -->
+  # The IO we're going to pipe through.
+  #
+  attr_reader io: untyped
+
+  # <!-- rdoc-file=lib/minitest/pride_plugin.rb -->
+  # Start an escape sequence
+  #
+  ESC: String
+
+  # <!-- rdoc-file=lib/minitest/pride_plugin.rb -->
+  # End the escape sequence
+  #
+  NND: String
+end

--- a/gems/minitest/5.25/minitest/pride_lol.rbs
+++ b/gems/minitest/5.25/minitest/pride_lol.rbs
@@ -1,0 +1,19 @@
+# <!-- rdoc-file=lib/minitest/pride_plugin.rb -->
+# If you thought the PrideIO was colorful...
+#
+# (Inspired by lolcat, but with clean math)
+#
+class Minitest::PrideLOL < ::Minitest::PrideIO
+  @colors: untyped
+  @index: untyped
+  def initialize: (untyped io) -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/pride_plugin.rb
+  #   - pride(string)
+  # -->
+  # Make the string even more colorful. Damnit.
+  #
+  def pride: (untyped string) -> ::String
+  PI_3: Float
+end

--- a/gems/minitest/5.25/minitest/progress_reporter.rbs
+++ b/gems/minitest/5.25/minitest/progress_reporter.rbs
@@ -1,0 +1,11 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# A very simple reporter that prints the "dots" during the run.
+#
+# This is added to the top-level CompositeReporter at the start of the run. If
+# you want to change the output of minitest via a plugin, pull this out of the
+# composite and replace it with your own.
+#
+class Minitest::ProgressReporter < ::Minitest::Reporter
+  def prerecord: (untyped klass, untyped name) -> (nil | untyped)
+  def record: (untyped result) -> untyped
+end

--- a/gems/minitest/5.25/minitest/reportable.rbs
+++ b/gems/minitest/5.25/minitest/reportable.rbs
@@ -1,0 +1,53 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Shared code for anything that can get passed to a Reporter. See Minitest::Test
+# & Minitest::Result.
+#
+module Minitest::Reportable
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - passed?()
+  # -->
+  # Did this run pass?
+  #
+  # Note: skipped runs are not considered passing, but they don't cause the
+  # process to exit non-zero.
+  #
+  def passed?: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - location()
+  # -->
+  # The location identifier of this test. Depends on a method existing called
+  # class_name.
+  #
+  def location: () -> ::String
+
+  def class_name: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - result_code()
+  # -->
+  # Returns ".", "F", or "E" based on the result of the run.
+  #
+  def result_code: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - skipped?()
+  # -->
+  # Was this run skipped?
+  #
+  def skipped?: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - error?()
+  # -->
+  # Did this run error?
+  #
+  def error?: () -> untyped
+
+  BASE_DIR: String
+end

--- a/gems/minitest/5.25/minitest/reporter.rbs
+++ b/gems/minitest/5.25/minitest/reporter.rbs
@@ -1,0 +1,5 @@
+class Minitest::Reporter < ::Minitest::AbstractReporter
+  def initialize: (?untyped io, ?::Hash[untyped, untyped] options) -> void
+  attr_accessor io: untyped
+  attr_accessor options: untyped
+end

--- a/gems/minitest/5.25/minitest/result.rbs
+++ b/gems/minitest/5.25/minitest/result.rbs
@@ -1,0 +1,28 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# This represents a test result in a clean way that can be marshalled over a
+# wire. Tests can do anything they want to the test instance and can create
+# conditions that cause Marshal.dump to blow up. By using Result.from(a_test)
+# you can be reasonably sure that the test result can be marshalled.
+#
+class Minitest::Result < ::Minitest::Runnable
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - from(runnable)
+  # -->
+  # Create a new test result from a Runnable instance.
+  #
+  def self.from: (untyped runnable) -> untyped
+  def class_name: () -> untyped
+  def to_s: () -> untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # The class name of the test result.
+  #
+  attr_accessor klass: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # The location of the test method.
+  #
+  attr_accessor source_location: untyped
+  include Minitest::Reportable
+end

--- a/gems/minitest/5.25/minitest/runnable.rbs
+++ b/gems/minitest/5.25/minitest/runnable.rbs
@@ -1,0 +1,163 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Represents anything "runnable", like Test, Spec, Benchmark, or whatever you
+# can dream up.
+#
+# Subclasses of this are automatically registered and available in
+# Runnable.runnables.
+#
+class Minitest::Runnable
+  @@runnables: untyped
+  @@marshal_dump_warned: untyped
+  self.@_info_handler: untyped
+  @NAME: untyped
+  @metadata: untyped
+  def time_it: () { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - name()
+  # -->
+  # Name of the run.
+  #
+  def name: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - name=(o)
+  # -->
+  # Set the name of the run.
+  #
+  def name=: (untyped o) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - methods_matching(re)
+  # -->
+  # Returns all instance methods matching the pattern `re`.
+  #
+  def self.methods_matching: (untyped re) -> untyped
+  def self.reset: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - run(reporter, options = {})
+  # -->
+  # Responsible for running all runnable methods in a given class, each in its own
+  # instance. Each instance is passed to the reporter to record.
+  #
+  def self.run: (untyped reporter, ?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - run_one_method(klass, method_name, reporter)
+  # -->
+  # Runs a single method and has the reporter record the result. This was
+  # considered internal API but is factored out of run so that subclasses can
+  # specialize the running of an individual test. See
+  # Minitest::ParallelTest::ClassMethods for an example.
+  #
+  def self.run_one_method: (untyped klass, untyped method_name, untyped reporter) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - test_order()
+  # -->
+  # Defines the order to run tests (:random by default). Override this or use a
+  # convenience method to change it for your tests.
+  #
+  def self.test_order: () -> :random
+  def self.with_info_handler: (untyped reporter) { (?) -> untyped } -> untyped
+  def self.on_signal: (untyped name, untyped action) { () -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - runnable_methods()
+  # -->
+  # Each subclass of Runnable is responsible for overriding this method to return
+  # all runnable methods. See #methods_matching.
+  #
+  def self.runnable_methods: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - runnables()
+  # -->
+  # Returns all subclasses of Runnable.
+  #
+  def self.runnables: () -> untyped
+  def marshal_dump: () -> ::Array[untyped]
+  def marshal_load: (untyped ary) -> untyped
+  def failure: () -> untyped
+  def initialize: (untyped name) -> void
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Sets metadata, mainly used for `Result.from`.
+  #
+  def metadata: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - metadata?()
+  # -->
+  # Returns true if metadata exists.
+  #
+  def metadata?: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - run()
+  # -->
+  # Runs a single method. Needs to return self.
+  #
+  def run: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - passed?()
+  # -->
+  # Did this run pass?
+  #
+  # Note: skipped runs are not considered passing, but they don't cause the
+  # process to exit non-zero.
+  #
+  def passed?: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - result_code()
+  # -->
+  # Returns a single character string to print based on the result of the run. One
+  # of `"."`, `"F"`, `"E"` or `"S"`.
+  #
+  def result_code: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - skipped?()
+  # -->
+  # Was this run skipped? See #passed? for more information.
+  #
+  def skipped?: () -> untyped
+  def self.inherited: (untyped klass) -> untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Number of assertions executed in this run.
+  #
+  attr_accessor assertions: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # An assertion raised during the run, if any.
+  #
+  attr_accessor failures: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # The time it took to run.
+  #
+  attr_accessor time: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Sets metadata, mainly used for `Result.from`.
+  #
+  attr_writer metadata: untyped
+  SIGNALS: Hash[String, Integer]
+end

--- a/gems/minitest/5.25/minitest/skip.rbs
+++ b/gems/minitest/5.25/minitest/skip.rbs
@@ -1,0 +1,6 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Assertion raised when skipping a run.
+#
+class Minitest::Skip < ::Minitest::Assertion
+  def result_label: () -> "Skipped"
+end

--- a/gems/minitest/5.25/minitest/spec.rbs
+++ b/gems/minitest/5.25/minitest/spec.rbs
@@ -1,0 +1,11 @@
+# <!-- rdoc-file=lib/minitest/spec.rb -->
+# Minitest::Spec -- The faster, better, less-magical spec framework!
+#
+# For a list of expectations, see Minitest::Expectations.
+#
+class Minitest::Spec < ::Minitest::Test
+  def self.current: () -> untyped
+  def initialize: (untyped name) -> void
+  extend Minitest::Spec::DSL
+  include Minitest::Spec::DSL::InstanceMethods
+end

--- a/gems/minitest/5.25/minitest/spec/dsl.rbs
+++ b/gems/minitest/5.25/minitest/spec/dsl.rbs
@@ -1,0 +1,129 @@
+# <!-- rdoc-file=lib/minitest/spec.rb -->
+# Oh look! A Minitest::Spec::DSL module! Eat your heart out DHH.
+#
+module Minitest::Spec::DSL
+  @children: untyped
+
+  @specs: untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - register_spec_type(*args, &block)
+  # -->
+  # Register a new type of spec that matches the spec's description. This method
+  # can take either a Regexp and a spec class or a spec class and a block that
+  # takes the description and returns true if it matches.
+  #
+  # Eg:
+  #
+  #     register_spec_type(/Controller$/, Minitest::Spec::Rails)
+  #
+  # or:
+  #
+  #     register_spec_type(Minitest::Spec::RailsModel) do |desc|
+  #       desc.superclass == ActiveRecord::Base
+  #     end
+  #
+  def register_spec_type: (*untyped args) ?{ (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - spec_type(desc, *additional)
+  # -->
+  # Figure out the spec class to use based on a spec's description. Eg:
+  #
+  #     spec_type("BlahController") # => Minitest::Spec::Rails
+  #
+  def spec_type: (untyped desc, *untyped additional) -> untyped
+
+  def describe_stack: () -> untyped
+
+  def children: () -> untyped
+
+  def nuke_test_methods!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - before(_type = nil, &block)
+  # -->
+  # Define a 'before' action. Inherits the way normal methods should.
+  #
+  # NOTE: `type` is ignored and is only there to make porting easier.
+  #
+  # Equivalent to Minitest::Test#setup.
+  #
+  def before: (?untyped? _type) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - after(_type = nil, &block)
+  # -->
+  # Define an 'after' action. Inherits the way normal methods should.
+  #
+  # NOTE: `type` is ignored and is only there to make porting easier.
+  #
+  # Equivalent to Minitest::Test#teardown.
+  #
+  def after: (?untyped? _type) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - it(desc = "anonymous", &block)
+  # -->
+  # Define an expectation with name `desc`. Name gets morphed to a proper test
+  # method name. For some freakish reason, people who write specs don't like class
+  # inheritance, so this goes way out of its way to make sure that expectations
+  # aren't inherited.
+  #
+  # This is also aliased to #specify and doesn't require a `desc` arg.
+  #
+  # Hint: If you *do* want inheritance, use minitest/test. You can mix and match
+  # between assertions and expectations as much as you want.
+  #
+  def it: (?::String desc) ?{ (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - let(name, &block)
+  # -->
+  # Essentially, define an accessor for `name` with `block`.
+  #
+  # Why use let instead of def? I honestly don't know.
+  #
+  def let: (untyped name) { (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - subject(&block)
+  # -->
+  # Another lazy man's accessor generator. Made even more lazy by setting the name
+  # for you to `subject`.
+  #
+  def subject: () { (?) -> untyped } -> untyped
+
+  def create: (untyped name, untyped desc) -> untyped
+
+  def name: () -> untyped
+
+  def to_s: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - specify(desc = "anonymous", &block)
+  # -->
+  #
+  alias specify it
+
+  def self.extended: (untyped obj) -> untyped
+
+  attr_reader desc: untyped
+
+  # <!-- rdoc-file=lib/minitest/spec.rb -->
+  # Contains pairs of matchers and Spec classes to be used to calculate the
+  # superclass of a top-level describe. This allows for automatically customizable
+  # spec types.
+  #
+  # See: register_spec_type and spec_type
+  #
+  TYPES: Array[Array[Regexp | singleton(Minitest::BenchSpec)] | Array[Regexp | singleton(Minitest::Spec)]]
+end

--- a/gems/minitest/5.25/minitest/spec/dsl/instance_methods.rbs
+++ b/gems/minitest/5.25/minitest/spec/dsl/instance_methods.rbs
@@ -1,0 +1,48 @@
+# <!-- rdoc-file=lib/minitest/spec.rb -->
+# Rdoc... why are you so dumb?
+#
+module Minitest::Spec::DSL::InstanceMethods
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - _(value = nil, &block)
+  # -->
+  # Takes a value or a block and returns a value monad that has all of
+  # Expectations methods available to it.
+  #
+  #     _(1 + 1).must_equal 2
+  #
+  # And for blocks:
+  #
+  #     _ { 1 + "1" }.must_raise TypeError
+  #
+  # This method of expectation-based testing is preferable to straight-expectation
+  # methods (on Object) because it stores its test context, bypassing our hacky
+  # use of thread-local variables.
+  #
+  # NOTE: At some point, the methods on Object will be deprecated and then
+  # removed.
+  #
+  # It is also aliased to #value and #expect for your aesthetic pleasure:
+  #
+  #          _(1 + 1).must_equal 2
+  #      value(1 + 1).must_equal 2
+  #     expect(1 + 1).must_equal 2
+  #
+  def _: (?untyped? value) ?{ (?) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - value(value = nil, &block)
+  # -->
+  #
+  alias value _
+
+  # <!--
+  #   rdoc-file=lib/minitest/spec.rb
+  #   - expect(value = nil, &block)
+  # -->
+  #
+  alias expect _
+
+  def before_setup: () -> untyped
+end

--- a/gems/minitest/5.25/minitest/statistics_reporter.rbs
+++ b/gems/minitest/5.25/minitest/statistics_reporter.rbs
@@ -1,0 +1,81 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# A reporter that gathers statistics about a test run. Does not do any IO
+# because meant to be used as a parent class for a reporter that does.
+#
+# If you want to create an entirely different type of output (eg, CI, HTML,
+# etc), this is the place to start.
+#
+# Example:
+#
+#     class JenkinsCIReporter < StatisticsReporter
+#       def report
+#         super  # Needed to calculate some statistics
+#
+#         print "<testsuite "
+#         print "tests='#{count}' "
+#         print "failures='#{failures}' "
+#         # Remaining XML...
+#       end
+#     end
+#
+class Minitest::StatisticsReporter < ::Minitest::Reporter
+  def initialize: (?untyped io, ?::Hash[untyped, untyped] options) -> void
+  def passed?: () -> untyped
+  def start: () -> untyped
+  def record: (untyped result) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest.rb
+  #   - report()
+  # -->
+  # Report on the tracked statistics.
+  #
+  def report: () -> untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Total number of assertions.
+  #
+  attr_accessor assertions: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Total number of test cases.
+  #
+  attr_accessor count: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # An `Array` of test cases that failed or were skipped.
+  #
+  attr_accessor results: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Time the test run started. If available, the monotonic clock is used and this
+  # is a `Float`, otherwise it's an instance of `Time`.
+  #
+  attr_accessor start_time: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Test run time. If available, the monotonic clock is used and this is a
+  # `Float`, otherwise it's an instance of `Time`.
+  #
+  attr_accessor total_time: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Total number of tests that failed.
+  #
+  attr_accessor failures: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Total number of tests that erred.
+  #
+  attr_accessor errors: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Total number of tests that warned.
+  #
+  attr_accessor warnings: untyped
+
+  # <!-- rdoc-file=lib/minitest.rb -->
+  # Total number of tests that where skipped.
+  #
+  attr_accessor skips: untyped
+end

--- a/gems/minitest/5.25/minitest/summary_reporter.rbs
+++ b/gems/minitest/5.25/minitest/summary_reporter.rbs
@@ -1,0 +1,18 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# A reporter that prints the header, summary, and failure details at the end of
+# the run.
+#
+# This is added to the top-level CompositeReporter at the start of the run. If
+# you want to change the output of minitest via a plugin, pull this out of the
+# composite and replace it with your own.
+#
+class Minitest::SummaryReporter < ::Minitest::StatisticsReporter
+  def start: () -> untyped
+  def report: () -> untyped
+  def statistics: () -> untyped
+  def aggregated_results: (untyped io) -> untyped
+  def to_s: () -> untyped
+  def summary: () -> untyped
+  attr_accessor sync: untyped
+  attr_accessor old_sync: untyped
+end

--- a/gems/minitest/5.25/minitest/test.rbs
+++ b/gems/minitest/5.25/minitest/test.rbs
@@ -1,0 +1,69 @@
+# <!-- rdoc-file=lib/minitest/test.rb -->
+# Subclass Test to create your own tests. Typically you'll want a Test subclass
+# per implementation class.
+#
+# See Minitest::Assertions
+#
+class Minitest::Test < ::Minitest::Runnable
+  def class_name: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - i_suck_and_my_tests_are_order_dependent!()
+  # -->
+  # Call this at the top of your tests when you absolutely positively need to have
+  # ordered tests. In doing so, you're admitting that you suck and your tests are
+  # weak.
+  #
+  def self.i_suck_and_my_tests_are_order_dependent!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - make_my_diffs_pretty!()
+  # -->
+  # Make diffs for this Test use #pretty_inspect so that diff in assert_equal can
+  # have more details. NOTE: this is much slower than the regular inspect but much
+  # more usable for complex objects.
+  #
+  def self.make_my_diffs_pretty!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - parallelize_me!()
+  # -->
+  # Call this at the top of your tests (inside the `Minitest::Test` subclass or
+  # `describe` block) when you want to run your tests in parallel. In doing so,
+  # you're admitting that you rule and your tests are awesome.
+  #
+  def self.parallelize_me!: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - runnable_methods()
+  # -->
+  # Returns all instance methods starting with "test_". Based on #test_order, the
+  # methods are either sorted, randomized (default), or run in parallel.
+  #
+  def self.runnable_methods: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - run()
+  # -->
+  # Runs a single test with setup/teardown hooks.
+  #
+  def run: () -> untyped
+  def capture_exceptions: () { () -> untyped } -> untyped
+  def sanitize_exception: (untyped e) -> untyped
+  def neuter_exception: (untyped e) -> untyped
+  def new_exception: (untyped klass, untyped msg, untyped bt, ?bool kill) -> untyped
+  attr_accessor self.io_lock: untyped
+  include Minitest::Assertions
+  include Minitest::Reportable
+  include Minitest::Test::LifecycleHooks
+  include Minitest::Guard
+  extend Minitest::Guard
+  PASSTHROUGH_EXCEPTIONS: Array[singleton(NoMemoryError) | singleton(SignalException) | singleton(SystemExit)]
+  SETUP_METHODS: Array[String]
+  TEARDOWN_METHODS: Array[String]
+end

--- a/gems/minitest/5.25/minitest/test/lifecycle_hooks.rbs
+++ b/gems/minitest/5.25/minitest/test/lifecycle_hooks.rbs
@@ -1,0 +1,92 @@
+# <!-- rdoc-file=lib/minitest/test.rb -->
+# Provides before/after hooks for setup and teardown. These are meant for
+# library writers, NOT for regular test authors. See #before_setup for an
+# example.
+#
+module Minitest::Test::LifecycleHooks
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - before_setup()
+  # -->
+  # Runs before every test, before setup. This hook is meant for libraries to
+  # extend minitest. It is not meant to be used by test developers.
+  #
+  # As a simplistic example:
+  #
+  #     module MyMinitestPlugin
+  #       def before_setup
+  #         super
+  #         # ... stuff to do before setup is run
+  #       end
+  #
+  #       def after_setup
+  #         # ... stuff to do after setup is run
+  #         super
+  #       end
+  #
+  #       def before_teardown
+  #         super
+  #         # ... stuff to do before teardown is run
+  #       end
+  #
+  #       def after_teardown
+  #         # ... stuff to do after teardown is run
+  #         super
+  #       end
+  #     end
+  #
+  #     class Minitest::Test
+  #       include MyMinitestPlugin
+  #     end
+  #
+  def before_setup: () -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - setup()
+  # -->
+  # Runs before every test. Use this to set up before each test run.
+  #
+  def setup: () -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - after_setup()
+  # -->
+  # Runs before every test, after setup. This hook is meant for libraries to
+  # extend minitest. It is not meant to be used by test developers.
+  #
+  # See #before_setup for an example.
+  #
+  def after_setup: () -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - before_teardown()
+  # -->
+  # Runs after every test, before teardown. This hook is meant for libraries to
+  # extend minitest. It is not meant to be used by test developers.
+  #
+  # See #before_setup for an example.
+  #
+  def before_teardown: () -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - teardown()
+  # -->
+  # Runs after every test. Use this to clean up after each test run.
+  #
+  def teardown: () -> void
+
+  # <!--
+  #   rdoc-file=lib/minitest/test.rb
+  #   - after_teardown()
+  # -->
+  # Runs after every test, after teardown. This hook is meant for libraries to
+  # extend minitest. It is not meant to be used by test developers.
+  #
+  # See #before_setup for an example.
+  #
+  def after_teardown: () -> void
+end

--- a/gems/minitest/5.25/minitest/unexpected_error.rbs
+++ b/gems/minitest/5.25/minitest/unexpected_error.rbs
@@ -1,0 +1,12 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Assertion wrapping an unexpected error that was raised during a run.
+#
+class Minitest::UnexpectedError < ::Minitest::Assertion
+  def initialize: (untyped error) -> void
+  def backtrace: () -> untyped
+  def message: () -> ::String
+  def result_label: () -> "Error"
+  attr_accessor error: untyped
+  include Minitest::Compress
+  BASE_RE: Regexp
+end

--- a/gems/minitest/5.25/minitest/unexpected_warning.rbs
+++ b/gems/minitest/5.25/minitest/unexpected_warning.rbs
@@ -1,0 +1,6 @@
+# <!-- rdoc-file=lib/minitest.rb -->
+# Assertion raised on warning when running in -Werror mode.
+#
+class Minitest::UnexpectedWarning < ::Minitest::Assertion
+  def result_label: () -> "Warning"
+end

--- a/gems/minitest/5.25/minitest/unit.rbs
+++ b/gems/minitest/5.25/minitest/unit.rbs
@@ -1,0 +1,4 @@
+class Minitest::Unit
+  def self.autorun: () -> untyped
+  def self.after_tests: () { (?) -> untyped } -> untyped
+end

--- a/gems/minitest/5.25/minitest/unit/test_case.rbs
+++ b/gems/minitest/5.25/minitest/unit/test_case.rbs
@@ -1,0 +1,3 @@
+class Minitest::Unit::TestCase < ::Minitest::Test
+  def self.inherited: (untyped klass) -> untyped
+end

--- a/gems/minitest/_reviewers.yaml
+++ b/gems/minitest/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/net-smtp/.rubocop.yml
+++ b/gems/net-smtp/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/net-smtp/0.5/manifest.yaml
+++ b/gems/net-smtp/0.5/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: net-protocol

--- a/gems/net-smtp/0.5/net-smtp.rbs
+++ b/gems/net-smtp/0.5/net-smtp.rbs
@@ -1,0 +1,55 @@
+module Net
+  # Module mixed in to all SMTP error classes
+  module SMTPError
+    attr_reader response: Response
+
+    def initialize: (Response response, ?message: String) -> void
+
+    def message: () -> String?
+  end
+
+  # Represents an SMTP authentication error.
+  class SMTPAuthenticationError < ProtoAuthError
+    include SMTPError
+  end
+
+  # Represents SMTP error code 4xx, a temporary error.
+  class SMTPServerBusy < ProtoServerError
+    include SMTPError
+  end
+
+  # Represents an SMTP command syntax error (error code 500)
+  class SMTPSyntaxError < ProtoSyntaxError
+    include SMTPError
+  end
+
+  # Represents a fatal SMTP error (error code 5xx, except for 500)
+  class SMTPFatalError < ProtoFatalError
+    include SMTPError
+  end
+
+  # Unexpected reply code returned from server.
+  class SMTPUnknownError < ProtoUnknownError
+    include SMTPError
+  end
+
+  # Command is not supported on server.
+  class SMTPUnsupportedCommand < ProtocolError
+    include SMTPError
+  end
+
+  class SMTP < Protocol
+    def self.start: (String address, ?Integer port, ?tls_verify: bool, ?tls_hostname: String?, ?helo: String, ?user: String?, ?password: String?, ?auth_type: Symbol) -> instance
+                  | [T] (String address, ?Integer port, ?tls_verify: bool, ?tls_hostname: String?, ?helo: String, ?user: String?, ?password: String?, ?auth_type: Symbol) { (instance) -> T } -> T
+                  | (String address, ?Integer port, ?String helo, ?String? user, ?String? password, ?Symbol auth_type) -> instance
+                  | [T] (String address, ?Integer port, ?String helo, ?String? user, ?String? password, ?Symbol auth_type) { (instance) -> T } -> T
+
+    def initialize: (String address, ?Integer port) -> void
+    def send_message: (_Each[String] mail_src, String from_addr, *String to_addrs) -> void
+  end
+
+  class Response
+  end
+
+  class SMTPSession = SMTP
+end

--- a/gems/net-smtp/_reviewers.yaml
+++ b/gems/net-smtp/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/nkf/.rubocop.yml
+++ b/gems/nkf/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/nkf/0.2/_test/test.rb
+++ b/gems/nkf/0.2/_test/test.rb
@@ -1,0 +1,7 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "nkf"
+
+NKF.guess("str")
+NKF.nkf("-w", "str")

--- a/gems/nkf/0.2/nkf.rbs
+++ b/gems/nkf/0.2/nkf.rbs
@@ -1,0 +1,402 @@
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# NKF - Ruby extension for Network Kanji Filter
+#
+# ## Description
+#
+# This is a Ruby Extension version of nkf (Network Kanji Filter). It converts
+# the first argument and returns converted result. Conversion details are
+# specified by flags as the first argument.
+#
+# **Nkf** is a yet another kanji code converter among networks, hosts and
+# terminals. It converts input kanji code to designated kanji code such as
+# ISO-2022-JP, Shift_JIS, EUC-JP, UTF-8 or UTF-16.
+#
+# One of the most unique faculty of **nkf** is the guess of the input kanji
+# encodings. It currently recognizes ISO-2022-JP, Shift_JIS, EUC-JP, UTF-8 and
+# UTF-16. So users needn't set the input kanji code explicitly.
+#
+# By default, X0201 kana is converted into X0208 kana. For X0201 kana, SO/SI,
+# SSO and ESC-(-I methods are supported. For automatic code detection, nkf
+# assumes no X0201 kana in Shift_JIS. To accept X0201 in Shift_JIS, use **-X**,
+# **-x** or **-S**.
+#
+# ## Flags
+#
+# ### -b -u
+#
+# Output is buffered (DEFAULT), Output is unbuffered.
+#
+# ### -j -s -e -w -w16 -w32
+#
+# Output code is ISO-2022-JP (7bit JIS), Shift_JIS, EUC-JP, UTF-8N, UTF-16BE,
+# UTF-32BE. Without this option and compile option, ISO-2022-JP is assumed.
+#
+# ### -J -S -E -W -W16 -W32
+#
+# Input assumption is JIS 7 bit, Shift_JIS, EUC-JP, UTF-8, UTF-16, UTF-32.
+#
+# #### -J
+#
+# Assume  JIS input. It also accepts EUC-JP. This is the default. This flag does
+# not exclude Shift_JIS.
+#
+# #### -S
+#
+# Assume Shift_JIS and X0201 kana input. It also accepts JIS. EUC-JP is
+# recognized as X0201 kana. Without **-x** flag, X0201 kana (halfwidth kana) is
+# converted into X0208.
+#
+# #### -E
+#
+# Assume EUC-JP input. It also accepts JIS. Same as -J.
+#
+# ### -t
+#
+# No conversion.
+#
+# ### -i_
+#
+# Output sequence to designate JIS-kanji. (DEFAULT B)
+#
+# ### -o_
+#
+# Output sequence to designate ASCII. (DEFAULT B)
+#
+# ### -r
+#
+# {de/en}crypt ROT13/47
+#
+# ### -h[123] --hiragana --katakana --katakana-hiragana
+#
+# -h1 --hiragana
+# :   Katakana to Hiragana conversion.
+#
+#
+# -h2 --katakana
+# :   Hiragana to Katakana conversion.
+#
+#
+# -h3 --katakana-hiragana
+# :   Katakana to Hiragana and Hiragana to Katakana conversion.
+#
+#
+# ### -T
+#
+# Text mode output (MS-DOS)
+#
+# ### -l
+#
+# ISO8859-1 (Latin-1) support
+#
+# ### -f[`m` [- `n`]]
+#
+# Folding on `m` length with `n` margin in a line. Without this option, fold
+# length is 60 and fold margin is 10.
+#
+# ### -F
+#
+# New line preserving line folding.
+#
+# ### -Z[0-3]
+#
+# Convert X0208 alphabet (Fullwidth Alphabets) to ASCII.
+#
+# -Z -Z0
+# :   Convert X0208 alphabet to ASCII.
+#
+#
+# -Z1
+# :   Converts X0208 kankaku to single ASCII space.
+#
+#
+# -Z2
+# :   Converts X0208 kankaku to double ASCII spaces.
+#
+#
+# -Z3
+# :   Replacing Fullwidth >, <, ", & into '&gt;', '&lt;', '&quot;', '&amp;' as
+#     in HTML.
+#
+#
+# ### -X -x
+#
+# Assume X0201 kana in MS-Kanji. With **-X** or without this option, X0201 is
+# converted into X0208 Kana. With **-x**, try to preserve X0208 kana and do not
+# convert X0201 kana to X0208. In JIS output, ESC-(-I is used. In EUC output,
+# SSO is used.
+#
+# ### -B[0-2]
+#
+# Assume broken JIS-Kanji input, which lost ESC. Useful when your site is using
+# old B-News Nihongo patch.
+#
+# -B1
+# :   allows any char after ESC-( or ESC-$.
+#
+#
+# -B2
+# :   forces ASCII after NL.
+#
+#
+# ### -I
+#
+# Replacing non iso-2022-jp char into a geta character (substitute character in
+# Japanese).
+#
+# ### -d -c
+#
+# Delete r in line feed, Add r in line feed.
+#
+# ### -m[BQN0]
+#
+# MIME ISO-2022-JP/ISO8859-1 decode. (DEFAULT) To see ISO8859-1 (Latin-1) -l is
+# necessary.
+#
+# -mB
+# :   Decode MIME base64 encoded stream. Remove header or other part before
+#
+# conversion.
+#
+# -mQ
+# :   Decode MIME quoted stream. '_' in quoted stream is converted to space.
+#
+#
+# -mN
+# :   Non-strict decoding.
+#
+# It allows line break in the middle of the base64 encoding.
+#
+# -m0
+# :   No MIME decode.
+#
+#
+# ### -M
+#
+# MIME encode. Header style. All ASCII code and control characters are intact.
+# Kanji conversion is performed before encoding, so this cannot be used as a
+# picture encoder.
+#
+# -MB
+# :   MIME encode Base64 stream.
+#
+#
+# -MQ
+# :   Perform quoted encoding.
+#
+#
+# ### -l
+#
+# Input and output code is ISO8859-1 (Latin-1) and ISO-2022-JP. **-s**, **-e**
+# and **-x** are not compatible with this option.
+#
+# ### -L[uwm]
+#
+# new line mode Without this option, nkf doesn't convert line breaks.
+#
+# -Lu
+# :   unix (LF)
+#
+#
+# -Lw
+# :   windows (CRLF)
+#
+#
+# -Lm
+# :   mac (CR)
+#
+#
+# ### --fj --unix --mac --msdos --windows
+#
+# convert for these system
+#
+# ### --jis --euc --sjis --mime --base64
+#
+# convert for named code
+#
+# ### --jis-input --euc-input --sjis-input --mime-input --base64-input
+#
+# assume input system
+#
+# ### --ic=`input codeset` --oc=`output codeset`
+#
+# Set the input or output codeset. NKF supports following codesets and those
+# codeset name are case insensitive.
+#
+# ISO-2022-JP
+# :   a.k.a. RFC1468, 7bit JIS, JUNET
+#
+#
+# EUC-JP (eucJP-nkf)
+# :   a.k.a. AT&T JIS, Japanese EUC, UJIS
+#
+#
+# eucJP-ascii
+# :   a.k.a. x-eucjp-open-19970715-ascii
+#
+#
+# eucJP-ms
+# :   a.k.a. x-eucjp-open-19970715-ms
+#
+#
+# CP51932
+# :   Microsoft Version of EUC-JP.
+#
+#
+# Shift_JIS
+# :   SJIS, MS-Kanji
+#
+#
+# Windows-31J
+# :   a.k.a. CP932
+#
+#
+# UTF-8
+# :   same as UTF-8N
+#
+#
+# UTF-8N
+# :   UTF-8 without BOM
+#
+#
+# UTF-8-BOM
+# :   UTF-8 with BOM
+#
+#
+# UTF-16
+# :   same as UTF-16BE
+#
+#
+# UTF-16BE
+# :   UTF-16 Big Endian without BOM
+#
+#
+# UTF-16BE-BOM
+# :   UTF-16 Big Endian with BOM
+#
+#
+# UTF-16LE
+# :   UTF-16 Little Endian without BOM
+#
+#
+# UTF-16LE-BOM
+# :   UTF-16 Little Endian with BOM
+#
+#
+# UTF-32
+# :   same as UTF-32BE
+#
+#
+# UTF-32BE
+# :   UTF-32 Big Endian without BOM
+#
+#
+# UTF-32BE-BOM
+# :   UTF-32 Big Endian with BOM
+#
+#
+# UTF-32LE
+# :   UTF-32 Little Endian without BOM
+#
+#
+# UTF-32LE-BOM
+# :   UTF-32 Little Endian with BOM
+#
+#
+# UTF8-MAC
+# :   NKDed UTF-8, a.k.a. UTF8-NFD (input only)
+#
+#
+# ### --fb-{skip, html, xml, perl, java, subchar}
+#
+# Specify the way that nkf handles unassigned characters. Without this option,
+# --fb-skip is assumed.
+#
+# ### --prefix= `escape character` `target character` ..
+#
+# When nkf converts to Shift_JIS, nkf adds a specified escape character to
+# specified 2nd byte of Shift_JIS characters. 1st byte of argument is the escape
+# character and following bytes are target characters.
+#
+# ### --no-cp932ext
+#
+# Handle the characters extended in CP932 as unassigned characters.
+#
+# ## --no-best-fit-chars
+#
+# When Unicode to Encoded byte conversion, don't convert characters which is not
+# round trip safe. When Unicode to Unicode conversion, with this and -x option,
+# nkf can be used as UTF converter. (In other words, without this and -x option,
+# nkf doesn't save some characters)
+#
+# When nkf convert string which related to path, you should use this option.
+#
+# ### --cap-input
+#
+# Decode hex encoded characters.
+#
+# ### --url-input
+#
+# Unescape percent escaped characters.
+#
+# ### --
+#
+# Ignore rest of -option.
+#
+module NKF
+  # <!--
+  #   rdoc-file=ext/nkf/nkf.c
+  #   - NKF.guess(str)  => encoding
+  # -->
+  # Returns guessed encoding of *str* by nkf routine.
+  #
+  def self.guess: (String str) -> Encoding
+
+  # <!--
+  #   rdoc-file=ext/nkf/nkf.c
+  #   - NKF.nkf(opt, str)   => string
+  # -->
+  # Convert *str* and return converted result. Conversion details are specified by
+  # *opt* as String.
+  #
+  #     require 'nkf'
+  #     output = NKF.nkf("-s", input)
+  #
+  def self.nkf: (String opt, String str) -> String
+end
+
+NKF::ASCII: Encoding
+
+NKF::AUTO: nil
+
+NKF::BINARY: Encoding
+
+NKF::EUC: Encoding
+
+NKF::JIS: Encoding
+
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# Release date of nkf
+#
+NKF::NKF_RELEASE_DATE: String
+
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# Version of nkf
+#
+NKF::NKF_VERSION: String
+
+NKF::NOCONV: nil
+
+NKF::SJIS: Encoding
+
+NKF::UNKNOWN: nil
+
+NKF::UTF16: Encoding
+
+NKF::UTF32: Encoding
+
+NKF::UTF8: Encoding
+
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# Full version string of nkf
+#
+NKF::VERSION: String

--- a/gems/nkf/_reviewers.yaml
+++ b/gems/nkf/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss

--- a/gems/observer/.rubocop.yml
+++ b/gems/observer/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/observer/0.1/_test/test.rb
+++ b/gems/observer/0.1/_test/test.rb
@@ -1,0 +1,4 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "observer"

--- a/gems/observer/0.1/observable.rbs
+++ b/gems/observer/0.1/observable.rbs
@@ -1,0 +1,217 @@
+# <!-- rdoc-file=lib/observer.rb -->
+# The Observer pattern (also known as publish/subscribe) provides a simple
+# mechanism for one object to inform a set of interested third-party objects
+# when its state changes.
+#
+# ## Mechanism
+#
+# The notifying class mixes in the `Observable` module, which provides the
+# methods for managing the associated observer objects.
+#
+# The observable object must:
+# *   assert that it has `#changed`
+# *   call `#notify_observers`
+#
+# An observer subscribes to updates using Observable#add_observer, which also
+# specifies the method called via #notify_observers. The default method for
+# #notify_observers is #update.
+#
+# ### Example
+#
+# The following example demonstrates this nicely.  A `Ticker`, when run,
+# continually receives the stock `Price` for its `@symbol`.  A `Warner` is a
+# general observer of the price, and two warners are demonstrated, a `WarnLow`
+# and a `WarnHigh`, which print a warning if the price is below or above their
+# set limits, respectively.
+#
+# The `update` callback allows the warners to run without being explicitly
+# called.  The system is set up with the `Ticker` and several observers, and the
+# observers do their duty without the top-level code having to interfere.
+#
+# Note that the contract between publisher and subscriber (observable and
+# observer) is not declared or enforced.  The `Ticker` publishes a time and a
+# price, and the warners receive that.  But if you don't ensure that your
+# contracts are correct, nothing else can warn you.
+#
+#     require "observer"
+#
+#     class Ticker          ### Periodically fetch a stock price.
+#       include Observable
+#
+#       def initialize(symbol)
+#         @symbol = symbol
+#       end
+#
+#       def run
+#         last_price = nil
+#         loop do
+#           price = Price.fetch(@symbol)
+#           print "Current price: #{price}\n"
+#           if price != last_price
+#             changed                 # notify observers
+#             last_price = price
+#             notify_observers(Time.now, price)
+#           end
+#           sleep 1
+#         end
+#       end
+#     end
+#
+#     class Price           ### A mock class to fetch a stock price (60 - 140).
+#       def self.fetch(symbol)
+#         60 + rand(80)
+#       end
+#     end
+#
+#     class Warner          ### An abstract observer of Ticker objects.
+#       def initialize(ticker, limit)
+#         @limit = limit
+#         ticker.add_observer(self)
+#       end
+#     end
+#
+#     class WarnLow < Warner
+#       def update(time, price)       # callback for observer
+#         if price < @limit
+#           print "--- #{time.to_s}: Price below #@limit: #{price}\n"
+#         end
+#       end
+#     end
+#
+#     class WarnHigh < Warner
+#       def update(time, price)       # callback for observer
+#         if price > @limit
+#           print "+++ #{time.to_s}: Price above #@limit: #{price}\n"
+#         end
+#       end
+#     end
+#
+#     ticker = Ticker.new("MSFT")
+#     WarnLow.new(ticker, 80)
+#     WarnHigh.new(ticker, 120)
+#     ticker.run
+#
+# Produces:
+#
+#     Current price: 83
+#     Current price: 75
+#     --- Sun Jun 09 00:10:25 CDT 2002: Price below 80: 75
+#     Current price: 90
+#     Current price: 134
+#     +++ Sun Jun 09 00:10:25 CDT 2002: Price above 120: 134
+#     Current price: 134
+#     Current price: 112
+#     Current price: 79
+#     --- Sun Jun 09 00:10:25 CDT 2002: Price below 80: 79
+#
+# ### Usage with procs
+#
+# The `#notify_observers` method can also be used with +proc+s by using the
+# `:call` as `func` parameter.
+#
+# The following example illustrates the use of a lambda:
+#
+#     require 'observer'
+#
+#     class Ticker
+#       include Observable
+#
+#       def run
+#         # logic to retrieve the price (here 77.0)
+#         changed
+#         notify_observers(77.0)
+#       end
+#     end
+#
+#     ticker = Ticker.new
+#     warner = ->(price) { puts "New price received: #{price}" }
+#     ticker.add_observer(warner, :call)
+#     ticker.run
+#
+module Observable
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - add_observer(observer, func=:update)
+  # -->
+  # Add `observer` as an observer on this object. So that it will receive
+  # notifications.
+  #
+  # `observer`
+  # :   the object that will be notified of changes.
+  #
+  # `func`
+  # :   Symbol naming the method that will be called when this Observable has
+  #     changes.
+  #
+  #     This method must return true for `observer.respond_to?` and will receive
+  #     `*arg` when #notify_observers is called, where `*arg` is the value passed
+  #     to #notify_observers by this Observable
+  #
+  def add_observer: (untyped observer, ?Symbol func) -> void
+
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - changed(state=true)
+  # -->
+  # Set the changed state of this object.  Notifications will be sent only if the
+  # changed `state` is `true`.
+  #
+  # `state`
+  # :   Boolean indicating the changed state of this Observable.
+  #
+  def changed: (?bool state) -> void
+
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - changed?()
+  # -->
+  # Returns true if this object's state has been changed since the last
+  # #notify_observers call.
+  #
+  def changed?: () -> bool
+
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - count_observers()
+  # -->
+  # Return the number of observers associated with this object.
+  #
+  def count_observers: () -> Integer
+
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - delete_observer(observer)
+  # -->
+  # Remove `observer` as an observer on this object so that it will no longer
+  # receive notifications.
+  #
+  # `observer`
+  # :   An observer of this Observable
+  #
+  def delete_observer: (untyped observer) -> void
+
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - delete_observers()
+  # -->
+  # Remove all observers associated with this object.
+  #
+  def delete_observers: () -> void
+
+  # <!--
+  #   rdoc-file=lib/observer.rb
+  #   - notify_observers(*arg)
+  # -->
+  # Notify observers of a change in state **if** this object's changed state is
+  # `true`.
+  #
+  # This will invoke the method named in #add_observer, passing `*arg`. The
+  # changed state is then set to `false`.
+  #
+  # `*arg`
+  # :   Any arguments to pass to the observers.
+  #
+  def notify_observers: (*untyped arg) -> void
+
+  VERSION: String
+end

--- a/gems/observer/_reviewers.yaml
+++ b/gems/observer/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss


### PR DESCRIPTION
From https://github.com/ruby/rbs/issues/2258

## Naming

`bigdecimal` and `bigdecimal-math` were merged due to name restrictions.

## Commit log

I wanted to fully copy the commit log, but it was difficult, so I opted to leave only a simple credit instead.  

## Testing

As for the tests, their format was different, and rewriting all of them would have been too much work, so I decided to abandon that approach.

## Behavior after merge

- Before adding to ALUMNI_STDLIBS in rbs
    - stdlib's will be used.
- After adding to ALUMNI_STDLIBS in rbs
    - stdlib's will be used. And a warning log will be output.
- After removing from the rbs repository
    - If listed in rbs_collection.yaml
        - If listed in manifest.yaml
            - If listed in ALUMNI_STDLIBS
                - Nothing is logged and gem_rbs_collection's will be used.
            - If not listed in ALUMNI_STDLIBS
                - Nothing is logged and gem_rbs_collection's will be used.
        - If not listed in manifest.yaml
            - If listed in ALUMNI_STDLIBS
                - Nothing is logged and gem_rbs_collection's will be used.
            - If not listed in ALUMNI_STDLIBS
                - Nothing is logged and gem_rbs_collection's will be used.
    - If not listed in rbs_collection.yaml
        - If listed in manifest.yaml
            - If listed in ALUMNI_STDLIBS
                - A deprecated log will be output and gem_rbs_collection's will be used.
            - If not listed in ALUMNI_STDLIBS
                - Nothing is logged and nothing is used. 🤔 
        - If not listed in manifest.yaml
            - If listed in ALUMNI_STDLIBS
                - Nothing is logged and nothing is used.
            - If not listed in ALUMNI_STDLIBS
                - Nothing is logged and nothing is used.