### PR TITLE
actioncontroller: fix render_to_string method signature

### DIFF
--- a/gems/actionpack/6.0/actioncontroller.rbs
+++ b/gems/actionpack/6.0/actioncontroller.rbs
@@ -255,6 +255,12 @@ module AbstractController
   end
 end
 
+module AbstractController
+  module Rendering
+    def render_to_string: (*untyped args) ?{ () -> untyped } -> ::String
+  end
+end
+
 module ActionController
   module Caching
     extend AbstractController::Caching::ClassMethods
@@ -274,5 +280,11 @@ module ActionController
   class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
     def fetch: (untyped key) ?{ () -> untyped } -> untyped
              | (untyped key, untyped args) -> untyped
+  end
+end
+
+module ActionController
+  module Rendering
+    def render_to_string: (*untyped args) ?{ () -> untyped } -> ::String
   end
 end

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -511,18 +511,6 @@ module AbstractController
     # sticks the result in <tt>self.response_body</tt>.
     def render: (*untyped args) { () -> untyped } -> untyped
 
-    # Raw rendering of a template to a string.
-    #
-    # It is similar to render, except that it does not
-    # set the +response_body+ and it should be guaranteed
-    # to always return a string.
-    #
-    # If a component extends the semantics of +response_body+
-    # (as ActionController extends it to be anything that
-    # responds to the method each), this method needs to be
-    # overridden in order to still return a string.
-    def render_to_string: (*untyped args) { () -> untyped } -> untyped
-
     # Performs the actual template rendering.
     def render_to_body: (?::Hash[untyped, untyped] options) -> nil
 
@@ -2747,9 +2735,6 @@ module ActionController
     def process_action: () -> untyped
 
     def render: (*untyped args) -> untyped
-
-    # Overwrite render_to_string because body can now be set to a Rack body.
-    def render_to_string: () -> untyped
 
     def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
 

--- a/gems/actionpack/7.2/_test/test.rb
+++ b/gems/actionpack/7.2/_test/test.rb
@@ -5,3 +5,5 @@ end
 class BarController < ActionController::Base
   allow_browser versions: { safari: 17.5, chrome: 127, ie: false }, block: -> { head :not_acceptable }
 end
+
+ActionController::Base.new.render_to_string(template: 'foo', locals: { bar: 'baz' })

--- a/gems/actionpack/7.2/actioncontroller.rbs
+++ b/gems/actionpack/7.2/actioncontroller.rbs
@@ -255,6 +255,12 @@ module AbstractController
   end
 end
 
+module AbstractController
+  module Rendering
+    def render_to_string: (*untyped args) ?{ () -> untyped } -> ::String
+  end
+end
+
 module ActionController
   module Caching
     extend AbstractController::Caching::ClassMethods
@@ -274,5 +280,11 @@ module ActionController
   class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
     def fetch: (untyped key) ?{ () -> untyped } -> untyped
              | (untyped key, untyped args) -> untyped
+  end
+end
+
+module ActionController
+  module Rendering
+    def render_to_string: (*untyped args) ?{ () -> untyped } -> ::String
   end
 end

--- a/gems/actionpack/7.2/actionpack-generated.rbs
+++ b/gems/actionpack/7.2/actionpack-generated.rbs
@@ -511,18 +511,6 @@ module AbstractController
     # sticks the result in <tt>self.response_body</tt>.
     def render: (*untyped args) { () -> untyped } -> untyped
 
-    # Raw rendering of a template to a string.
-    #
-    # It is similar to render, except that it does not
-    # set the +response_body+ and it should be guaranteed
-    # to always return a string.
-    #
-    # If a component extends the semantics of +response_body+
-    # (as ActionController extends it to be anything that
-    # responds to the method each), this method needs to be
-    # overridden in order to still return a string.
-    def render_to_string: (*untyped args) { () -> untyped } -> untyped
-
     # Performs the actual template rendering.
     def render_to_body: (?::Hash[untyped, untyped] options) -> nil
 
@@ -2747,9 +2735,6 @@ module ActionController
     def process_action: () -> untyped
 
     def render: (*untyped args) -> untyped
-
-    # Overwrite render_to_string because body can now be set to a Rack body.
-    def render_to_string: () -> untyped
 
     def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
 


### PR DESCRIPTION
Arguments can be passed, and the block is optional.