### PR TITLE
Fix `RBS::NoSuperclassFoundError`

### DIFF
--- a/gems/activeadmin/3.3/shims.rbs
+++ b/gems/activeadmin/3.3/shims.rbs
@@ -1,0 +1,5 @@
+# Avoid class missing issue when using activeadmin but not using devise.
+module Devise
+  class SessionsController
+  end
+end


### PR DESCRIPTION
Our application uses **activeadmin** but not **devise**.
When we run `rbs validate` on this application, it fails with `RBS::NoSuperclassFoundError`.