### PR TITLE
Add types for rubocop ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -325,4 +325,20 @@ sym_node = RuboCop::AST::ProcessedSource.new(':sym', RUBY_VERSION.to_f).ast
 sym_node.value if sym_node.is_a?(RuboCop::AST::SymbolNode)
 
 regexp_node = RuboCop::AST::ProcessedSource.new('/abc/', RUBY_VERSION.to_f).ast
-regexp_node.to_regexp if regexp_node.is_a?(RuboCop::AST::RegexpNode)
+if regexp_node.is_a?(RuboCop::AST::RegexpNode)
+  regexp_node.to_regexp
+  regexp_node.regopt
+  regexp_node.options
+  regexp_node.content
+  regexp_node.slash_literal?
+  regexp_node.percent_r_literal?
+  regexp_node.delimiters
+  regexp_node.delimiter?('/')
+  regexp_node.interpolation?
+  regexp_node.multiline_mode?
+  regexp_node.extended?
+  regexp_node.ignore_case?
+  regexp_node.single_interpolation?
+  regexp_node.no_encoding?
+  regexp_node.fixed_encoding?
+end

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -282,6 +282,7 @@ if send_node.is_a?(RuboCop::AST::SendNode)
   send_node.lambda_literal?
   send_node.unary_operation?
   send_node.binary_operation?
+  send_node.send_type?
 end
 
 array_node = RuboCop::AST::ProcessedSource.new('[1,2,3]', RUBY_VERSION.to_f).ast

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -7,7 +7,7 @@ class MyRule < Parser::AST::Processor
   include RuboCop::AST::Traversal
 
   def on_sym(node)
-    puts "I found a symbol! #{node.value}"
+    node.value
   end
 
   def on_if(node)
@@ -34,7 +34,7 @@ class MyRule < Parser::AST::Processor
   def on_hash(node)
     node.pairs
     node.empty?
-    node.each_pair {|k, v| puts "#{k}#{v}" }
+    node.each_pair {|k, v| "#{k}#{v}" }
     node.each_pair
     node.keys
     node.each_key {|n| n }
@@ -45,6 +45,18 @@ class MyRule < Parser::AST::Processor
     node.pairs_on_same_line?
     node.mixed_delimiters?
     node.braces?
+    return if node.pairs.size == 0
+    pair = node.pairs.first
+    pair.key
+    pair.value
+    pair.hash_rocket?
+    pair.colon?
+    pair.delimiter
+    pair.delimiter(with_spacing: true)
+    pair.inverse_delimiter
+    pair.inverse_delimiter(with_spacing: true)
+    pair.value_on_new_line?
+    pair.value_omission?
   end
 end
 

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -317,7 +317,11 @@ if block_node.is_a?(RuboCop::AST::BlockNode)
 end
 
 str_node = RuboCop::AST::ProcessedSource.new('"str"', RUBY_VERSION.to_f).ast
-str_node.value if str_node.is_a?(RuboCop::AST::StrNode)
+if str_node.is_a?(RuboCop::AST::StrNode)
+  str_node.value
+  str_node.character_literal?
+  str_node.heredoc?
+end
 
 dstr_node = RuboCop::AST::ProcessedSource.new('"dstr#{123}dstr"', RUBY_VERSION.to_f).ast
 dstr_node.value if dstr_node.is_a?(RuboCop::AST::DstrNode)

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -241,6 +241,37 @@ node&.each_node(:send) { |node| node.send_type? }
 node&.each_node&.each { |node| node.send_type? }
 node&.each_node(:send)&.each { |node| node.send_type? }
 
+array_node = RuboCop::AST::ProcessedSource.new('[1,2,3]', RUBY_VERSION.to_f).ast
+if array_node.is_a?(RuboCop::AST::ArrayNode)
+  array_node.values
+  array_node.each_value { |node| node }
+  array_node.each_value.each {}
+  array_node.square_brackets?
+  array_node.percent_literal?
+  array_node.bracketed?
+end
+
+block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast
+if block_node.is_a?(RuboCop::AST::BlockNode)
+  block_node.send_node.method?(:tap)
+  block_node.first_argument
+  block_node.last_argument
+  block_node.arguments
+  block_node.argument_list
+  block_node.body
+  block_node.method_name
+  block_node.arguments?
+  block_node.braces?
+  block_node.keywords?
+  block_node.delimiters
+  block_node.opening_delimiter
+  block_node.closing_delimiter
+  block_node.single_line?
+  block_node.multiline?
+  block_node.lambda?
+  block_node.void_context?
+end
+
 def_node = RuboCop::AST::ProcessedSource.new('def hoge(a, b); end', RUBY_VERSION.to_f).ast
 if def_node.is_a?(RuboCop::AST::DefNode)
   def_node.first_argument
