### PR TITLE
Make `Object#blank?` and `Object#present?` return types `bool`

### DIFF
--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -462,8 +462,8 @@ end
 
 # active_support/core_ext/object/blank.rb
 class Object
-  def blank?: () -> false
-  def present?: () -> true
+  def blank?: () -> bool
+  def present?: () -> bool
   def presence: () -> self?
 end
 


### PR DESCRIPTION
Those methods are introduced at https://github.com/ruby/gem_rbs_collection/pull/815 with specific bool types. Now after considering a few examples I found with the method definitions, I changed my opinion that these methods should have return type of `bool`.

The difficulty is the `Object` implementation returns different values based on if `#empty?` is defined or not.

https://github.com/rails/rails/blob/9f39c019243138d73bb265ec32da9aee26b2c18f/activesupport/lib/active_support/core_ext/object/blank.rb#L6-L27

This makes having `true`/`false` here incomplete and really annoying. If we have `#empty?` method in a class, we have to change the type of `present?` and `blank?` in the class, while the Ruby definition doesn't have custom implementation of them.