### PR TITLE
rubocop-ast: Add types for rubocop ast

### DIFF
--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -15,5 +15,9 @@ module RuboCop
     class Node < Parser::AST::Node
       def source: () -> (String | nil)
     end
+
+    class ArrayNode < Node
+      alias values children
+    end
   end
 end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -12,7 +12,7 @@ module RuboCop
       end
     end
 
-    class Node
+    class Node < Parser::AST::Node
       def source: () -> (String | nil)
     end
   end


### PR DESCRIPTION
- RuboCop::AST::Node inherits from Parser::AST::Node
- Add RuboCop::AST::ArrayNode to rubocop-ast