@@ -251,6 +282,9 @@ if def_node.is_a?(RuboCop::AST::DefNode)
   def_node.rest_argument?
   def_node.block_argument?
 end
+
+dstr_node = RuboCop::AST::ProcessedSource.new('"dstr#{123}dstr"', RUBY_VERSION.to_f).ast
+dstr_node.value if dstr_node.is_a?(RuboCop::AST::DstrNode)
 
 send_node = RuboCop::AST::ProcessedSource.new('1 + 2', RUBY_VERSION.to_f).ast
 if send_node.is_a?(RuboCop::AST::SendNode)
@@ -285,46 +319,12 @@ if send_node.is_a?(RuboCop::AST::SendNode)
   send_node.send_type?
 end
 
-array_node = RuboCop::AST::ProcessedSource.new('[1,2,3]', RUBY_VERSION.to_f).ast
-if array_node.is_a?(RuboCop::AST::ArrayNode)
-  array_node.values
-  array_node.each_value { |node| node }
-  array_node.each_value.each {}
-  array_node.square_brackets?
-  array_node.percent_literal?
-  array_node.bracketed?
-end
-
-block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast
-if block_node.is_a?(RuboCop::AST::BlockNode)
-  block_node.send_node.method?(:tap)
-  block_node.first_argument
-  block_node.last_argument
-  block_node.arguments
-  block_node.argument_list
-  block_node.body
-  block_node.method_name
-  block_node.arguments?
-  block_node.braces?
-  block_node.keywords?
-  block_node.delimiters
-  block_node.opening_delimiter
-  block_node.closing_delimiter
-  block_node.single_line?
-  block_node.multiline?
-  block_node.lambda?
-  block_node.void_context?
-end
-
 str_node = RuboCop::AST::ProcessedSource.new('"str"', RUBY_VERSION.to_f).ast
 if str_node.is_a?(RuboCop::AST::StrNode)
   str_node.value
   str_node.character_literal?
   str_node.heredoc?
 end
-
-dstr_node = RuboCop::AST::ProcessedSource.new('"dstr#{123}dstr"', RUBY_VERSION.to_f).ast
-dstr_node.value if dstr_node.is_a?(RuboCop::AST::DstrNode)
 
 sym_node = RuboCop::AST::ProcessedSource.new(':sym', RUBY_VERSION.to_f).ast
 sym_node.value if sym_node.is_a?(RuboCop::AST::SymbolNode)

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -358,6 +358,7 @@ module RuboCop
     class SendNode < Node
       include ParameterizedNode::RestArguments
       include MethodDispatchNode
+      def send_type?: () -> true
     end
 
     class StrNode < Node

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -329,6 +329,12 @@ module RuboCop
 
     class PairNode < Node
       include HashElementNode
+      def hash_rocket?: () -> bool
+      def colon?: () -> bool
+      def delimiter: (?with_spacing: bool) -> String
+      def inverse_delimiter: (?with_spacing: bool) -> String
+      def value_on_new_line?: () -> bool
+      def value_omission?: () -> bool
     end
 
     class RegexpNode < Node

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -364,6 +364,8 @@ module RuboCop
     class StrNode < Node
       include BasicLiteralNode
       def value: () -> (String | StrNode)
+      def character_literal?: () -> bool
+      def heredoc?: () -> bool
     end
 
     class SymbolNode < Node

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -339,6 +339,20 @@ module RuboCop
 
     class RegexpNode < Node
       def to_regexp: () -> ::Regexp
+      def regopt: () -> Node
+      def options: () -> Integer
+      def content: () -> String
+      def slash_literal?: () -> bool
+      def percent_r_literal?: () -> bool
+      def delimiters: () -> String
+      def delimiter?: (String char) -> bool
+      def interpolation?: () -> bool
+      def multiline_mode?: () -> bool
+      def extended?: () -> bool
+      def ignore_case?: () -> bool
+      def single_interpolation?: () -> bool
+      def no_encoding?: () -> bool
+      def fixed_encoding?: () -> bool
     end
 
     class SendNode < Node


### PR DESCRIPTION
Add types to:

- rubocop-ast
    - `RuboCop::AST::PairNode`
    - `RuboCop::AST::RegexpNode`
    - `RuboCop::AST::SendNode`
    - `RuboCop::AST::StrNode`
