### PR TITLE
rubocop-ast: Fix type definition on RuboCop::AST::Node#each_ancestor

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -205,7 +205,9 @@ node&.itblock_type?
 
 node&.parent
 node&.each_ancestor { |node| node.send_type? }
+node&.each_ancestor(:send) { |node| node.send_type? }
 node&.each_ancestor&.each { |node| node.send_type? }&.send_type?
+node&.each_ancestor(:send)&.each { |node| node.send_type? }&.send_type?
 node&.source_range
 
 def_node = RuboCop::AST::ProcessedSource.new('def hoge(a, b); end', RUBY_VERSION.to_f).ast

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -188,7 +188,7 @@ module RuboCop
       def send_type?: () -> bool
       def parent: () -> Node?
       def each_ancestor: (*Symbol types) { (Node) -> void } -> self
-                       | () -> ::Enumerator[Node, self]
+                       | (*Symbol types) -> ::Enumerator[Node, self]
       def source_range: () -> Parser::Source::Range
     end
 


### PR DESCRIPTION
Fixes type definition on `RuboCop::AST::Node#each_ancestor`