### PR TITLE
Add belongs_to, has_one and has_many method on ActiveModelSerializers

### DIFF
--- a/gems/active_model_serializers/0.10/_test/test.rb
+++ b/gems/active_model_serializers/0.10/_test/test.rb
@@ -1,9 +1,19 @@
 require "active_model_serializers"
 
 module Test
+  class Author < ActiveModelSerializers::Model
+    # @dynamic name, name=, initialize
+    attributes :name
+  end
+
+  class Category < ActiveModelSerializers::Model
+    # @dynamic name, name=, initialize
+    attributes :name
+  end
+
   class Article < ActiveModelSerializers::Model
-    # @dynamic title, title=, body, body=, tags, tags=, initialize
-    attributes :title, :body, :tags
+    # @dynamic title, title=, body, body=, tags, tags=, author, author=, category, category=, initialize
+    attributes :title, :body, :tags, :author, :category
   end
 
   class Tag < ActiveModelSerializers::Model
@@ -21,9 +31,19 @@ module Test
     def tag_names
       object.tags.map(&:name)
     end
+
+    has_many :tags, serializer: TagSerializer
+    has_one :author
+    belongs_to :category
   end
 
-  resource = Article.new(title: "Hello", body: "World", tags: [Tag.new(name: "foo"), Tag.new(name: "bar")])
+  class TagSerializer < ActiveModel::Serializer
+    type :tag
+
+    attribute :name
+  end
+
+  resource = Article.new(title: "Hello", body: "World", tags: [Tag.new(name: "foo"), Tag.new(name: "bar")], author: Author.new(name: "John"), category: Category.new(name: "Tech"))
   ArticleSerializer.new(resource).as_json
 
   serialization = ActiveModelSerializers::SerializableResource.new(resource)

--- a/gems/active_model_serializers/0.10/_test/test.rbs
+++ b/gems/active_model_serializers/0.10/_test/test.rbs
@@ -1,10 +1,24 @@
 module Test
+  class Author < ActiveModelSerializers::Model
+    attr_accessor name: String
+
+    def initialize: (name: String) -> void
+  end
+
+  class Category < ActiveModelSerializers::Model
+    attr_accessor name: String
+
+    def initialize: (name: String) -> void
+  end
+
   class Article < ActiveModelSerializers::Model
     attr_accessor title: String
     attr_accessor body: String
     attr_accessor tags: Array[Tag]
+    attr_accessor author: Author
+    attr_accessor category: Category
 
-    def initialize: (title: String, body: String, tags: Array[Tag]) -> void
+    def initialize: (title: String, body: String, tags: Array[Tag], author: Author, category: Category) -> void
   end
 
   class Tag < ActiveModelSerializers::Model
@@ -15,5 +29,14 @@ module Test
 
   class ArticleSerializer < ActiveModel::Serializer[Article]
     def tag_names: () -> Array[String]
+  end
+
+  class TagSerializer < ActiveModel::Serializer[Tag]
+  end
+
+  class AuthorSerializer < ActiveModel::Serializer[Author]
+  end
+
+  class CategorySerializer < ActiveModel::Serializer[Category]
   end
 end

--- a/gems/active_model_serializers/0.10/active_model.rbs
+++ b/gems/active_model_serializers/0.10/active_model.rbs
@@ -3,6 +3,9 @@ module ActiveModel
     def self.attributes: (*Symbol attrs) -> void
     def self.attribute: (Symbol attr, ?Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
     def self.type: (_ToS type) -> void
+    def self.belongs_to: (Symbol name, ?Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
+    def self.has_one: (Symbol name, ?Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
+    def self.has_many: (Symbol name, ?Hash[Symbol, untyped] options) ?{ () -> untyped } -> void
 
     attr_accessor object: T
     attr_accessor root: untyped


### PR DESCRIPTION

## Overview

This pull request introduces type definitions for three methods and tests within the ActiveModelSerializers gem:

- `belongs_to`
- `has_one`
- `has_many`

## References

- `belongs_to`:
  - https://github.com/rails-api/active_model_serializers/blob/0-10-stable/lib/active_model/serializer.rb#L249
- `has_one`:
  - https://github.com/rails-api/active_model_serializers/blob/0-10-stable/lib/active_model/serializer.rb#L260
- `has_many`:
  - https://github.com/rails-api/active_model_serializers/blob/0-10-stable/lib/active_model/serializer.rb#L238