### PR TITLE
Add types for parser, rubocop-ast, rubocop

### DIFF
--- a/gems/parser/3.2/_test/test.rb
+++ b/gems/parser/3.2/_test/test.rb
@@ -71,4 +71,7 @@ node = Parser::CurrentRuby.parse("1.to_s") or raise
 if node.loc.is_a? Parser::Source::Map::Send
   node.loc.dot
   node.loc.selector
+  node.loc.operator
+  node.loc.begin
+  node.loc.end
 end

--- a/gems/parser/3.2/parser.rbs
+++ b/gems/parser/3.2/parser.rbs
@@ -121,6 +121,7 @@ module Parser
     class TreeRewriter
       def replace: (Range range, String content) -> self
       def remove: (Range range) -> self
+      def insert_before: (Range range, String content) -> self
       def insert_after: (Range range, String content) -> self
     end
 
@@ -149,6 +150,9 @@ module Parser
     class Map::Send < Map
       attr_reader dot: Range
       attr_reader selector: Range
+      attr_reader operator: Range?
+      attr_reader begin: Range?
+      attr_reader end: Range?
     end
 
     class Comment

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -209,6 +209,11 @@ node&.each_ancestor(:send) { |node| node.send_type? }
 node&.each_ancestor&.each { |node| node.send_type? }&.send_type?
 node&.each_ancestor(:send)&.each { |node| node.send_type? }&.send_type?
 node&.source_range
+node&.sibling_index
+node&.right_sibling
+node&.left_sibling
+node&.left_siblings
+node&.right_siblings
 
 node&.each_child_node { |node| node.send_type? }
 node&.each_child_node(:send) { |node| node.send_type? }
@@ -225,13 +230,56 @@ node&.each_node&.each { |node| node.send_type? }
 node&.each_node(:send)&.each { |node| node.send_type? }
 
 def_node = RuboCop::AST::ProcessedSource.new('def hoge(a, b); end', RUBY_VERSION.to_f).ast
-def_node.first_argument if def_node.is_a?(RuboCop::AST::DefNode)
+if def_node.is_a?(RuboCop::AST::DefNode)
+  def_node.first_argument
+  def_node.parenthesized?
+  def_node.last_argument
+  def_node.arguments?
+  def_node.splat_argument?
+  def_node.rest_argument?
+  def_node.block_argument?
+end
 
 send_node = RuboCop::AST::ProcessedSource.new('1 + 2', RUBY_VERSION.to_f).ast
 if send_node.is_a?(RuboCop::AST::SendNode)
   send_node.first_argument
   send_node.arguments
+  send_node.receiver
   send_node.method_name
+  send_node.selector
+  send_node.block_node
+  send_node.macro?
+  send_node.access_modifier?
+  send_node.bare_access_modifier?
+  send_node.non_bare_access_modifier?
+  send_node.special_modifier?
+  send_node.command?(:a)
+  send_node.setter_method?
+  send_node.assignment?
+  send_node.dot?
+  send_node.double_colon?
+  send_node.safe_navigation?
+  send_node.self_receiver?
+  send_node.const_receiver?
+  send_node.implicit_call?
+  send_node.block_literal?
+  send_node.arithmetic_operation?
+  send_node.def_modifier?
+  send_node.def_modifier
+  send_node.lambda?
+  send_node.lambda_literal?
+  send_node.unary_operation?
+  send_node.binary_operation?
+end
+
+array_node = RuboCop::AST::ProcessedSource.new('[1,2,3]', RUBY_VERSION.to_f).ast
+if array_node.is_a?(RuboCop::AST::ArrayNode)
+  array_node.values
+  array_node.each_value { |node| node }
+  array_node.each_value.each {}
+  array_node.square_brackets?
+  array_node.percent_literal?
+  array_node.bracketed?
 end
 
 block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -11,6 +11,7 @@ module RuboCop
     class NodePattern
       module Macros
         def def_node_matcher: (Symbol, String) -> void
+        def def_node_search: (Symbol, String) -> void
       end
 
       class Compiler
@@ -39,7 +40,32 @@ module RuboCop
 
     module MethodDispatchNode
       include MethodIdentifierPredicates
+      def receiver: () -> Node?
       def method_name: () -> Symbol
