### PR TITLE
Fix type of ActiveSupport::Messages::Metadata

### DIFF
--- a/gems/activesupport/7.0/activesupport-generated.rbs
+++ b/gems/activesupport/7.0/activesupport-generated.rbs
@@ -8455,42 +8455,6 @@ end
 
 module ActiveSupport
   module Messages
-    class Metadata
-      # nodoc:
-      # nodoc:
-      def initialize: (untyped message, ?untyped? expires_at, ?untyped? purpose) -> untyped
-
-      def as_json: (?::Hash[untyped, untyped] options) -> { _rails: { message: untyped, exp: untyped, pur: untyped } }
-
-      def self.wrap: (untyped message, ?purpose: untyped? purpose, ?expires_in: untyped? expires_in, ?expires_at: untyped? expires_at) -> untyped
-
-      def self.verify: (untyped message, untyped purpose) -> untyped
-
-      private
-
-      def self.pick_expiry: (untyped expires_at, untyped expires_in) -> untyped
-
-      def self.extract_metadata: (untyped message) -> untyped
-
-      def self.encode: (untyped message) -> untyped
-
-      def self.decode: (untyped message) -> untyped
-
-      public
-
-      def verify: (untyped purpose) -> untyped
-
-      private
-
-      def match?: (untyped purpose) -> untyped
-
-      def fresh?: () -> untyped
-    end
-  end
-end
-
-module ActiveSupport
-  module Messages
     class RotationConfiguration
       # :nodoc:
       attr_reader signed: untyped

--- a/gems/activesupport/7.0/activesupport.rbs
+++ b/gems/activesupport/7.0/activesupport.rbs
@@ -715,3 +715,10 @@ module ActiveSupport
     def handler_for_rescue: (untyped exception) -> untyped
   end
 end
+
+module ActiveSupport
+  module Messages
+    module Metadata
+    end
+  end
+end


### PR DESCRIPTION
This is now a module and no class anymore. Also most generated methods for it do not exist anymore.

Fixes #883