### PR TITLE
climate_control: Add RBS for climate_control

### DIFF
--- a/gems/climate_control/.rubocop.yml
+++ b/gems/climate_control/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/climate_control/1.2/_test/metadata.yaml
+++ b/gems/climate_control/1.2/_test/metadata.yaml
@@ -1,0 +1,4 @@
+# If the test needs gem's RBS files, declare them here.
+#
+# additional_gems:
+#   - GEM_NAME

--- a/gems/climate_control/1.2/_test/test.rb
+++ b/gems/climate_control/1.2/_test/test.rb
@@ -1,0 +1,11 @@
+require "climate_control"
+
+a = ClimateControl.modify(ABC: "abc", MY_VAR1: "var1", EDITOR: nil) do
+  "#{ENV['ABC']} #{ENV['MY_VAR1']}"
+end
+a.upcase
+
+xs = ClimateControl.unsafe_modify(XYZ: nil, MY_VAR2: "var2") do
+  [ENV["MY_VAR2"]]
+end
+xs.detect { |x| x == "var1" }

--- a/gems/climate_control/1.2/climate_control.rbs
+++ b/gems/climate_control/1.2/climate_control.rbs
@@ -1,0 +1,4 @@
+module ClimateControl
+  def self.modify: [T] (?Hash[_ToS, String?] environment_overrides) { () -> T } -> T
+  def self.unsafe_modify: [T] (?Hash[_ToS, String?] environment_overrides) { () -> T } -> T
+end

--- a/gems/climate_control/1.2/manifest.yaml
+++ b/gems/climate_control/1.2/manifest.yaml
@@ -1,0 +1,7 @@
+# manifest.yaml describes dependencies which do not appear in the gemspec.
+# If this gem includes such dependencies, comment-out the following lines and
+# declare the dependencies.
+# If all dependencies appear in the gemspec, you should remove this file.
+#
+# dependencies:
+#   - name: pathname

--- a/gems/climate_control/_reviewers.yaml
+++ b/gems/climate_control/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - yykamei


### PR DESCRIPTION
Climate Control allows temporary modification of environment variables within a block.

https://github.com/thoughtbot/climate_control

This patch adds RBS for the methods written in the README of Climate Control.