### PR TITLE
activesupport: Add types to AS::RangeWithFormat#to_s and AS::NumericWithFormat#to_s

### DIFF
--- a/gems/activesupport/6.0/activesupport-6.0.rbs
+++ b/gems/activesupport/6.0/activesupport-6.0.rbs
@@ -24,6 +24,131 @@ module ActiveSupport
   end
 end
 
+module ActiveSupport
+  module RangeWithFormat
+    # Convert range to a formatted string. See RANGE_FORMATS for predefined formats.
+    #
+    #   range = (1..100)           # => 1..100
+    #
+    #   range.to_s                 # => "1..100"
+    #   range.to_s(:db)            # => "BETWEEN '1' AND '100'"
+    #
+    # == Adding your own range formats to to_s
+    # You can add your own formats to the Range::RANGE_FORMATS hash.
+    # Use the format name as the hash key and a Proc instance.
+    #
+    #   # config/initializers/range_formats.rb
+    #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_s(:db)} and #{stop.to_s(:db)}" }
+    def to_s: (?::Symbol format) -> String
+
+    alias to_default_s to_s
+
+    alias to_formatted_s to_s
+  end
+end
+
+module ActiveSupport
+  module NumericWithFormat
+    # Provides options for converting numbers into formatted strings.
+    # Options are provided for phone numbers, currency, percentage,
+    # precision, positional notation, file size and pretty printing.
+    #
+    # ==== Options
+    #
+    # For details on which formats use which options, see ActiveSupport::NumberHelper
+    #
+    # ==== Examples
+    #
+    #  Phone Numbers:
+    #  5551234.to_s(:phone)                                     # => "555-1234"
+    #  1235551234.to_s(:phone)                                  # => "123-555-1234"
+    #  1235551234.to_s(:phone, area_code: true)                 # => "(123) 555-1234"
+    #  1235551234.to_s(:phone, delimiter: ' ')                  # => "123 555 1234"
+    #  1235551234.to_s(:phone, area_code: true, extension: 555) # => "(123) 555-1234 x 555"
+    #  1235551234.to_s(:phone, country_code: 1)                 # => "+1-123-555-1234"
+    #  1235551234.to_s(:phone, country_code: 1, extension: 1343, delimiter: '.')
+    #  # => "+1.123.555.1234 x 1343"
+    #
+    #  Currency:
+    #  1234567890.50.to_s(:currency)                 # => "$1,234,567,890.50"
+    #  1234567890.506.to_s(:currency)                # => "$1,234,567,890.51"
+    #  1234567890.506.to_s(:currency, precision: 3)  # => "$1,234,567,890.506"
+    #  1234567890.506.to_s(:currency, locale: :fr)   # => "1 234 567 890,51 (trim non-ascii characters)"
+    #  -1234567890.50.to_s(:currency, negative_format: '(%u%n)')
+    #  # => "($1,234,567,890.50)"
+    #  1234567890.50.to_s(:currency, unit: '&pound;', separator: ',', delimiter: '')
+    #  # => "&pound;1234567890,50"
+    #  1234567890.50.to_s(:currency, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
+    #  # => "1234567890,50 &pound;"
+    #
+    #  Percentage:
+    #  100.to_s(:percentage)                                  # => "100.000%"
+    #  100.to_s(:percentage, precision: 0)                    # => "100%"
+    #  1000.to_s(:percentage, delimiter: '.', separator: ',') # => "1.000,000%"
+    #  302.24398923423.to_s(:percentage, precision: 5)        # => "302.24399%"
+    #  1000.to_s(:percentage, locale: :fr)                    # => "1 000,000%"
+    #  100.to_s(:percentage, format: '%n  %')                 # => "100.000  %"
+    #
+    #  Delimited:
+    #  12345678.to_s(:delimited)                     # => "12,345,678"
+    #  12345678.05.to_s(:delimited)                  # => "12,345,678.05"
+    #  12345678.to_s(:delimited, delimiter: '.')     # => "12.345.678"
+    #  12345678.to_s(:delimited, delimiter: ',')     # => "12,345,678"
+    #  12345678.05.to_s(:delimited, separator: ' ')  # => "12,345,678 05"
+    #  12345678.05.to_s(:delimited, locale: :fr)     # => "12 345 678,05"
+    #  98765432.98.to_s(:delimited, delimiter: ' ', separator: ',')
+    #  # => "98 765 432,98"
+    #
+    #  Rounded:
+    #  111.2345.to_s(:rounded)                                      # => "111.235"
+    #  111.2345.to_s(:rounded, precision: 2)                        # => "111.23"
+    #  13.to_s(:rounded, precision: 5)                              # => "13.00000"
+    #  389.32314.to_s(:rounded, precision: 0)                       # => "389"
+    #  111.2345.to_s(:rounded, significant: true)                   # => "111"
+    #  111.2345.to_s(:rounded, precision: 1, significant: true)     # => "100"
+    #  13.to_s(:rounded, precision: 5, significant: true)           # => "13.000"
+    #  111.234.to_s(:rounded, locale: :fr)                          # => "111,234"
+    #  13.to_s(:rounded, precision: 5, significant: true, strip_insignificant_zeros: true)
+    #  # => "13"
+    #  389.32314.to_s(:rounded, precision: 4, significant: true)    # => "389.3"
+    #  1111.2345.to_s(:rounded, precision: 2, separator: ',', delimiter: '.')
+    #  # => "1.111,23"
+    #
+    #  Human-friendly size in Bytes:
+    #  123.to_s(:human_size)                                   # => "123 Bytes"
+    #  1234.to_s(:human_size)                                  # => "1.21 KB"
+    #  12345.to_s(:human_size)                                 # => "12.1 KB"
+    #  1234567.to_s(:human_size)                               # => "1.18 MB"
+    #  1234567890.to_s(:human_size)                            # => "1.15 GB"
+    #  1234567890123.to_s(:human_size)                         # => "1.12 TB"
+    #  1234567890123456.to_s(:human_size)                      # => "1.1 PB"
+    #  1234567890123456789.to_s(:human_size)                   # => "1.07 EB"
+    #  1234567.to_s(:human_size, precision: 2)                 # => "1.2 MB"
+    #  483989.to_s(:human_size, precision: 2)                  # => "470 KB"
+    #  1234567.to_s(:human_size, precision: 2, separator: ',') # => "1,2 MB"
+    #  1234567890123.to_s(:human_size, precision: 5)           # => "1.1228 TB"
+    #  524288000.to_s(:human_size, precision: 5)               # => "500 MB"
+    #
+    #  Human-friendly format:
+    #  123.to_s(:human)                                       # => "123"
+    #  1234.to_s(:human)                                      # => "1.23 Thousand"
+    #  12345.to_s(:human)                                     # => "12.3 Thousand"
+    #  1234567.to_s(:human)                                   # => "1.23 Million"
+    #  1234567890.to_s(:human)                                # => "1.23 Billion"
+    #  1234567890123.to_s(:human)                             # => "1.23 Trillion"
+    #  1234567890123456.to_s(:human)                          # => "1.23 Quadrillion"
+    #  1234567890123456789.to_s(:human)                       # => "1230 Quadrillion"
+    #  489939.to_s(:human, precision: 2)                      # => "490 Thousand"
+    #  489939.to_s(:human, precision: 4)                      # => "489.9 Thousand"
+    #  1234567.to_s(:human, precision: 4,
+    #                   significant: false)                   # => "1.2346 Million"
+    #  1234567.to_s(:human, precision: 1,
+    #                   separator: ',',
+    #                   significant: false)                   # => "1,2 Million"
+    def to_s: (?untyped? format, ?untyped? options) -> String
+  end
+end
+
 # activesupport/lib/active_support/core_ext/time/zones.rb
 class Time
   # Returns a TimeZone instance matching the time zone provided.
