### PR TITLE
Addresses sample code from the rubocop-ast docs

### DIFF
--- a/gems/parser/3.2/parser.rbs
+++ b/gems/parser/3.2/parser.rbs
@@ -40,6 +40,14 @@ module Parser
       attr_reader location: Source::Map
       alias loc location
     end
+
+    class Processor
+      module Mixin
+        def process: (Node? node) ->  Node?
+      end
+
+      include Mixin
+    end
   end
 
   module Source

--- a/gems/parser/_reviewers.yaml
+++ b/gems/parser/_reviewers.yaml
@@ -1,2 +1,3 @@
 reviewers:
   - pocke
+  - kozy4324

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -11,7 +11,40 @@ class MyRule < Parser::AST::Processor
   end
 
   def on_if(node)
-    puts "I found a if! #{node.if?}"
+    node.if?
+    node.if_branch
+    node.else_branch
+    node.elsif_conditional?
+    node.if?
+    node.unless?
+    node.elsif?
+    node.else?
+    node.ternary?
+    node.keyword
+    node.inverse_keyword
+    node.modifier_form?
+    node.nested_conditional?
+    node.elsif_conditional?
+    node.if_branch
+    node.else_branch
+    node.node_parts
+    node.branches
+  end
+
+  def on_hash(node)
+    node.pairs
+    node.empty?
+    node.each_pair {|k, v| puts "#{k}#{v}" }
+    node.each_pair
+    node.keys
+    node.each_key {|n| n }
+    node.each_key
+    node.values
+    node.each_value {|n| n }
+    node.each_value
+    node.pairs_on_same_line?
+    node.mixed_delimiters?
+    node.braces?
   end
 end
 
@@ -24,3 +57,5 @@ ast.each_node { |n| rule.process(n) }
 ast.each_node(:sym) { |n| rule.process(n) }
 ast.each_node(:sym, :if) { |n| rule.process(n) }
 ast.each_node.each {}.each_node
+
+{ this_is: :hash }

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -2,3 +2,25 @@
 # It is type checked by `steep check` command.
 
 require "rubocop-ast"
+
+class MyRule < Parser::AST::Processor
+  include RuboCop::AST::Traversal
+
+  def on_sym(node)
+    puts "I found a symbol! #{node.value}"
+  end
+
+  def on_if(node)
+    puts "I found a if! #{node.if?}"
+  end
+end
+
+code = File.read(__FILE__)
+source = RuboCop::AST::ProcessedSource.new(code, 2.7)
+rule = MyRule.new
+ast = source.ast
+exit if ast.nil?
+ast.each_node { |n| rule.process(n) }
+ast.each_node(:sym) { |n| rule.process(n) }
+ast.each_node(:sym, :if) { |n| rule.process(n) }
+ast.each_node.each {}.each_node

--- a/gems/rubocop-ast/1.30/_test/test.rbs
+++ b/gems/rubocop-ast/1.30/_test/test.rbs
@@ -1,0 +1,16 @@
+module Parser
+  module AST
+    class Processor
+      module Mixin
+        def process: (Node? node) ->  Node?
+      end
+      include Mixin
+    end
+  end
+end
+
+class MyRule < Parser::AST::Processor
+  include RuboCop::AST::Traversal
+  def on_sym: (RuboCop::AST::SymbolNode node) -> void
+  def on_if: (RuboCop::AST::IfNode node) -> void
+end

--- a/gems/rubocop-ast/1.30/_test/test.rbs
+++ b/gems/rubocop-ast/1.30/_test/test.rbs
@@ -1,14 +1,3 @@
-module Parser
-  module AST
-    class Processor
-      module Mixin
-        def process: (Node? node) ->  Node?
-      end
-      include Mixin
-    end
-  end
-end
-
 class MyRule < Parser::AST::Processor
   include RuboCop::AST::Traversal
   def on_sym: (RuboCop::AST::SymbolNode node) -> void

--- a/gems/rubocop-ast/1.30/_test/test.rbs
+++ b/gems/rubocop-ast/1.30/_test/test.rbs
@@ -13,4 +13,5 @@ class MyRule < Parser::AST::Processor
   include RuboCop::AST::Traversal
   def on_sym: (RuboCop::AST::SymbolNode node) -> void
   def on_if: (RuboCop::AST::IfNode node) -> void
