### PR TITLE
[actiontext] Unify maintenance systems

### DIFF
--- a/gems/actiontext/.rubocop.yml
+++ b/gems/actiontext/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from: ../../.rubocop.yml
+
+RBS/Layout:
+  Enabled: true
+RBS/Lint:
+  Enabled: true
+RBS/Style:
+  Enabled: true

--- a/gems/actiontext/README.md
+++ b/gems/actiontext/README.md
@@ -1,0 +1,29 @@
+Maintenance policy for RBS of Rails
+===
+
+We basically only accept changes for the versions listed under the **"List of currently supported releases"** in the [Rails' maintenance policy](https://rubyonrails.org/maintenance).
+Or support the last version maintained in this repository.
+
+Versions outside of that are generally not accepted for changes. We do not run tests for them, nor do we include them in format detection.
+
+This is a measure to reduce maintenance costs.
+
+If you have any questions, please contact the maintainers. Refer to `_reviewers.yaml` for the list of maintainers.
+
+## Target gems
+
+- actioncable
+- actionmailer
+- actionpack
+- actiontext
+- actionview
+- activejob
+- activemodel
+- activerecord
+- activestorage
+- activesupport
+- railties
+
+## See also
+
+https://github.com/ruby/gem_rbs_collection/issues/788

--- a/gems/actiontext/_reviewers.yaml
+++ b/gems/actiontext/_reviewers.yaml
@@ -1,2 +1,3 @@
 reviewers:
   - tk0miya
+  - ksss


### PR DESCRIPTION
We have established a maintenance policy for the Rails gem.
https://github.com/ruby/gem_rbs_collection/issues/788

In order to unify the system, I propose the following
- Add me as a reviewer.
- Put up a maintenance policy as a README.
- Unify RBS format by rubocop.