@@ -45,4 +170,16 @@ class Time
   #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
   #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
   def self.find_zone: (String | real | ActiveSupport::Duration | nil) -> ActiveSupport::TimeZone?
+end
+
+class Integer
+  prepend ActiveSupport::NumericWithFormat
+end
+
+class Float
+  prepend ActiveSupport::NumericWithFormat
+end
+
+class BigDecimal
+  prepend ActiveSupport::NumericWithFormat
 end

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -2057,13 +2057,6 @@ class Array[unchecked out Elem]
   def inquiry: () -> ActiveSupport::ArrayInquirer[Elem]
 end
 
-module ActiveSupport
-  module BigDecimalWithDefaultFormat
-    # nodoc:
-    def to_s: (?::String format) -> untyped
-  end
-end
-
 class Class
   # Declare a class-level attribute whose value is inheritable by subclasses.
   # Subclasses can change their own value and it will not impact parent class.
@@ -4068,108 +4061,6 @@ class Numeric
   alias exabyte exabytes
 end
 
-module ActiveSupport
-  module NumericWithFormat
-    # Provides options for converting numbers into formatted strings.
-    # Options are provided for phone numbers, currency, percentage,
-    # precision, positional notation, file size and pretty printing.
-    #
-    # ==== Options
-    #
-    # For details on which formats use which options, see ActiveSupport::NumberHelper
-    #
-    # ==== Examples
-    #
-    #  Phone Numbers:
-    #  5551234.to_s(:phone)                                     # => "555-1234"
-    #  1235551234.to_s(:phone)                                  # => "123-555-1234"
-    #  1235551234.to_s(:phone, area_code: true)                 # => "(123) 555-1234"
-    #  1235551234.to_s(:phone, delimiter: ' ')                  # => "123 555 1234"
-    #  1235551234.to_s(:phone, area_code: true, extension: 555) # => "(123) 555-1234 x 555"
-    #  1235551234.to_s(:phone, country_code: 1)                 # => "+1-123-555-1234"
-    #  1235551234.to_s(:phone, country_code: 1, extension: 1343, delimiter: '.')
-    #  # => "+1.123.555.1234 x 1343"
-    #
-    #  Currency:
-    #  1234567890.50.to_s(:currency)                 # => "$1,234,567,890.50"
-    #  1234567890.506.to_s(:currency)                # => "$1,234,567,890.51"
-    #  1234567890.506.to_s(:currency, precision: 3)  # => "$1,234,567,890.506"
-    #  1234567890.506.to_s(:currency, locale: :fr)   # => "1 234 567 890,51 (trim non-ascii characters)"
-    #  -1234567890.50.to_s(:currency, negative_format: '(%u%n)')
-    #  # => "($1,234,567,890.50)"
-    #  1234567890.50.to_s(:currency, unit: '&pound;', separator: ',', delimiter: '')
-    #  # => "&pound;1234567890,50"
-    #  1234567890.50.to_s(:currency, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
-    #  # => "1234567890,50 &pound;"
-    #
-    #  Percentage:
-    #  100.to_s(:percentage)                                  # => "100.000%"
-    #  100.to_s(:percentage, precision: 0)                    # => "100%"
-    #  1000.to_s(:percentage, delimiter: '.', separator: ',') # => "1.000,000%"
-    #  302.24398923423.to_s(:percentage, precision: 5)        # => "302.24399%"
-    #  1000.to_s(:percentage, locale: :fr)                    # => "1 000,000%"
-    #  100.to_s(:percentage, format: '%n  %')                 # => "100.000  %"
-    #
-    #  Delimited:
-    #  12345678.to_s(:delimited)                     # => "12,345,678"
-    #  12345678.05.to_s(:delimited)                  # => "12,345,678.05"
-    #  12345678.to_s(:delimited, delimiter: '.')     # => "12.345.678"
-    #  12345678.to_s(:delimited, delimiter: ',')     # => "12,345,678"
-    #  12345678.05.to_s(:delimited, separator: ' ')  # => "12,345,678 05"
-    #  12345678.05.to_s(:delimited, locale: :fr)     # => "12 345 678,05"
-    #  98765432.98.to_s(:delimited, delimiter: ' ', separator: ',')
-    #  # => "98 765 432,98"
-    #
-    #  Rounded:
-    #  111.2345.to_s(:rounded)                                      # => "111.235"
-    #  111.2345.to_s(:rounded, precision: 2)                        # => "111.23"
-    #  13.to_s(:rounded, precision: 5)                              # => "13.00000"
-    #  389.32314.to_s(:rounded, precision: 0)                       # => "389"
-    #  111.2345.to_s(:rounded, significant: true)                   # => "111"
-    #  111.2345.to_s(:rounded, precision: 1, significant: true)     # => "100"
-    #  13.to_s(:rounded, precision: 5, significant: true)           # => "13.000"
-    #  111.234.to_s(:rounded, locale: :fr)                          # => "111,234"
-    #  13.to_s(:rounded, precision: 5, significant: true, strip_insignificant_zeros: true)
-    #  # => "13"
-    #  389.32314.to_s(:rounded, precision: 4, significant: true)    # => "389.3"
-    #  1111.2345.to_s(:rounded, precision: 2, separator: ',', delimiter: '.')
-    #  # => "1.111,23"
-    #
-    #  Human-friendly size in Bytes:
-    #  123.to_s(:human_size)                                   # => "123 Bytes"
-    #  1234.to_s(:human_size)                                  # => "1.21 KB"
-    #  12345.to_s(:human_size)                                 # => "12.1 KB"
-    #  1234567.to_s(:human_size)                               # => "1.18 MB"
-    #  1234567890.to_s(:human_size)                            # => "1.15 GB"
-    #  1234567890123.to_s(:human_size)                         # => "1.12 TB"
-    #  1234567890123456.to_s(:human_size)                      # => "1.1 PB"
-    #  1234567890123456789.to_s(:human_size)                   # => "1.07 EB"
-    #  1234567.to_s(:human_size, precision: 2)                 # => "1.2 MB"
-    #  483989.to_s(:human_size, precision: 2)                  # => "470 KB"
-    #  1234567.to_s(:human_size, precision: 2, separator: ',') # => "1,2 MB"
-    #  1234567890123.to_s(:human_size, precision: 5)           # => "1.1228 TB"
-    #  524288000.to_s(:human_size, precision: 5)               # => "500 MB"
-    #
-    #  Human-friendly format:
-    #  123.to_s(:human)                                       # => "123"
-    #  1234.to_s(:human)                                      # => "1.23 Thousand"
-    #  12345.to_s(:human)                                     # => "12.3 Thousand"
-    #  1234567.to_s(:human)                                   # => "1.23 Million"
-    #  1234567890.to_s(:human)                                # => "1.23 Billion"
-    #  1234567890123.to_s(:human)                             # => "1.23 Trillion"
-    #  1234567890123456.to_s(:human)                          # => "1.23 Quadrillion"
-    #  1234567890123456789.to_s(:human)                       # => "1230 Quadrillion"
-    #  489939.to_s(:human, precision: 2)                      # => "490 Thousand"
-    #  489939.to_s(:human, precision: 4)                      # => "489.9 Thousand"
-    #  1234567.to_s(:human, precision: 4,
-    #                   significant: false)                   # => "1.2346 Million"
-    #  1234567.to_s(:human, precision: 1,
-    #                   separator: ',',
-    #                   significant: false)                   # => "1,2 Million"
-    def to_s: (?untyped? format, ?untyped? options) -> untyped
-  end
-end
-
 class Numeric
   # Returns a Duration instance matching the number of seconds provided.
   #
