### PR TITLE
parser: Add types for Parser::Source

### DIFF
--- a/gems/parser/3.2/_test/test.rb
+++ b/gems/parser/3.2/_test/test.rb
@@ -2,9 +2,31 @@
 # It is type checked by `steep check` command.
 
 require "parser"
+require "parser/current"
 
 node = Parser::CurrentRuby.parse("2 + 2") or raise
 node.loc
 
 buffer = Parser::Source::Buffer.new(__FILE__)
 buffer.name
+
+node, comments = Parser::CurrentRuby.parse_with_comments(<<SOURCE)
+# comment
+2 + 2
+SOURCE
+node.location.node unless node.nil?
+comments.first.text
+range = comments.first.location.expression
+range.source_buffer
+range.begin_pos
+range.end_pos
+range.size
+range.length
+range.line
+range.first_line
+range.column
+range.last_line
+range.last_column
+range.column_range
+range.source_line
+range.source

--- a/gems/parser/3.2/parser.rbs
+++ b/gems/parser/3.2/parser.rbs
@@ -3,6 +3,7 @@ module Parser
 
   class Base < Racc::Parser
     def parse: (String string, ?String file, ?Integer line) -> Parser::AST::Node?
+    def parse_with_comments: (String string, ?String file, ?Integer line) -> [Parser::AST::Node?, Array[Source::Comment]]
   end
 
   class Ruby18 < Base
@@ -43,6 +44,19 @@ module Parser
 
   module Source
     class Range
+      attr_reader source_buffer: Buffer
+      attr_reader begin_pos: Integer
+      attr_reader end_pos: Integer
+      def size: () -> Integer
+      alias length size
+      def line: () -> Integer
+      alias first_line line
+      def column: () -> Integer
+      def last_line: () -> Integer
+      def last_column: () -> Integer
+      def column_range: () -> ::Range[Integer]
+      def source_line: () -> String
+      def source: () -> String
     end
 
     ##
@@ -88,6 +102,8 @@ module Parser
     end
 
     class Map
+      attr_reader node: AST::Node | nil
+      attr_reader expression: Range
       def line: () -> Integer
       def first_line: () -> Integer
       def last_line: () -> Integer
@@ -97,7 +113,8 @@ module Parser
     end
 
     class Comment
-      def location: () -> Map
+      attr_reader text: String
+      attr_reader location: Map
       alias loc location
     end
   end


### PR DESCRIPTION
- Add `#text` to `Parser::Source::Comment` class
- Add `#node` and `#expression` to `Parser::Source::Map` class
- Add some methods to `Parser::Source::Range`
- Write tests for the added methods
    - Add `#parse_with_comments` to `Parser::Base` class