### PR TITLE
rubocop-ast: Add types for rubocop-ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -217,4 +217,4 @@ send_node = RuboCop::AST::ProcessedSource.new('1 + 2', RUBY_VERSION.to_f).ast
 send_node&.first_argument if send_node.is_a?(RuboCop::AST::SendNode)
 
 block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast
-block_node.send_node if block_node.is_a?(RuboCop::AST::BlockNode)
+block_node.send_node.method?(:tap) if block_node.is_a?(RuboCop::AST::BlockNode)

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -32,6 +32,14 @@ module RuboCop
       def value: () -> Node
     end
 
+    module MethodDispatchNode
+      include MethodIdentifierPredicates
+    end
+
+    module MethodIdentifierPredicates
+      def method?: ((Symbol | String) name) -> bool
+    end
+
     module ParameterizedNode
       def first_argument: () -> Node?
       module RestArguments
@@ -250,6 +258,7 @@ module RuboCop
 
     class SendNode < Node
       include ParameterizedNode::RestArguments
+      include MethodDispatchNode
     end
 
     class SymbolNode < Node


### PR DESCRIPTION
Added types for `rubocop-ast`

- `RuboCop::AST::SendNode`
- `RuboCop::AST::MethodDispatchNode `
- `RuboCop::AST::MethodIdentifierPredicates `