### PR TITLE
rubocop-ast: Add types for rubocop-ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -215,3 +215,6 @@ def_node.first_argument if def_node.is_a?(RuboCop::AST::DefNode)
 
 send_node = RuboCop::AST::ProcessedSource.new('1 + 2', RUBY_VERSION.to_f).ast
 send_node&.first_argument if send_node.is_a?(RuboCop::AST::SendNode)
+
+block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast
+block_node.send_node if block_node.is_a?(RuboCop::AST::BlockNode)

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -196,6 +196,10 @@ module RuboCop
       alias values children
     end
 
+    class BlockNode < Node
+      def send_node: () -> SendNode
+    end
+
     class DefNode < Node
       include ParameterizedNode
       def void_context?: () -> bool


### PR DESCRIPTION
Added types for `rubocop-ast`

- `RuboCop::AST::BlockNode`