### PR TITLE
graphql: Add types for GraphQL::ExecutionError#initialize

### DIFF
--- a/gems/graphql/1.12/_test/test.rb
+++ b/gems/graphql/1.12/_test/test.rb
@@ -55,6 +55,11 @@ module Types
     field :article, String, null: false do
       argument :id, ID, required: true
     end
+
+    field :error_field, String, null: false
+    def error_field
+      raise GraphQL::ExecutionError.new("Test error message", ast_node: nil, options: { "custom" => "option" }, extensions: { "code" => "TEST_ERROR" })
+    end
   end
 end
 

--- a/gems/graphql/1.12/_test/test.rb
+++ b/gems/graphql/1.12/_test/test.rb
@@ -58,7 +58,7 @@ module Types
 
     field :error_field, String, null: false
     def error_field
-      raise GraphQL::ExecutionError.new("Test error message", ast_node: nil, options: { "custom" => "option" }, extensions: { "code" => "TEST_ERROR" })
+      raise GraphQL::ExecutionError.new("Test error message", ast_node: nil, extensions: { "code" => "TEST_ERROR" })
     end
   end
 end

--- a/gems/graphql/1.12/_test/test.rbs
+++ b/gems/graphql/1.12/_test/test.rbs
@@ -52,6 +52,8 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
 
     def ping: -> untyped
+
+    def error_field: -> untyped
   end
 end
 

--- a/gems/graphql/1.12/graphql.rbs
+++ b/gems/graphql/1.12/graphql.rbs
@@ -191,7 +191,7 @@ module GraphQL
   class Error < StandardError
   end
   class ExecutionError < Error
-    def initialize: (String message, ?ast_node: untyped, ?options: Hash[untyped, untyped]?, ?extensions: Hash[untyped, untyped]?) -> void
+    def initialize: (String message, ?ast_node: untyped, ?extensions: Hash[untyped, untyped]?) -> void
     def to_h: () -> Hash[String, untyped]
   end
   class RequiredImplementationMissingError < Error

--- a/gems/graphql/1.12/graphql.rbs
+++ b/gems/graphql/1.12/graphql.rbs
@@ -191,6 +191,7 @@ module GraphQL
   class Error < StandardError
   end
   class ExecutionError < Error
+    def initialize: (String message, ?ast_node: untyped, ?options: Hash[untyped, untyped]?, ?extensions: Hash[untyped, untyped]?) -> void
     def to_h: () -> Hash[String, untyped]
   end
   class RequiredImplementationMissingError < Error


### PR DESCRIPTION
Add type definitions for `GraphQL::ExecutionError#initialize` method.

The `GraphQL::ExecutionError` class accepts optional parameters for `ast_node`, ~`options`~, and `extensions`.

References:
- https://graphql-ruby.org/api-doc/1.12.0/GraphQL/ExecutionError.html#initialize-instance_method
- https://github.com/rmosolgo/graphql-ruby/blob/v1.12.0/lib/graphql/execution_error.rb