### PR TITLE
activeadmin: Add activeadmin gem

### DIFF
--- a/gems/activeadmin/.rubocop.yml
+++ b/gems/activeadmin/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/activeadmin/3.3/_test/metadata.yaml
+++ b/gems/activeadmin/3.3/_test/metadata.yaml
@@ -1,0 +1,2 @@
+additional_gems:
+  - devise

--- a/gems/activeadmin/3.3/_test/test.rb
+++ b/gems/activeadmin/3.3/_test/test.rb
@@ -1,0 +1,15 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "activeadmin"
+
+class SessionsController < ActiveAdmin::Devise::SessionsController
+end
+
+class TestPanel < ActiveAdmin::Views::Panel
+  builder_method :test_panel
+end
+
+class TestStatusTag < ActiveAdmin::Views::StatusTag
+  builder_method :test_status_tag
+end

--- a/gems/activeadmin/3.3/_test/test.rbs
+++ b/gems/activeadmin/3.3/_test/test.rbs
@@ -1,0 +1,8 @@
+class SessionsController < ActiveAdmin::Devise::SessionsController
+end
+
+class TestPanel < ActiveAdmin::Views::Panel
+end
+
+class TestStatusTag < ActiveAdmin::Views::StatusTag
+end

--- a/gems/activeadmin/3.3/activeadmin.rbs
+++ b/gems/activeadmin/3.3/activeadmin.rbs
@@ -1,0 +1,20 @@
+module ActiveAdmin
+  module Devise
+    class SessionsController < ::Devise::SessionsController
+    end
+  end
+
+  class Component < Arbre::Component
+  end
+
+  module Views
+    class Panel < Component
+    end
+
+    class StatusTag < Component
+    end
+  end
+
+  class Page
+  end
+end

--- a/gems/arbre/.rubocop.yml
+++ b/gems/arbre/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/arbre/1.7/_test/test.rb
+++ b/gems/arbre/1.7/_test/test.rb
@@ -1,0 +1,5 @@
+require "arbre"
+
+class CustomComponent < Arbre::Component
+  builder_method :custom_component
+end

--- a/gems/arbre/1.7/_test/test.rbs
+++ b/gems/arbre/1.7/_test/test.rbs
@@ -1,0 +1,2 @@
+class CustomComponent < Arbre::Component
+end

--- a/gems/arbre/1.7/arbre.rbs
+++ b/gems/arbre/1.7/arbre.rbs
@@ -1,0 +1,22 @@
+module Arbre
+  class Element
+    module BuilderMethods
+      module ClassMethods
+        def builder_method: (_ToS) -> void
+      end
+    end
+
+    extend BuilderMethods::ClassMethods
+  end
+
+  module HTML
+    class Tag < Element
+    end
+
+    class Div < Tag
+    end
+  end
+
+  class Component < HTML::Div
+  end
+end


### PR DESCRIPTION
Added type definitions for the `activeadmin` gem, which were needed in my use case. 
Also added type definitions for the `arbre` gem, as it is a dependency of `activeadmin`.