+      def selector: () -> Parser::Source::Range
+      def block_node: () -> BlockNode?
+      def macro?: () -> bool
+      def access_modifier?: () -> bool
+      def bare_access_modifier?: () -> bool
+      def non_bare_access_modifier?: () -> bool
+      def special_modifier?: () -> bool
+      def command?: (Symbol name) -> bool
+      def setter_method?: () -> bool
+      alias assignment? setter_method?
+      def dot?: () -> bool
+      def double_colon?: () -> bool
+      def safe_navigation?: () -> bool
+      def self_receiver?: () -> bool
+      def const_receiver?: () -> bool
+      def implicit_call?: () -> bool
+      def block_literal?: () -> bool
+      def arithmetic_operation?: () -> bool
+      def def_modifier?: (?Node node) -> bool
+      def def_modifier: (?Node node) -> Node?
+      def lambda?: () -> bool
+      def lambda_literal?: () -> bool
+      def unary_operation?: () -> bool
+      def binary_operation?: () -> bool
     end
 
     module MethodIdentifierPredicates
@@ -47,10 +73,22 @@ module RuboCop
     end
 
     module ParameterizedNode
+      def parenthesized?: () -> bool
       def first_argument: () -> Node?
-      def arguments: () -> Array[Node]
+      def last_argument: () -> Node?
+      def arguments?: () -> bool
+      def splat_argument?: () -> bool
+      alias rest_argument? splat_argument?
+      def block_argument?: () -> bool
+
+      module WrappedArguments
+        include ParameterizedNode
+        def arguments: () -> Array[Node]
+      end
+
       module RestArguments
         include ParameterizedNode
+        def arguments: () -> Array[Node]
       end
     end
 
@@ -205,10 +243,20 @@ module RuboCop
       def each_ancestor: (*Symbol types) { (Node) -> void } -> self
                        | (*Symbol types) -> ::Enumerator[Node, self]
       def source_range: () -> Parser::Source::Range
+      def sibling_index: () -> (Integer | nil)
+      def right_sibling: () -> (Node | nil)
+      def left_sibling: () -> (Node | nil)
+      def left_siblings: () -> Array[Node]
+      def right_siblings: () -> Array[Node]
     end
 
     class ArrayNode < Node
       alias values children
+      def each_value: () { (Node) -> void } -> self
+                    | () -> ::Enumerator[Node, self]
+      def square_brackets?: () -> bool
+      def percent_literal?: (?Symbol type) -> bool
+      def bracketed?: () -> bool
     end
 
     class BlockNode < Node
@@ -278,7 +326,7 @@ module RuboCop
 
     class StrNode < Node
       include BasicLiteralNode
-      def value: () -> String
+      def value: () -> (String | StrNode)
     end
 
     class SymbolNode < Node

--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -29,6 +29,7 @@ module RuboCop
     class Corrector < Parser::Source::TreeRewriter
       def replace: ((Parser::Source::Range | RuboCop::AST::Node) range, String content) -> self
       def remove: ((Parser::Source::Range | RuboCop::AST::Node) range) -> self
+      def insert_before: ((Parser::Source::Range | RuboCop::AST::Node) range, String content) -> self
       def insert_after: ((Parser::Source::Range | RuboCop::AST::Node) range, String content) -> self
     end
 
@@ -39,6 +40,10 @@ module RuboCop
     module RangeHelp
       def source_range: (Parser::Source::Buffer source_buffer, Integer line_number, Integer column, ?Integer length) -> Parser::Source::Range
       def range_between: (Integer start_pos, Integer end_pos) -> Parser::Source::Range
+      def range_with_surrounding_space: (?Parser::Source::Range range_positional,
+                                         ?range: Parser::Source::Range, ?side: Symbol, ?newlines: bool,
+                                         ?whitespace: bool, ?continuations: bool,
+                                         ?buffer: Parser::Source::Buffer) -> Parser::Source::Range
     end
 
     module IgnoredNode


### PR DESCRIPTION
Add types to:

- parser
    - `Parser::Source::TreeRewriter`
    - `Parser::Source::Map::Send`
- rubocop-ast
    - `RuboCop::AST::NodePattern::Macros`
    - `RuboCop::AST::MethodDispatchNode`
    - `RuboCop::AST::ParameterizedNode`
    - `RuboCop::AST::Node`
    - `RuboCop::AST::ArrayNode`
    - `RuboCop::AST::StrNode`
- rubocop
    - `RuboCop::Cop::Corrector`
    - `RuboCop::Cop::Corrector`