### PR TITLE
`I18n.with_locale` should return block result

### DIFF
--- a/gems/i18n/1.10/i18n.rbs
+++ b/gems/i18n/1.10/i18n.rbs
@@ -37,7 +37,7 @@ module I18n
     def transliterate: (untyped key, ?throw: bool, ?raise: bool, ?locale: untyped?, ?replacement: untyped?, **untyped) -> untyped
     def localize: (untyped object, ?locale: untyped, ?format: untyped, **untyped) -> untyped
     alias l localize
-    def with_locale: (?untyped? tmp_locale) { () -> untyped } -> untyped
+    def with_locale: [T] (?untyped? tmp_locale) { () -> T } -> T
     def normalize_keys: (untyped locale, untyped key, untyped scope, ?untyped separator) -> Array[Symbol]
     def locale_available?: (Symbol | String locale) -> bool
     def enforce_available_locales!: (untyped locale) -> nil

--- a/gems/i18n/_reviewers.yaml
+++ b/gems/i18n/_reviewers.yaml
@@ -1,2 +1,3 @@
 reviewers:
   - takahashim
+  - ksss


### PR DESCRIPTION
Our application has the following implementation, which has lost type information.

```rb
def foo
  I18n.with_locale(:ja) do
    { bar: }
  end
end
```