### PR TITLE
Fix ActiveRecord read_attribute type

### DIFF
--- a/gems/activerecord/7.2/_test/activerecord-7.2.rb
+++ b/gems/activerecord/7.2/_test/activerecord-7.2.rb
@@ -72,6 +72,9 @@ module Test
   user.strict_loading!(false, mode: :n_plus_one_only)
   user.strict_loading?
   user.previously_persisted?
+  user.read_attribute(:name)
+  user.read_attribute("name")
+  user.read_attribute(:name) {}
 
   user = User.new
   user.normalize_attribute(:email)

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -66,6 +66,19 @@ module ActiveRecord
     end
   end
 
+  module AttributeMethods
+    module Read
+      # Returns the value of the attribute identified by <tt>attr_name</tt> after
+      # it has been typecast (for example, "2004-12-12" in a date column is cast
+      # to a date object, like Date.new(2004, 12, 12)).
+      def read_attribute: (untyped attr_name) ?{ () -> untyped } -> untyped
+
+      def _read_attribute: (untyped attr_name) ?{ () -> untyped } -> untyped
+
+      alias attribute _read_attribute
+    end
+  end
+
   module Encryption
     module EncryptableRecord
       module ClassMethods

--- a/gems/activerecord/7.2/activerecord-generated.rbs
+++ b/gems/activerecord/7.2/activerecord-generated.rbs
@@ -4314,15 +4314,6 @@ module ActiveRecord
 
         def define_method_attribute: (untyped name) -> untyped
       end
-
-      # Returns the value of the attribute identified by <tt>attr_name</tt> after
-      # it has been typecast (for example, "2004-12-12" in a date column is cast
-      # to a date object, like Date.new(2004, 12, 12)).
-      def read_attribute: (untyped attr_name) { () -> untyped } -> untyped
-
-      def _read_attribute: (untyped attr_name) { () -> untyped } -> untyped
-
-      alias attribute _read_attribute
     end
   end
 end

--- a/gems/activerecord/8.0/_test/activerecord-8.0.rb
+++ b/gems/activerecord/8.0/_test/activerecord-8.0.rb
@@ -72,6 +72,9 @@ module Test
   user.strict_loading!(false, mode: :n_plus_one_only)
   user.strict_loading?
   user.previously_persisted?
+  user.read_attribute(:name)
+  user.read_attribute("name")
+  user.read_attribute(:name) {}
 
   user = User.new
   user.normalize_attribute(:email)

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -66,6 +66,19 @@ module ActiveRecord
     end
   end
 
+  module AttributeMethods
+    module Read
+      # Returns the value of the attribute identified by <tt>attr_name</tt> after
+      # it has been typecast (for example, "2004-12-12" in a date column is cast
+      # to a date object, like Date.new(2004, 12, 12)).
+      def read_attribute: (untyped attr_name) ?{ () -> untyped } -> untyped
+
+      def _read_attribute: (untyped attr_name) ?{ () -> untyped } -> untyped
+
+      alias attribute _read_attribute
+    end
+  end
+
   module Encryption
     module EncryptableRecord
       module ClassMethods

--- a/gems/activerecord/8.0/activerecord-generated.rbs
+++ b/gems/activerecord/8.0/activerecord-generated.rbs
@@ -4314,15 +4314,6 @@ module ActiveRecord
 
         def define_method_attribute: (untyped name) -> untyped
       end
-
-      # Returns the value of the attribute identified by <tt>attr_name</tt> after
-      # it has been typecast (for example, "2004-12-12" in a date column is cast
-      # to a date object, like Date.new(2004, 12, 12)).
-      def read_attribute: (untyped attr_name) { () -> untyped } -> untyped
-
-      def _read_attribute: (untyped attr_name) { () -> untyped } -> untyped
-
-      alias attribute _read_attribute
     end
   end
 end


### PR DESCRIPTION
## Overview
When calling the `read_attribute` in ActiveRecord, `The method cannot be called without a block` error occurs.

```
activerecord-generated.rb:37:5: [error] The method cannot be called without a block
│ Diagnostic ID: Ruby::RequiredBlockMissing
│
└ user.read_attribute(:name)
```

The block argument was required by the current type definition, so I made it optional.

## References
- read_attribute
  - https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Read.html