### PR TITLE
active_model_serializers: add `ActiveModel::Serializer.type`

### DIFF
--- a/gems/active_model_serializers/0.10/_test/test.rb
+++ b/gems/active_model_serializers/0.10/_test/test.rb
@@ -12,6 +12,8 @@ module Test
   end
 
   class ArticleSerializer < ActiveModel::Serializer
+    type :article
+
     attribute :title
     attribute :title, key: :name
     attributes :body, :tag_names

--- a/gems/active_model_serializers/0.10/active_model.rbs
+++ b/gems/active_model_serializers/0.10/active_model.rbs
@@ -2,6 +2,7 @@ module ActiveModel
   class Serializer[T]
     def self.attributes: (*Symbol attrs) -> void
     def self.attribute: (Symbol attr, ?Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
+    def self.type: (_ToS type) -> void
 
     attr_accessor object: T
     attr_accessor root: untyped


### PR DESCRIPTION
Added missing type definition for `ActiveModel::Serializer.type`.