### PR TITLE
Make ksss a reviewer

### DIFF
--- a/gems/sidekiq-pro/_reviewers.yaml
+++ b/gems/sidekiq-pro/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss


### PR DESCRIPTION
Since **sidekiq-pro** is a gem that is difficult to test, assigning a reviewer will help prevent breaking the RBS in advance.