### PR TITLE
google-cloud-errors: Add rbs for google-cloud-errors gem

### DIFF
--- a/gems/google-cloud-errors/.rubocop.yml
+++ b/gems/google-cloud-errors/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/google-cloud-errors/1.5/_test/metadata.yaml
+++ b/gems/google-cloud-errors/1.5/_test/metadata.yaml
@@ -1,0 +1,4 @@
+# If the test needs gem's RBS files, declare them here.
+#
+# additional_gems:
+#   - GEM_NAME

--- a/gems/google-cloud-errors/1.5/_test/test.rb
+++ b/gems/google-cloud-errors/1.5/_test/test.rb
@@ -2,3 +2,7 @@
 # It is type checked by `steep check` command.
 
 require "google-cloud-errors"
+
+begin
+rescue Google::Cloud::UnauthenticatedError => e
+end

--- a/gems/google-cloud-errors/1.5/_test/test.rb
+++ b/gems/google-cloud-errors/1.5/_test/test.rb
@@ -1,0 +1,4 @@
+# Write Ruby code to test the RBS.
+# It is type checked by `steep check` command.
+
+require "google-cloud-errors"

--- a/gems/google-cloud-errors/1.5/google-cloud-errors.rbs
+++ b/gems/google-cloud-errors/1.5/google-cloud-errors.rbs
@@ -1,0 +1,4 @@
+# Write the type definition here!
+#
+# You can write all the definitions in this file,
+# or you can split the definitions into multiple files by organizing them into classes or modules.

--- a/gems/google-cloud-errors/1.5/google-cloud-errors.rbs
+++ b/gems/google-cloud-errors/1.5/google-cloud-errors.rbs
@@ -1,4 +1,51 @@
-# Write the type definition here!
-#
-# You can write all the definitions in this file,
-# or you can split the definitions into multiple files by organizing them into classes or modules.
+module Google
+  module Cloud
+    class Error < StandardError
+    end
+
+    class CanceledError < Error
+    end
+
+    class UnknownError < Error
+    end
+
+    class InvalidArgumentError < Error
+    end
+
+    class DeadlineExceededError < Error
+    end
+
+    class NotFoundError < Error
+    end
+
+    class AlreadyExistsError < Error
+    end
+
+    class PermissionDeniedError < Error
+    end
+
+    class ResourceExhaustedError < Error
+    end
+
+    class FailedPreconditionError < Error
+    end
+
+    class AbortedError < Error
+    end
+
+    class OutOfRangeError < Error
+    end
+
+    class UnimplementedError < Error
+    end
+
+    class InternalError < Error
+    end
+
+    class DataLossError < Error
+    end
+
+    class UnauthenticatedError < Error
+    end
+  end
+end

--- a/gems/google-cloud-errors/1.5/manifest.yaml
+++ b/gems/google-cloud-errors/1.5/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname


### PR DESCRIPTION
I add google-cloud-errors rbs

c.f.

* https://rubygems.org/gems/google-cloud-errors
* https://github.com/googleapis/google-cloud-ruby/blob/google-cloud-errors/v1.5.0/google-cloud-errors/lib/google/cloud/errors.rb