### PR TITLE
rubocop-ast: Add types for rubocop-ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -475,6 +475,17 @@ end
 sym_node = RuboCop::AST::ProcessedSource.new(':sym', RUBY_VERSION.to_f).ast
 sym_node.value if sym_node.is_a?(RuboCop::AST::SymbolNode)
 
+irange_node = RuboCop::AST::ProcessedSource.new('1..10', RUBY_VERSION.to_f).ast
+if irange_node.is_a?(RuboCop::AST::RangeNode)
+  irange_node.begin
+  irange_node.end
+end
+erange_node = RuboCop::AST::ProcessedSource.new('1...10', RUBY_VERSION.to_f).ast
+if erange_node.is_a?(RuboCop::AST::RangeNode)
+  erange_node.begin
+  erange_node.end
+end
+
 regexp_node = RuboCop::AST::ProcessedSource.new('/abc/', RUBY_VERSION.to_f).ast
 if regexp_node.is_a?(RuboCop::AST::RegexpNode)
   regexp_node.to_regexp

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -322,6 +322,11 @@ if block_node.is_a?(RuboCop::AST::BlockNode)
   block_node.loc.end
 end
 
+csend_node = RuboCop::AST::ProcessedSource.new('o&.hoge(1)', RUBY_VERSION.to_f).ast
+if csend_node.is_a?(RuboCop::AST::CsendNode)
+  csend_node.send_type?
+end
+
 def_node = RuboCop::AST::ProcessedSource.new('def hoge(a, b); end', RUBY_VERSION.to_f).ast
 if def_node.is_a?(RuboCop::AST::DefNode)
   def_node.first_argument

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -322,6 +322,35 @@ if block_node.is_a?(RuboCop::AST::BlockNode)
   block_node.loc.end
 end
 
+case_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
+case num
+when 1
+  :one
+when 2
+  :two
+else
+  :else
+end
+EOM
+if case_node.is_a?(RuboCop::AST::CaseNode)
+  case_node.single_line_condition?
+  case_node.multiline_condition?
+  case_node.condition
+  case_node.body
+  case_node.keyword
+  case_node.when_branches
+  case_node.branches
+  case_node.else_branch
+  case_node.else?
+  when_node = case_node.when_branches.first
+  if when_node.is_a?(RuboCop::AST::WhenNode)
+    when_node.conditions
+    when_node.branch_index
+    when_node.then?
+    when_node.body
+  end
+end
+
 csend_node = RuboCop::AST::ProcessedSource.new('o&.hoge(1)', RUBY_VERSION.to_f).ast
 if csend_node.is_a?(RuboCop::AST::CsendNode)
   csend_node.send_type?

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -388,6 +388,18 @@ if dstr_node.is_a?(RuboCop::AST::DstrNode)
   end
 end
 
+float_node = RuboCop::AST::ProcessedSource.new('1.1', RUBY_VERSION.to_f).ast
+if float_node.is_a?(RuboCop::AST::FloatNode)
+  float_node.sign?
+  float_node.value
+end
+
+int_node = RuboCop::AST::ProcessedSource.new('+1', RUBY_VERSION.to_f).ast
+if int_node.is_a?(RuboCop::AST::IntNode)
+  int_node.sign?
+  int_node.value
+end
+
 send_node = RuboCop::AST::ProcessedSource.new('puts("hello")', RUBY_VERSION.to_f).ast
 if send_node.is_a?(RuboCop::AST::SendNode)
   send_node.first_argument

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -283,6 +283,10 @@ module RuboCop
       alias loc location
     end
 
+    class CsendNode < SendNode
+      def send_type?: () -> false
+    end
+
     class DefNode < Node
       include ParameterizedNode
       def void_context?: () -> bool

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -99,6 +99,13 @@ module RuboCop
       def value: () -> untyped
     end
 
+    module ConditionalNode
+      def single_line_condition?: () -> bool
+      def multiline_condition?: () -> bool
+      def condition: () -> Node?
+      def body: () -> Node?
+    end
+
     module NumericNode
       def sign?: () -> bool
     end
@@ -287,6 +294,15 @@ module RuboCop
       alias loc location
     end
 
+    class CaseNode < Node
+      include ConditionalNode
+      def keyword: () -> 'case'
+      def when_branches: () -> Array[WhenNode]
+      def branches: () -> Array[Node | nil]
+      def else_branch: () -> Node?
+      def else?: () -> bool
+    end
+
     class CsendNode < SendNode
       def send_type?: () -> false
     end
@@ -416,6 +432,13 @@ module RuboCop
       def value: () -> Symbol
       attr_reader location: Parser::Source::Map::Collection
       alias loc location
+    end
+
+    class WhenNode < Node
+      def conditions: () -> Array[Node]
+      def branch_index: () -> Integer
+      def then?: () -> bool
+      def body: () -> Node?
     end
   end
 end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -99,6 +99,10 @@ module RuboCop
       def value: () -> untyped
     end
 
+    module NumericNode
+      def sign?: () -> bool
+    end
+
     class Node < Parser::AST::Node
       include Descendence
       def type?: (*Symbol types) -> bool
@@ -306,6 +310,11 @@ module RuboCop
       alias loc location
     end
 
+    class FloatNode < Node
+      include BasicLiteralNode
+      include NumericNode
+    end
+
     class HashNode < Node
       def pairs: () -> Array[PairNode]
       def empty?: () -> bool
@@ -341,6 +350,11 @@ module RuboCop
       def branches: () -> Array[Node]
       attr_reader location: (Parser::Source::Map::Condition | Parser::Source::Map::Keyword | Parser::Source::Map::Ternary)
       alias loc location
+    end
+
+    class IntNode < Node
+      include BasicLiteralNode
+      include NumericNode
     end
 
     class PairNode < Node

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -355,6 +355,11 @@ module RuboCop
       alias loc location
     end
 
+    class RangeNode < Node
+      def begin: () -> Node?
+      def end: () -> Node?
+    end
+
     class RegexpNode < Node
       def to_regexp: () -> ::Regexp
       def regopt: () -> Node


### PR DESCRIPTION
Added:

- `RuboCop::AST::CsendNode`
- `RuboCop::AST::RangeNode`
- `RuboCop::AST::FloatNode`
- `RuboCop::AST::IntNode`
- `RuboCop::AST::CaseNode`
- `RuboCop::AST::WhenNode`