### PR TITLE
Remove manifest.yaml from sidekiq-pro

### DIFF
--- a/gems/sidekiq-pro/7.3/manifest.yaml
+++ b/gems/sidekiq-pro/7.3/manifest.yaml
@@ -1,7 +1,0 @@
-# manifest.yaml describes dependencies which do not appear in the gemspec.
-# If this gem includes such dependencies, comment-out the following lines and
-# declare the dependencies.
-# If all dependencies appear in the gemspec, you should remove this file.
-#
-dependencies:
-  - name: sidekiq


### PR DESCRIPTION
sidekiq-pro declares a dependency to `sidekiq` gem with `manifest.yaml`. It's because sidekiq-pro is a private gem, so it can't fetch sidekiq gem in the test of this type definition.

But this `manifest.yaml` introduces an error when using this RBS via `rbs collection`.

`rbs validate` command displays the following error.

```
Cannot find type definitions for library: sidekiq (0) (RBS::EnvironmentLoader::UnknownLibraryError)
```

`rbs collection install` generates the following lock file.

```
- name: sidekiq
  version: '0'
  source:
    type: stdlib
```

Because `manifest.yaml` works only for standard libraries. So `manifest.yaml` does not work for a ordinary gem (at least for now). See also https://github.com/ruby/rbs/issues/1538

So I removed this `manifest.yaml`.

----

BTW, this `manifest.yaml` is unnecessary for users. The comment in the `manifest.yaml` said:

> manifest.yaml describes dependencies which do not appear in the gemspec.

It's for gems "which do not appear in the gemspec", but `sidekiq-pro` gem declares a dependency to `sidekiq` in the gemspec. So the `manifest.yaml` is not necessary the user to use this RBS definitions.