### PR TITLE
devise: add Devise::SessionController

### DIFF
--- a/gems/devise/.rubocop.yml
+++ b/gems/devise/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/devise/4.9/_test/test.rb
+++ b/gems/devise/4.9/_test/test.rb
@@ -1,0 +1,4 @@
+require "devise"
+
+class CustomSessionsController < Devise::SessionsController
+end

--- a/gems/devise/4.9/_test/test.rbs
+++ b/gems/devise/4.9/_test/test.rbs
@@ -1,0 +1,2 @@
+class CustomSessionsController < Devise::SessionsController
+end

--- a/gems/devise/4.9/devise.rbs
+++ b/gems/devise/4.9/devise.rbs
@@ -1,0 +1,9 @@
+module Devise
+  class SessionsController < ::DeviseController
+  end
+end
+
+# NOTE: `DeviseController` was not defined under the `Devise` module.
+# https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/app/controllers/devise_controller.rb#L4
+class DeviseController
+end


### PR DESCRIPTION
Added type definitions for the `devise` gem.
I needed type definitions for the `Devise::SessionsController` class in my use case, so I added them.