### PR TITLE
[rails] Drop mutex_m

### DIFF
--- a/gems/actionmailer/7.0/manifest.yaml
+++ b/gems/actionmailer/7.0/manifest.yaml
@@ -8,7 +8,6 @@ dependencies:
   - name: date
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time
   - name: tsort

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -2430,9 +2430,6 @@ module ActionController
     EXCLUDE_PARAMETERS: ::Array[untyped]
 
     class Options
-      # :nodoc:
-      include Mutex_m
-
       def self.from_hash: (untyped hash) -> untyped
 
       def initialize: (untyped name, untyped format, untyped `include`, untyped exclude, untyped klass, untyped model) -> untyped

--- a/gems/actionpack/7.2/actionpack-generated.rbs
+++ b/gems/actionpack/7.2/actionpack-generated.rbs
@@ -2430,9 +2430,6 @@ module ActionController
     EXCLUDE_PARAMETERS: ::Array[untyped]
 
     class Options
-      # :nodoc:
-      include Mutex_m
-
       def self.from_hash: (untyped hash) -> untyped
 
       def initialize: (untyped name, untyped format, untyped `include`, untyped exclude, untyped klass, untyped model) -> untyped

--- a/gems/activemodel/7.0/manifest.yaml
+++ b/gems/activemodel/7.0/manifest.yaml
@@ -7,6 +7,5 @@ dependencies:
   - name: date
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time

--- a/gems/activemodel/7.1/manifest.yaml
+++ b/gems/activemodel/7.1/manifest.yaml
@@ -7,6 +7,5 @@ dependencies:
   - name: date
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time

--- a/gems/activerecord/6.0/activerecord-generated.rbs
+++ b/gems/activerecord/6.0/activerecord-generated.rbs
@@ -4473,8 +4473,6 @@ module ActiveRecord
     RESTRICTED_CLASS_METHODS: ::Array[untyped]
 
     class GeneratedAttributeMethods < Module
-      # nodoc:
-      include Mutex_m
     end
 
     module ClassMethods
@@ -17644,9 +17642,6 @@ module ActiveRecord
     end
 
     class GeneratedRelationMethods < Module
-      # :nodoc:
-      include Mutex_m
-
       def generate_method: (untyped method) -> untyped
     end
 

--- a/gems/activerecord/7.0/manifest.yaml
+++ b/gems/activerecord/7.0/manifest.yaml
@@ -8,6 +8,5 @@ dependencies:
   - name: delegate
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time

--- a/gems/activerecord/7.1/manifest.yaml
+++ b/gems/activerecord/7.1/manifest.yaml
@@ -8,6 +8,5 @@ dependencies:
   - name: delegate
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time

--- a/gems/activerecord/7.2/activerecord-generated.rbs
+++ b/gems/activerecord/7.2/activerecord-generated.rbs
@@ -4464,8 +4464,6 @@ module ActiveRecord
     RESTRICTED_CLASS_METHODS: ::Array[untyped]
 
     class GeneratedAttributeMethods < Module
-      # nodoc:
-      include Mutex_m
     end
 
     module ClassMethods
@@ -17635,9 +17633,6 @@ module ActiveRecord
     end
 
     class GeneratedRelationMethods < Module
-      # :nodoc:
-      include Mutex_m
-
       def generate_method: (untyped method) -> untyped
     end
 

--- a/gems/activerecord/7.2/manifest.yaml
+++ b/gems/activerecord/7.2/manifest.yaml
@@ -8,6 +8,5 @@ dependencies:
   - name: delegate
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time

--- a/gems/activerecord/8.0/activerecord-generated.rbs
+++ b/gems/activerecord/8.0/activerecord-generated.rbs
@@ -4464,8 +4464,6 @@ module ActiveRecord
     RESTRICTED_CLASS_METHODS: ::Array[untyped]
 
     class GeneratedAttributeMethods < Module
-      # nodoc:
-      include Mutex_m
     end
 
     module ClassMethods
@@ -17635,9 +17633,6 @@ module ActiveRecord
     end
 
     class GeneratedRelationMethods < Module
-      # :nodoc:
-      include Mutex_m
-
       def generate_method: (untyped method) -> untyped
     end
 

--- a/gems/activerecord/8.0/manifest.yaml
+++ b/gems/activerecord/8.0/manifest.yaml
@@ -8,6 +8,5 @@ dependencies:
   - name: delegate
   - name: logger
   - name: monitor
-  - name: mutex_m
   - name: singleton
   - name: time

--- a/gems/activesupport/6.0/activesupport-generated.rbs
+++ b/gems/activesupport/6.0/activesupport-generated.rbs
@@ -8771,8 +8771,6 @@ module ActiveSupport
     #
     # This class is thread safe. All methods are reentrant.
     class Fanout
-      include Mutex_m
-
       def initialize: () -> untyped
 
       def subscribe: (?untyped? pattern, ?untyped? callable) { () -> untyped } -> untyped

--- a/gems/activesupport/6.0/manifest.yaml
+++ b/gems/activesupport/6.0/manifest.yaml
@@ -4,7 +4,6 @@ dependencies:
   - name: singleton
   - name: logger
   - name: minitest
-  - name: mutex_m
   - name: time
   - name: openssl
   - name: pathname

--- a/gems/activesupport/7.0/activesupport-generated.rbs
+++ b/gems/activesupport/7.0/activesupport-generated.rbs
@@ -8771,8 +8771,6 @@ module ActiveSupport
     #
     # This class is thread safe. All methods are reentrant.
     class Fanout
-      include Mutex_m
-
       def initialize: () -> untyped
 
       def subscribe: (?untyped? pattern, ?untyped? callable) { () -> untyped } -> untyped

--- a/gems/activesupport/7.0/manifest.yaml
+++ b/gems/activesupport/7.0/manifest.yaml
@@ -8,7 +8,6 @@ dependencies:
   - name: logger
   - name: minitest
   - name: monitor
-  - name: mutex_m
   - name: openssl
   - name: singleton
   - name: time


### PR DESCRIPTION
[mutex_m](https://github.com/ruby/mutex_m) has been removed from rails v7.2.
https://github.com/rails/rails/pull/49674

It will no longer be accurate as type information in earlier versions, but I think the problem of dependencies is greater than the benefits gained.
