### PR TITLE
mysql2: Add types for mysql2::statement

### DIFF
--- a/gems/mysql2/0.5/_test/statement.rb
+++ b/gems/mysql2/0.5/_test/statement.rb
@@ -1,0 +1,3 @@
+client = Mysql2::Client.new
+
+statement = client.prepare("INSERT INTO users (name) VALUES (?)")

--- a/gems/mysql2/0.5/_test/statement.rb
+++ b/gems/mysql2/0.5/_test/statement.rb
@@ -1,3 +1,4 @@
 client = Mysql2::Client.new
 
 statement = client.prepare("INSERT INTO users (name) VALUES (?)")
+statement.execute('John')

--- a/gems/mysql2/0.5/client.rbs
+++ b/gems/mysql2/0.5/client.rbs
@@ -46,6 +46,8 @@ module Mysql2
 
     def affected_rows: () -> Integer
 
+    def prepare: (String sql) -> Mysql2::Statement
+
     private
 
     def self.local_offset: () -> untyped

--- a/gems/mysql2/0.5/statement.rbs
+++ b/gems/mysql2/0.5/statement.rbs
@@ -1,0 +1,5 @@
+module Mysql2
+  class Statement
+    def execute: (*untyped, **untyped) -> void
+  end
+end


### PR DESCRIPTION
- Currently, this gem does not have type definitions for mysql2 statements.
  - However, this class is something I want to use in my project, and I need type definitions for it.
  - Therefore, in this PR, I am adding the necessary type definitions.

reference: method definition with added types
- [mysql2::statement](https://github.com/brianmario/mysql2/blob/57b8df188c963ae0e4d4e1123d3e9de2bbcab637/lib/mysql2/statement.rb#L4)
- [mysql2::client.prepare](https://github.com/brianmario/mysql2/blob/57b8df188c963ae0e4d4e1123d3e9de2bbcab637/ext/mysql2/client.c#L1537)