### PR TITLE
fix activerecord sum methods

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/6.0/_test/activerecord-generated.rb
@@ -44,9 +44,14 @@ User.create_with(name: 'name', age: 1)
 User.create_with(nil)
 User.find_by_sql("SELECT * FROM users")
 
-users = User.all
-users.sum(:age)
-users.sum(&:age)
+User.sum(:age)
+User.sum(&:age).times
+User.sum { |user| user.age }.times
+User.sum(0.0) { |user| user.age.to_f }.next_float
+User.all.sum(:age)
+User.all.sum(&:age).times
+User.all.sum { |user| user.age }.times
+User.all.sum(0.0) { |user| user.age.to_f }.next_float
 
 t = User.arel_table
 User.limit(10).select(:id, "name", t[:age].as("years"), t[:email])

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -431,8 +431,8 @@ module ActiveRecord
                    | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
-      def sum: (?untyped? column_name) -> Integer
-             | () { (Model) -> Integer } -> Integer
+      def sum: (?untyped? column_name) -> untyped
+             | [T] (?T initial_value) { (Model) -> T } -> T
       def destroy_all: () -> untyped
       def delete_all: () -> untyped
       def update_all: (*untyped) -> untyped
@@ -528,8 +528,8 @@ module ActiveRecord
                    | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
       def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
       def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
-      def sum: (?untyped? column_name) -> Integer
-             | () { (Model) -> Integer } -> Integer
+      def sum: (?untyped? column_name) -> untyped
+             | [T] (?T initial_value) { (Model) -> T } -> T
       def destroy_all: () -> untyped
       def delete_all: () -> untyped
       def update_all: (*untyped) -> untyped
@@ -680,8 +680,8 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
                | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
   def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
   def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (self) -> void } -> nil
-  def sum: (?untyped? column_name) -> Integer
-         | () { (Model) -> Integer } -> Integer
+  def sum: (?untyped? column_name) -> untyped
+         | [T] (?T initial_value) { (Model) -> T } -> T
   def destroy_all: () -> untyped
   def delete_all: () -> untyped
   def update_all: (untyped) -> untyped
@@ -771,8 +771,8 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rub
                | (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) -> Enumerator[Model, nil]
   def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Array[Model]) -> void } -> nil
   def in_batches: (?of: Integer, ?start: Integer, ?finish: Integer, ?load: bool, ?error_on_ignore: bool, ?order: untyped) { (Relation) -> void } -> nil
-  def sum: (?untyped? column_name) -> Integer
-         | () { (Model) -> Integer } -> Integer
+  def sum: (?untyped? column_name) -> untyped
+         | [T] (?T initial_value) { (Model) -> T } -> T
   def destroy_all: () -> untyped
   def delete_all: () -> untyped
   def update_all: (untyped) -> untyped


### PR DESCRIPTION
When a block is given, it is delegated to Enumerable#sum. See `Enumerable#sum` for reference.

Since it is more type-friendly for the types of `initial_value`, the block's return value, and the method's return value to match, I will accept some imprecision and unify all types as `T`.

When no block is given, the calculate method processes the result, so the return value is not necessarily an Integer.

https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/calculations.rb#L127