### PR TITLE
activerecord: Add block support to sum method

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -4,6 +4,8 @@ class FunQuery
 end
 
 class User < ActiveRecord::Base
+  # @dynamic age
+
   enum status: { active: 0, inactive: 1 }, _suffix: true
   enum role: { admin: 0, user: 1 }, _prefix: :user_role
 
@@ -41,6 +43,10 @@ User.count
 User.create_with(name: 'name', age: 1)
 User.create_with(nil)
 User.find_by_sql("SELECT * FROM users")
+
+users = User.all
+users.sum(:age)
+users.sum(&:age)
 
 t = User.arel_table
 User.limit(10).select(:id, "name", t[:age].as("years"), t[:email])

--- a/gems/activerecord/6.0/_test/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rbs
@@ -16,6 +16,8 @@ class User < ActiveRecord::Base
   def articles: () -> Article::ActiveRecord_Associations_CollectionProxy
 
   def something: () -> untyped
+
+  attr_reader age: Integer
 end
 
 class Article < ActiveRecord::Base

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -432,6 +432,7 @@ module ActiveRecord
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
       def sum: (?untyped? column_name) -> Integer
+             | () { (Model) -> Integer } -> Integer
       def destroy_all: () -> untyped
       def delete_all: () -> untyped
       def update_all: (*untyped) -> untyped
@@ -528,6 +529,7 @@ module ActiveRecord
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
       def sum: (?untyped? column_name) -> Integer
+             | () { (Model) -> Integer } -> Integer
       def destroy_all: () -> untyped
       def delete_all: () -> untyped
       def update_all: (*untyped) -> untyped
@@ -679,6 +681,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
   def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
   def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
   def sum: (?untyped? column_name) -> Integer
+         | () { (Model) -> Integer } -> Integer
   def destroy_all: () -> untyped
   def delete_all: () -> untyped
   def update_all: (untyped) -> untyped
@@ -769,6 +772,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rub
   def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
   def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
   def sum: (?untyped? column_name) -> Integer
+         | () { (Model) -> Integer } -> Integer
   def destroy_all: () -> untyped
   def delete_all: () -> untyped
   def update_all: (untyped) -> untyped


### PR DESCRIPTION
In addition to passing column names, the sum method can also pass blocks. https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/calculations.rb#L84-L94

```rb
users = User.all
users.sum(:age) # Already defined in type definition
users.sum(&:age) # Not defined in type definition
```

This change adds support for the sum method to accept a block.