+  def on_hash: (RuboCop::AST::HashNode node) -> void
 end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -1,6 +1,7 @@
 module RuboCop
   module AST
     class ProcessedSource
+      def initialize: (String source, Float ruby_version, ?path?) -> untyped
       def raw_source: () -> String
       def buffer: () -> Parser::Source::Buffer
       def comments: () -> Array[Parser::Source::Comment]
@@ -15,6 +16,15 @@ module RuboCop
 
     module Descendence
       def child_nodes: () -> Array[Node]
+      def each_node: (*Symbol types) { (Node) -> void } -> void
+                   | () -> ::Enumerator[Node, self]
+    end
+
+    module Traversal
+    end
+
+    module BasicLiteralNode
+      def value: () -> untyped
     end
 
     class Node < Parser::AST::Node
@@ -34,6 +44,14 @@ module RuboCop
       def body: () -> Node
       def receiver: () -> (Node | nil)
       def endless?: () -> bool
+    end
+
+    class IfNode < Node
+      def if?: () -> bool
+    end
+
+    class SymbolNode < Node
+      include BasicLiteralNode
     end
   end
 end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -54,13 +54,13 @@ module RuboCop
     class HashNode < Node
       def pairs: () -> Array[PairNode]
       def empty?: () -> bool
-      def each_pair: { (Node, Node) -> void } -> self
+      def each_pair: () { (Node, Node) -> void } -> self
                    | () -> ::Enumerator[PairNode, self]
       def keys: () -> Array[Node]
-      def each_key: { (Node) -> void } -> self
+      def each_key: () { (Node) -> void } -> self
                   | () -> ::Enumerator[Node, self]
       def values: () -> Array[Node]
-      def each_value: { (Node) -> void } -> self
+      def each_value: () { (Node) -> void } -> self
                     | () -> ::Enumerator[Node, self]
       def pairs_on_same_line?: () -> bool
       def mixed_delimiters?: () -> bool

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -20,6 +20,11 @@ module RuboCop
                    | () -> ::Enumerator[Node, self]
     end
 
+    module HashElementNode
+      def key: () -> Node
+      def value: () -> Node
+    end
+
     module Traversal
     end
 
@@ -46,8 +51,41 @@ module RuboCop
       def endless?: () -> bool
     end
 
+    class HashNode < Node
+      def pairs: () -> Array[PairNode]
+      def empty?: () -> bool
+      def each_pair: { (Node, Node) -> void } -> self
+                   | () -> ::Enumerator[PairNode, self]
+      def keys: () -> Array[Node]
+      def each_key: { (Node) -> void } -> self
+                  | () -> ::Enumerator[Node, self]
+      def values: () -> Array[Node]
+      def each_value: { (Node) -> void } -> self
+                    | () -> ::Enumerator[Node, self]
+      def pairs_on_same_line?: () -> bool
+      def mixed_delimiters?: () -> bool
+      def braces?: () -> bool
+    end
+
     class IfNode < Node
       def if?: () -> bool
+      def unless?: () -> bool
+      def elsif?: () -> bool
+      def else?: () -> bool
+      def ternary?: () -> bool
+      def keyword: () -> String
+      def inverse_keyword: () -> String
+      def modifier_form?: () -> bool
+      def nested_conditional?: () -> bool
+      def elsif_conditional?: () -> bool
+      def if_branch: () -> Node?
+      def else_branch: () -> Node?
+      def node_parts: () -> Array[Node]
+      def branches: () -> Array[Node]
+    end
+
+    class PairNode < Node
+      include HashElementNode
     end
 
     class SymbolNode < Node

--- a/gems/rubocop-ast/_reviewers.yaml
+++ b/gems/rubocop-ast/_reviewers.yaml
@@ -1,3 +1,2 @@
 reviewers:
-  - pocke
   - kozy4324

--- a/gems/rubocop/_reviewers.yaml
+++ b/gems/rubocop/_reviewers.yaml
@@ -1,3 +1,2 @@
 reviewers:
-  - pocke
   - kozy4324


### PR DESCRIPTION
This PR addresses sample code from: https://docs.rubocop.org/rubocop-ast/

- Adds `Parser::AST::Processor` to the parser gem
- Adds type definitions to `RuboCop::AST`
- Adds `tests` for rubocop-ast
- Add kozy4324 to the _reviewers.yaml files