### PR TITLE
Fix sidekiq-pro type definitions

### DIFF
--- a/gems/sidekiq-pro/7.3/sidekiq-pro.rbs
+++ b/gems/sidekiq-pro/7.3/sidekiq-pro.rbs
@@ -1,12 +1,6 @@
 # This RBS is unofficial.
 # The above declaration is a requirement for publishing the RBS for sidekiq-pro and sidekiq-ent, so please do not remove it.
 
-module Sidekiq
-  NAME: "Sidekiq Pro"
-
-  LICENSE: ::String
-end
-
 class Sidekiq::CLI
   def self.banner: () -> untyped
 end
@@ -223,7 +217,7 @@ end
 class Sidekiq::Batch::DeadSet
   @_size: untyped
 
-  include Enumerable
+  include Enumerable[untyped]
 
   def size: () -> untyped
 
@@ -418,7 +412,7 @@ module Sidekiq
   class BatchSet
     @_size: untyped
 
-    include Enumerable
+    include Enumerable[untyped]
 
     def size: () -> untyped
 

--- a/gems/sidekiq/7.0/middleware.rbs
+++ b/gems/sidekiq/7.0/middleware.rbs
@@ -59,3 +59,5 @@ module Sidekiq
     def redis: () { (RedisClientAdapter::CompatClient) -> void } -> void
   end
 end
+
+module Sidekiq::ClientMiddleware = Sidekiq::ServerMiddleware

--- a/gems/sidekiq/7.0/scheduled.rbs
+++ b/gems/sidekiq/7.0/scheduled.rbs
@@ -1,0 +1,6 @@
+module Sidekiq
+  module Scheduled
+    class Enq
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes `sidekiq-pro` gem's RBS to pass `rbs validate`.



## Duplicated constants

`Sidekiq::NAME` and `Sidekiq::LICENSE` are already defined in `sidekiq` gem's RBS.
So we need to remove them to avoid duplication errors.

https://github.com/pocke/gem_rbs_collection/blob/56fe0732b57bd4e1dc6bdf8a9c09fe59cdcc9e4c/gems/sidekiq/7.0/sidekiq.rbs#L38-L42


## Missing type parameters

There are lack of type parameters of `Enumerable`. So I specified `untyped` for them.

We can probably specify more concrete type for it, but I just specify `untyped` for the first step.


## Missing mixin

This RBS file has `include Sidekiq::ClientMiddleware`, but this module is not defined.
So I added the definition to `sidekiq` gem.


This module is defined here in Ruby. https://github.com/sidekiq/sidekiq/blob/c019d52a0854e405699a16c70aa207765ff3f648/lib/sidekiq/middleware/modules.rb#L21-L22


## Missing superclass

`Sidekiq::Scheduled::Enq` is specified as a superclass, but it's not defined. So I added the class definition to `sidekiq` gem.
This class actually has some methods, but I just defined an empty class for the first step.



It's defined here in Ruby.
https://github.com/sidekiq/sidekiq/blob/c019d52a0854e405699a16c70aa207765ff3f648/lib/sidekiq/scheduled.rb#L6-L10








-----------








I've confirmed `rbs validate` command passes with these changes.




BTW, I made these changes only for `sidekiq` v7.0, but this repository has sidekiq 6.3 and 6.2 types. So `sidekiq-pro` gem's RBS does not work with sidekiq v6.4 and v6.2.

I think it's not a problem. This repository has `sidekiq-pro` only for v7.3, and this version does not support the sidekiq v6 series.
