### PR TITLE
Mysql2: Add types for Mysql2::Result#to_a

### DIFF
--- a/gems/mysql2/0.5/_test/result.rb
+++ b/gems/mysql2/0.5/_test/result.rb
@@ -1,3 +1,4 @@
 client = Mysql2::Client.new
 result = client.query("SELECT * FROM users WHERE age > 10")
 result.size
+result.to_a

--- a/gems/mysql2/0.5/result.rbs
+++ b/gems/mysql2/0.5/result.rbs
@@ -14,6 +14,7 @@ module Mysql2
 
     def each: () { (Hash[key_type, row_value_type]) -> void } -> void
     def count: () -> Integer
+    def to_a: () -> Array[untyped]
     alias size count
   end
 
@@ -24,6 +25,7 @@ module Mysql2
 
     def each: () { (Array[row_value_type]) -> void } -> void
     def count: () -> Integer
+    def to_a: () -> Array[untyped]
     alias size count
   end
 end


### PR DESCRIPTION
- Currently, this gem does not have type definitions for Mysql2::Result#to_a
  - However, this class is something I want to use in my project, and I need type definitions for it.
  - Therefore, in this PR, I am adding the necessary type definitions.
