### PR TITLE
`BigDecimal#precs` has been deprecated.

### DIFF
--- a/gems/bigdecimal/3.1/bigdecimal.rbs
+++ b/gems/bigdecimal/3.1/bigdecimal.rbs
@@ -795,6 +795,7 @@ class BigDecimal < Numeric
   # in scientific notation, and BigDecimal#precision for obtaining the number of
   # digits in decimal notation.
   #
+  %a{deprecated}
   def precs: () -> [ Integer, Integer ]
 
   # <!--


### PR DESCRIPTION
https://github.com/ruby/bigdecimal/blob/a015c8b91575fc6cb25df6be64a69f42abf34399/CHANGES.md#L128