### PR TITLE
rubocop-ast: Add types for rubocop-ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -236,3 +236,15 @@ end
 
 block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast
 block_node.send_node.method?(:tap) if block_node.is_a?(RuboCop::AST::BlockNode)
+
+str_node = RuboCop::AST::ProcessedSource.new('"str"', RUBY_VERSION.to_f).ast
+str_node.value if str_node.is_a?(RuboCop::AST::StrNode)
+
+dstr_node = RuboCop::AST::ProcessedSource.new('"dstr#{123}dstr"', RUBY_VERSION.to_f).ast
+dstr_node.value if dstr_node.is_a?(RuboCop::AST::DstrNode)
+
+sym_node = RuboCop::AST::ProcessedSource.new(':sym', RUBY_VERSION.to_f).ast
+sym_node.value if sym_node.is_a?(RuboCop::AST::SymbolNode)
+
+regexp_node = RuboCop::AST::ProcessedSource.new('/abc/', RUBY_VERSION.to_f).ast
+regexp_node.to_regexp if regexp_node.is_a?(RuboCop::AST::RegexpNode)

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -226,6 +226,10 @@ module RuboCop
       def endless?: () -> bool
     end
 
+    class DstrNode < Node
+      def value: () -> String
+    end
+
     class HashNode < Node
       def pairs: () -> Array[PairNode]
       def empty?: () -> bool
@@ -263,13 +267,23 @@ module RuboCop
       include HashElementNode
     end
 
+    class RegexpNode < Node
+      def to_regexp: () -> ::Regexp
+    end
+
     class SendNode < Node
       include ParameterizedNode::RestArguments
       include MethodDispatchNode
     end
 
+    class StrNode < Node
+      include BasicLiteralNode
+      def value: () -> String
+    end
+
     class SymbolNode < Node
       include BasicLiteralNode
+      def value: () -> Symbol
     end
   end
 end


### PR DESCRIPTION
- Add
    - `RuboCop::AST::StrNode`
    - `RuboCop::AST::DstrNode`
    - `RuboCop::AST::RegexpNode`
- Add(test only)
    - `RuboCop::AST::SymbolNode`
