### PR TITLE
Fix type signature for `ActiveRecord::Base.validate` (to match official Ruby documentation)

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -49,7 +49,7 @@ module ActiveRecord
     def self.transaction: [T] (?requires_new: boolish, ?isolation: (:read_uncommitted | :read_committed | :repeatable_read | :serializable)?, ?joinable: boolish) { () -> T } -> T
     def self.create: (**untyped) -> instance
     def self.create!: (**untyped) -> instance
-    def self.validate: (*untyped, ?if: condition[instance], ?unless: condition[instance], **untyped) -> void
+    def self.validate: (*untyped, ?if: condition[instance] | Array[condition[instance]], ?unless: condition[instance] | Array[condition[instance]], **untyped) -> void
     def self.validates: (*untyped, ?if: condition[instance], ?unless: condition[instance], **untyped) -> void
 
     # callbacks


### PR DESCRIPTION
According to https://guides.rubyonrails.org/v6.0/active_record_validations.html#combining-validation-conditions

the official documentation says you can have
`if: [Proc.new { |c| c.market.retail? }, :desktop?],`
so, RBS signatures should reflect that.