### PR TITLE
refactor: replace `Object#name` with `(String | Symbol)` in ActiveSupport

### DIFF
--- a/gems/activesupport/6.0/activesupport.rbs
+++ b/gems/activesupport/6.0/activesupport.rbs
@@ -360,22 +360,22 @@ module ActiveSupport
   module Tryable : BasicObject
     def try: [T] () { (self) -> T } -> T # When yield self
            | [T] () { () -> T } -> T # When instance_eval
-           | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+           | ((String | Symbol) method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
     def try!: [T] () { (self) -> T } -> T # When yield self
             | [T] () { () -> T } -> T # When instance_eval
-            | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+            | ((String | Symbol) method_name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
   end
 end
 
 class NilClass
   def try: () { (untyped) -> untyped } -> nil
          | () { () -> untyped } -> nil
-         | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+         | ((String | Symbol) method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
 
   def try!: () { (untyped) -> untyped } -> nil
           | () { () -> untyped } -> nil
-          | (Object::name method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
+          | ((String | Symbol) method_name, *untyped args) ?{ (*untyped) -> untyped } -> nil
 end
 
 class Array[unchecked out Elem]


### PR DESCRIPTION
Because `Object::name` type is deprecated.