@@ -4587,25 +4478,6 @@ end
 module ActiveSupport
   module RangeWithFormat
     RANGE_FORMATS: ::Hash[untyped, untyped]
-
-    # Convert range to a formatted string. See RANGE_FORMATS for predefined formats.
-    #
-    #   range = (1..100)           # => 1..100
-    #
-    #   range.to_s                 # => "1..100"
-    #   range.to_s(:db)            # => "BETWEEN '1' AND '100'"
-    #
-    # == Adding your own range formats to to_s
-    # You can add your own formats to the Range::RANGE_FORMATS hash.
-    # Use the format name as the hash key and a Proc instance.
-    #
-    #   # config/initializers/range_formats.rb
-    #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_s(:db)} and #{stop.to_s(:db)}" }
-    def to_s: (?::Symbol format) -> untyped
-
-    alias to_default_s to_s
-
-    alias to_formatted_s to_s
   end
 end
 

--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -356,18 +356,6 @@ class Module
   def attr_internal_define: ((Symbol | String) attr_name, access_type `type`) -> void
 end
 
-class Integer
-  prepend ActiveSupport::NumericWithFormat
-end
-
-class Float
-  prepend ActiveSupport::NumericWithFormat
-end
-
-class BigDecimal
-  prepend ActiveSupport::NumericWithFormat
-end
-
 module ActiveSupport
   module Tryable : BasicObject
     def try: [T] () { (self) -> T } -> T # When yield self

