### PR TITLE
devise: Add support for authentication_keys

### DIFF
--- a/gems/devise/4.9/_test/test.rb
+++ b/gems/devise/4.9/_test/test.rb
@@ -7,5 +7,6 @@ end
 class User < ActiveRecord::Base
   devise :database_authenticatable, :omniauthable, :confirmable,
          :recoverable, :registerable, :rememberable,
-         :trackable, :timeoutable, :validatable, :lockable
+         :trackable, :timeoutable, :validatable, :lockable,
+         authentication_keys: [:email]
 end

--- a/gems/devise/4.9/devise.rbs
+++ b/gems/devise/4.9/devise.rbs
@@ -11,7 +11,7 @@ end
 module Devise
   module Models
     interface _DeviseClassMethod
-      def devise: (*::Symbol) -> void
+      def devise: (*(::Symbol | ::Hash[::Symbol, untyped])) -> void
     end
 
     module DatabaseAuthenticatable


### PR DESCRIPTION
- Add support devise method `authentication_keys` to allow customization of the keys used for authentication.