### PR TITLE
activerecord: Update callback types to accept CallbackObject

### DIFF
--- a/gems/activerecord/6.0/_test/activerecord.rb
+++ b/gems/activerecord/6.0/_test/activerecord.rb
@@ -1,0 +1,49 @@
+class TestCallbackObject < ActiveRecord::Base
+  before_validation ::Callbacks::ClassCallback
+  after_validation ::Callbacks::ClassCallback
+  before_save ::Callbacks::ClassCallback
+  before_create ::Callbacks::ClassCallback
+  after_create ::Callbacks::ClassCallback
+  after_save ::Callbacks::ClassCallback
+  around_create ::Callbacks::ClassCallback
+  around_save ::Callbacks::ClassCallback
+end
+
+module Callbacks
+  class ClassCallback
+    def self.before_validation(model_obj)
+      puts("class before_validation: #{model_obj}")
+    end
+
+    def self.after_validation(model_obj)
+      puts("class after_validation: #{model_obj}")
+    end
+
+    def self.before_save(model_obj)
+      puts("class before_save: #{model_obj}")
+    end
+
+    def self.before_create(model_obj)
+      puts("class before_create: #{model_obj}")
+    end
+
+    def self.after_create(model_obj)
+      puts("class after_create: #{model_obj}")
+    end
+
+    def self.after_save(model_obj)
+      puts("class after_save: #{model_obj}")
+    end
+
+    def self.around_create(model_obj)
+      puts("class around_create: #{model_obj}")
+      yield
+    end
+
+    def self.around_save(model_obj)
+      puts("class around_save: #{model_obj}")
+      yield
+    end
+  end
+end
+

--- a/gems/activerecord/6.0/_test/activerecord.rbs
+++ b/gems/activerecord/6.0/_test/activerecord.rbs
@@ -1,0 +1,22 @@
+class TestCallbackObject < ActiveRecord::Base
+end
+
+module Callbacks
+  class ClassCallback
+    def self.before_validation: (untyped) -> void
+
+    def self.after_validation: (untyped) -> void
+
+    def self.before_save: (untyped) -> void
+
+    def self.before_create: (untyped) -> void
+
+    def self.after_create: (untyped) -> void
+
+    def self.after_save: (untyped) -> void
+
+    def self.around_create: (untyped) { () -> void } -> void
+
+    def self.around_save: (untyped) { () -> void } -> void
+  end
+end

--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -53,31 +53,72 @@ module ActiveRecord
     def self.validates: (*untyped, ?if: condition[instance], ?unless: condition[instance], **untyped) -> void
 
     # callbacks
+    interface _AfterCreateCallbackObject
+      def after_create: (untyped) -> void
+    end
+
+    interface _AfterSaveCallbackObject
+      def after_save: (untyped) -> void
+    end
+
+    interface _AfterValidationCallbackObject
+      def after_validation: (untyped) -> void
+    end
+
+    interface _AroundCreateCallbackObject
+      def around_create: (untyped) { () -> void } -> void
+    end
+
+    interface _AroundSaveCallbackObject
+      def around_save: (untyped) { () -> void } -> void
+    end
+
+    interface _BeforeCreateCallbackObject
+      def before_create: (untyped) -> void
+    end
+    interface _BeforeSaveCallbackObject
+      def before_save: (untyped) -> void
+    end
+
+    interface _BeforeValidationCallbackObject
+      def before_validation: (untyped) -> void
+    end
+
     type callback[T] = Symbol | ^(T) [self: T] -> void
     type around_callback[T] = Symbol | ^(T, Proc) [self: T] -> void
+
+    type after_create_callback[T] = callback[T] | _AfterCreateCallbackObject
+    type after_save_callback[T] = callback[T] | _AfterSaveCallbackObject
+    type after_validation_callback[T] = callback[T] | _AfterValidationCallbackObject
+    type around_create_callback[T] = around_callback[T] | _AroundCreateCallbackObject
+    type around_save_callback[T] = around_callback[T] | _AroundSaveCallbackObject
+    type before_create_callback[T] = callback[T] | _BeforeCreateCallbackObject
+    type before_validation_callback[T] = callback[T] | _BeforeValidationCallbackObject
+    type before_save_callback[T] = callback[T] | _BeforeSaveCallbackObject
+
     def self.after_commit: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_create_commit: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) -> void | ...
     def self.after_update_commit: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) -> void | ...
     def self.after_destroy_commit: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) -> void | ...
-    def self.after_save_commit: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) -> void | ...
-    def self.after_create: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_save_commit: (*after_save_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) -> void | ...
+    def self.after_create: (*after_create_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_destroy: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_rollback: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.after_save: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_save: (*after_save_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_update: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.after_validation: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.after_validation: (*after_validation_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_initialize: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_find: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.after_touch: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.around_create: (*around_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.around_create: (*around_create_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.around_destroy: (*around_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.around_save: (*around_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.around_save: (*around_save_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.around_update: (*around_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.before_create: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_create: (*before_create_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.before_destroy: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.before_save: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_save: (*before_save_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
     def self.before_update: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
-    def self.before_validation: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
+    def self.before_validation: (*before_validation_callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> untyped } -> void
 
     def self.columns: () -> Array[untyped]
     def self.reflect_on_all_associations: (?Symbol) -> Array[untyped]


### PR DESCRIPTION
### Background
In the current type definitions for ActiveRecord, callback objects could not be properly accepted as arguments for lifecycle callbacks. This limitation made it difficult to use callback objects in a type-safe manner, even though they are supported by Rails.

### Changes
This PR updates the type definitions to allow callback objects to be passed to the lifecycle callbacks listed in the Rails documentation:  
[Active Record Callbacks - Available Callbacks](https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks).  
Only the callbacks explicitly listed in the documentation have been addressed in this update.

### How to Verify
To confirm the current issue and verify the changes, please refer to the following repository:  
[https://github.com/Okunichiyou/rbs-pra/tree/test1](https://github.com/Okunichiyou/rbs-pra/tree/test1)

This repository demonstrates the type error that occurs when using callback objects with the current type definitions.

1. Install dependencies:
   ```bash
   bundle install
   ```

2. Run RSpec tests:
   ```bash
   bundle exec rspec spec/models/comment_spec.rb
   ```
   This confirms that the callback object is correctly accepted in Rails.

3. Perform type checking:
   ```bash
   bundle exec steep check
   ```
   This reproduces the type error caused by the current type definitions.