### PR TITLE
devise: add types for Devise methods and modules

### DIFF
--- a/gems/devise/4.9/_test/metadata.yaml
+++ b/gems/devise/4.9/_test/metadata.yaml
@@ -1,0 +1,2 @@
+additional_gems:
+  - 'activerecord'

--- a/gems/devise/4.9/_test/test.rb
+++ b/gems/devise/4.9/_test/test.rb
@@ -1,4 +1,11 @@
 require "devise"
+require "active_record"
 
 class CustomSessionsController < Devise::SessionsController
+end
+
+class User < ActiveRecord::Base
+  devise :database_authenticatable, :omniauthable, :confirmable,
+         :recoverable, :registerable, :rememberable,
+         :trackable, :timeoutable, :validatable, :lockable
 end

--- a/gems/devise/4.9/_test/test.rbs
+++ b/gems/devise/4.9/_test/test.rbs
@@ -1,2 +1,15 @@
 class CustomSessionsController < Devise::SessionsController
 end
+
+class User < ActiveRecord::Base
+  include Devise::Models::DatabaseAuthenticatable
+  include Devise::Models::Omniauthable
+  include Devise::Models::Confirmable
+  include Devise::Models::Recoverable
+  include Devise::Models::Registerable
+  include Devise::Models::Rememberable
+  include Devise::Models::Trackable
+  include Devise::Models::Timeoutable
+  include Devise::Models::Validatable
+  include Devise::Models::Lockable
+end

--- a/gems/devise/4.9/devise.rbs
+++ b/gems/devise/4.9/devise.rbs
@@ -7,3 +7,50 @@ end
 # https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/app/controllers/devise_controller.rb#L4
 class DeviseController
 end
+
+module Devise
+  module Models
+    interface _DeviseClassMethod
+      def devise: (*::Symbol) -> void
+    end
+
+    module DatabaseAuthenticatable
+    end
+
+    module Omniauthable
+    end
+
+    module Confirmable
+    end
+
+    module Recoverable
+    end
+
+    module Registerable
+    end
+
+    module Rememberable
+    end
+
+    module Trackable
+    end
+
+    module Timeoutable
+    end
+
+    module Validatable
+    end
+
+    module Lockable
+    end
+  end
+end
+
+# NOTE: For type checking, we represent the `devise` class method from Devise::Models
+# being available to ActiveRecord models by extending the base class with the interface.
+# See: https://github.com/heartcombo/devise/blob/v4.9.4/lib/devise/models.rb#L79
+module ActiveRecord
+  class Base
+    extend Devise::Models::_DeviseClassMethod
+  end
+end


### PR DESCRIPTION
Add type definitions for:
- `devise` class method that enables authentication in ActiveRecord models
- Devise modules (Confirmable, Recoverable, Registerable, etc.)

This allows proper type checking when using Devise authentication functionality.
　