### PR TITLE
Update rubocop on rbs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@
 # where the inspected file is and continue its way up to the root directory.
 #
 # See https://docs.rubocop.org/rubocop/configuration
-require:
+plugins:
   - rubocop-on-rbs
 
 AllCops:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,9 +60,10 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.38.0)
       parser (>= 3.3.1.0)
-    rubocop-on-rbs (1.4.2)
+    rubocop-on-rbs (1.5.0)
+      lint_roller (~> 1.1)
       rbs (~> 3.5)
-      rubocop (~> 1.61)
+      rubocop (>= 1.72.1, < 2.0)
       zlib
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)


### PR DESCRIPTION
Use plugins.

See also: https://docs.rubocop.org/rubocop/plugin_migration_guide.html