### PR TITLE
Fix type of Hashie::Mash

### DIFF
--- a/gems/hashie/5.0/hashie.rbs
+++ b/gems/hashie/5.0/hashie.rbs
@@ -1,4 +1,7 @@
 module Hashie
-  class Mash < Hash[untyped, untyped]
+  class Hash < ::Hash[untyped, untyped]
+  end
+
+  class Mash < Hash
   end
 end


### PR DESCRIPTION
The Mash class does not inherit from stdlib's Hash but instead from Hashie::Hash which inherits from Hash.