### PR TITLE
activerecord: Add types for `from` to ActiveRecord ClassMethods

### DIFF
--- a/gems/activerecord/7.2/_test/activerecord-7.2.rb
+++ b/gems/activerecord/7.2/_test/activerecord-7.2.rb
@@ -54,6 +54,8 @@ module Test
   User.sole.id
   User.all.sole.id
   User.take.articles.sole.id
+  User.from('users AS users')
+  User.from(User.where(:active), :u)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -13,6 +13,7 @@ module ActiveRecord
       def and: (::ActiveRecord::Relation) -> Relation
       def strict_loading: (?bool value) -> Relation
       def sole: () -> Model
+      def from: (untyped value, ?untyped? subquery_name) -> untyped
     end
   end
 

--- a/gems/activerecord/8.0/_test/activerecord-8.0.rb
+++ b/gems/activerecord/8.0/_test/activerecord-8.0.rb
@@ -54,6 +54,8 @@ module Test
   User.sole.id
   User.all.sole.id
   User.take.articles.sole.id
+  User.from('users AS users')
+  User.from(User.where(:active), :u)
   user = User.new(secret: 'dummy', key: 'dummy', token: 'dummy', phrase: 'dummy')
   user.encrypt
   user.encrypted_attribute?(:secret)

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -13,6 +13,7 @@ module ActiveRecord
       def and: (::ActiveRecord::Relation) -> Relation
       def strict_loading: (?bool value) -> Relation
       def sole: () -> Model
+      def from: (untyped value, ?untyped? subquery_name) -> untyped
     end
   end
 


### PR DESCRIPTION
Currently, the `from` method is defined for the `ActiveRecord::QueryMethods` class, but not for the class method of the ActiveRecord type.

Therefore, `User.from(something)` is a type error.

However, `from` is actually used to chain model classes to retrieve records.

The related file in `rails/rails` has a comment about this. See the link below.

ref. https://github.com/rails/rails/blob/a11f0a63673d274c59c69c2688c63ba303b86193/activerecord/lib/active_record/relation/query_methods.rb#L1359-L1368