### PR TITLE
activesupport: Update return types of `#present?` and `#blank?`

### DIFF
--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -462,8 +462,8 @@ end
 
 # active_support/core_ext/object/blank.rb
 class Object
-  def blank?: () -> bool
-  def present?: () -> bool
+  def blank?: () -> false
+  def present?: () -> true
   def presence: () -> self?
 end
 
@@ -475,22 +475,27 @@ end
 
 class NilClass
   def blank?: () -> true
+  def present?: () -> false
 end
 
 class FalseClass
   def blank?: () -> true
+  def present?: () -> false
 end
 
 class TrueClass
   def blank?: () -> false
+  def present?: () -> true
 end
 
 class Array[unchecked out Elem]
   alias blank? empty?
+  def present?: () -> bool
 end
 
 class Hash[unchecked out K, unchecked out V]
   alias blank? empty?
+  def present?: () -> bool
 
   # Returns a string containing an XML representation of its receiver:
   #
@@ -561,6 +566,7 @@ class String
   BLANK_RE: Regexp
   ENCODED_BLANKS: Concurrent::Map[Encoding, Regexp]
   def blank?: () -> bool
+  def present?: () -> bool
 end
 
 class Numeric


### PR DESCRIPTION
This updates the return types of `#present?` and `#blank?` to narrow the type of receiver possibly.

Since 1.10, Steep can narrow the type of receiver via the return type of the method when the type of receiver is union.  For example, a receiver typed as will be narrowed to `String` on the `if present?` block, and be narrowed to `String | nil` on the `else` block because `String#present?` returns bool and `NilClass#present?` returns false.

```ruby
var = ... # String | nil
if var.present?
  # var is narrowed to String
else
  # var is narrowed to String | nil
end
```

refs:

* https://github.com/soutaro/steep/wiki/Release-Note-1.10 (unreleased yet)
* https://github.com/soutaro/steep/pull/1497