### PR TITLE
rqrcode: Fix type definition for RQRCode::QRCode#initialize

### DIFF
--- a/gems/rqrcode/2.2/_test/test.rb
+++ b/gems/rqrcode/2.2/_test/test.rb
@@ -3,7 +3,7 @@
 
 require "rqrcode"
 
-qr = RQRCode::QRCode.new("https://kyan.com")
+qr = RQRCode::QRCode.new("https://kyan.com", level: :h)
 
 puts qr.to_s
 

--- a/gems/rqrcode/2.2/rqrcode.rbs
+++ b/gems/rqrcode/2.2/rqrcode.rbs
@@ -4,7 +4,7 @@ module RQRCode
     type mode = :number | :alphanumeric | :byte_8bit | :kanji
     type segment = { data: String, mode: mode }
 
-    def initialize: (String) -> void
+    def initialize: (String, *untyped) -> void
     def as_svg: (?offset: Integer, ?fill: String | :white | :currentColor, ?color: String | :black | :currentColor, ?module_size: Integer, ?shape_rendering: "auto" | "optimizeSpeed" | "crispEdges" | "geometricPrecision", ?standalone: bool, ?use_path: bool, ?viewbox: bool, ?svg_attributes: Hash[untyped, untyped]) -> String
     def as_png: (?fill: untyped, ?color: untyped, ?size: Integer, ?border_modules: Integer, ?module_px_size: Integer, ?border: Integer, ?resize_exactly_to: bool, ?resize_gte_to: bool) -> ChunkyPNG::Image
               | (file: untyped, ?fill: untyped, ?color: untyped, ?color_mode: Integer, ?bit_depth: Integer, ?interlace: bool, ?compression: untyped, ?size: Integer, ?border_modules: Integer, ?module_px_size: Integer, ?border: Integer, ?resize_exactly_to: bool, ?resize_gte_to: bool) -> ChunkyPNG::Image


### PR DESCRIPTION
The `RQRCode::QRCode#initialize` method accepts a string as the first parameter and additional optional arguments.

References:
- https://www.rubydoc.info/gems/rqrcode/2.2.0/RQRCode/QRCode#initialize-instance_method
- https://github.com/whomwah/rqrcode/blob/v2.2.0/lib/rqrcode/qrcode/qrcode.rb