--- a/gems/activesupport/7.0/_test/test.rb
+++ b/gems/activesupport/7.0/_test/test.rb
@@ -4,8 +4,8 @@
 require 'active_support/all'
 
 # Test ActiveSupport::NumericWithFormat
-42.to_s
-42.to_s(:phone)
+42.to_fs
+42.to_fs(:phone)
 
 5.try(:to_s)
 5.try('round', 2)

--- a/gems/activesupport/7.0/activesupport-7.0.rbs
+++ b/gems/activesupport/7.0/activesupport-7.0.rbs
@@ -286,6 +286,8 @@ class Range[out Elem]
   #   # config/initializers/range_formats.rb
   #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_fs(:db)} and #{stop.to_fs(:db)}" }
   def to_fs: (?Symbol format) -> String
+
+  alias to_formatted_s to_fs
 end
 
 # active_support/core_ext/date/conversions.rb


### PR DESCRIPTION
`#to_s` methods should return String object.

Additionally, I moved the definitions to activesupport-6.0.rbs, not activesupport.rbs because `#to_s` overrides ware marked as deprecated since v7.0, and removed since v7.1.

refs:

* https://github.com/rails/rails/pull/43772
* https://github.com/rails/rails/commit/e420c3380eb2b698a4fe84ed196f914d18f7844a
* https://github.com/soutaro/steep/issues/1478