### PR TITLE
Add Concurrent::Map#compute* methods

### DIFF
--- a/gems/concurrent-ruby/1.1/_test/map.rb
+++ b/gems/concurrent-ruby/1.1/_test/map.rb
@@ -1,0 +1,17 @@
+require 'concurrent-ruby'
+
+map = Concurrent::Map.new #: Concurrent::Map[Symbol, Integer]
+
+map[:a] = 1
+map.fetch(:b) { 2 }
+map.fetch(:c, 3)
+
+new_value = map.compute(:a) { |old_value| (old_value || 0) + 1 }
+new_value + 2
+map.compute(:a) { |_old_value| nil }
+
+new_value = map.compute_if_absent(:absent) { 3 }
+new_value + 2
+
+map.compute_if_present(:maybe_present) { |old_value| old_value + 1 }
+map.compute_if_present(:a) { |_old_value| nil }

--- a/gems/concurrent-ruby/1.1/map.rbs
+++ b/gems/concurrent-ruby/1.1/map.rbs
@@ -8,6 +8,13 @@ module Concurrent
     alias get []
     alias put []=
 
+    def compute: (K key) { (V? old_value) -> V } -> V
+               | (K key) { (V? old_value) -> nil } -> nil
+
+    def compute_if_absent: (K key) { () -> V } -> V
+
+    def compute_if_present: (K key) { (V old_value) -> V? } -> V?
+
     def fetch: (untyped key) -> V
              | [D] (untyped key, D default_value) -> (V | D)
              | [T, D] (T key) { (T key) -> D } -> (V | D)
@@ -15,7 +22,7 @@ module Concurrent
     def fetch_or_store: (untyped key) -> V
                       | (K key, V default_value) -> V
                       | (K key) { (K key) -> V } -> V
-    
+
     def put_if_absent: (K key, V value) -> V?
 
     def value?: (untyped value) -> bool


### PR DESCRIPTION
Added RBS support for the following methods...

- `Concurrent::Map#compute`
- `Concurrent::Map#compute_if_absent`
- `Concurrent::Map#compute_if_present`

I attempted to match what [the documentation](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Map.html) has as well as reviewing the underlying code.