### PR TITLE
Add types for robocop ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -509,6 +509,17 @@ if int_node.is_a?(RuboCop::AST::IntNode)
   int_node.value
 end
 
+module_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
+module Foo
+  def test
+  end
+end
+EOM
+if module_node.is_a?(RuboCop::AST::ModuleNode)
+  module_node.identifier
+  module_node.body
+end
+
 or_asgn_node = RuboCop::AST::ProcessedSource.new('a ||= 1', RUBY_VERSION.to_f).ast
 if or_asgn_node.is_a?(RuboCop::AST::OrAsgnNode)
   or_asgn_node.assignment_node

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -434,6 +434,20 @@ if float_node.is_a?(RuboCop::AST::FloatNode)
   float_node.value
 end
 
+for_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
+for i in [1, 2, 3]
+  print i*2, "\n"
+end
+EOM
+if for_node.is_a?(RuboCop::AST::ForNode)
+  for_node.keyword
+  for_node.do?
+  for_node.void_context?
+  for_node.variable
+  for_node.collection
+  for_node.body
+end
+
 int_node = RuboCop::AST::ProcessedSource.new('+1', RUBY_VERSION.to_f).ast
 if int_node.is_a?(RuboCop::AST::IntNode)
   int_node.sign?
@@ -575,12 +589,12 @@ end
 
 while_node = RuboCop::AST::ProcessedSource.new('1 while true', RUBY_VERSION.to_f).ast
 if while_node.is_a?(RuboCop::AST::WhileNode)
-  puts while_node.single_line_condition?
-  puts while_node.multiline_condition?
-  puts while_node.condition
-  puts while_node.body
-  puts while_node.modifier_form?
-  puts while_node.keyword
-  puts while_node.inverse_keyword
-  puts while_node.do?
+  while_node.single_line_condition?
+  while_node.multiline_condition?
+  while_node.condition
+  while_node.body
+  while_node.modifier_form?
+  while_node.keyword
+  while_node.inverse_keyword
+  while_node.do?
 end

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -351,6 +351,17 @@ if case_node.is_a?(RuboCop::AST::CaseNode)
   end
 end
 
+const_node = RuboCop::AST::ProcessedSource.new('::Foo::Bar::BAZ', RUBY_VERSION.to_f).ast
+if const_node.is_a?(RuboCop::AST::ConstNode)
+  const_node.namespace
+  const_node.short_name
+  const_node.module_name?
+  const_node.class_name?
+  const_node.absolute?
+  const_node.relative?
+  const_node.each_path { |node| node.type }
+end
+
 csend_node = RuboCop::AST::ProcessedSource.new('o&.hoge(1)', RUBY_VERSION.to_f).ast
 if csend_node.is_a?(RuboCop::AST::CsendNode)
   csend_node.send_type?

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -292,6 +292,12 @@ if def_node.is_a?(RuboCop::AST::DefNode)
   if args_node.is_a?(RuboCop::AST::ArgsNode)
     args_node.empty_and_without_delimiters?
     args_node.argument_list
+    arg_node = args_node.child_nodes.first
+    if arg_node.is_a?(RuboCop::AST::ArgNode)
+      arg_node.name
+      arg_node.default_value
+      arg_node.default?
+    end
   end
 end
 

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -297,6 +297,12 @@ if array_node.is_a?(RuboCop::AST::ArrayNode)
   array_node.loc.end
 end
 
+asgn_node = RuboCop::AST::ProcessedSource.new('x = 1', RUBY_VERSION.to_f).ast
+if asgn_node.is_a?(RuboCop::AST::AsgnNode)
+  asgn_node.name
+  asgn_node.expression
+end
+
 block_node = RuboCop::AST::ProcessedSource.new('1.tap { |n| n }', RUBY_VERSION.to_f).ast
 if block_node.is_a?(RuboCop::AST::BlockNode)
   block_node.send_node.method?(:tap)

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -589,6 +589,12 @@ if str_node.is_a?(RuboCop::AST::StrNode)
   end
 end
 
+super_node = RuboCop::AST::ProcessedSource.new('super 1, 2, 3', RUBY_VERSION.to_f).ast
+if super_node.is_a?(RuboCop::AST::SuperNode)
+  super_node.node_parts
+  super_node.arguments
+end
+
 sym_node = RuboCop::AST::ProcessedSource.new(':sym', RUBY_VERSION.to_f).ast
 sym_node.value if sym_node.is_a?(RuboCop::AST::SymbolNode)
 

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -467,6 +467,14 @@ if int_node.is_a?(RuboCop::AST::IntNode)
   int_node.value
 end
 
+or_asgn_node = RuboCop::AST::ProcessedSource.new('a ||= 1', RUBY_VERSION.to_f).ast
+if or_asgn_node.is_a?(RuboCop::AST::OrAsgnNode)
+  or_asgn_node.assignment_node
+  or_asgn_node.name
+  or_asgn_node.operator
+  or_asgn_node.expression
+end
+
 or_node = RuboCop::AST::ProcessedSource.new('1 or 2', RUBY_VERSION.to_f).ast
 if or_node.is_a?(RuboCop::AST::OrNode)
   or_node.lhs

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -283,6 +283,18 @@ node&.each_node(:send) { |node| node.send_type? }
 node&.each_node&.each { |node| node.send_type? }
 node&.each_node(:send)&.each { |node| node.send_type? }
 
+and_node = RuboCop::AST::ProcessedSource.new('1 and 2', RUBY_VERSION.to_f).ast
+if and_node.is_a?(RuboCop::AST::AndNode)
+  and_node.lhs
+  and_node.rhs
+  and_node.conditions
+  and_node.operator
+  and_node.logical_operator?
+  and_node.semantic_operator?
+  and_node.alternate_operator
+  and_node.inverse_operator
+end
+
 def_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
 def m(a, b, c)
 end

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -572,3 +572,15 @@ if until_node.is_a?(RuboCop::AST::UntilNode)
   until_node.inverse_keyword
   until_node.do?
 end
+
+while_node = RuboCop::AST::ProcessedSource.new('1 while true', RUBY_VERSION.to_f).ast
+if while_node.is_a?(RuboCop::AST::WhileNode)
+  puts while_node.single_line_condition?
+  puts while_node.multiline_condition?
+  puts while_node.condition
+  puts while_node.body
+  puts while_node.modifier_form?
+  puts while_node.keyword
+  puts while_node.inverse_keyword
+  puts while_node.do?
+end

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -283,6 +283,18 @@ node&.each_node(:send) { |node| node.send_type? }
 node&.each_node&.each { |node| node.send_type? }
 node&.each_node(:send)&.each { |node| node.send_type? }
 
+def_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
+def m(a, b, c)
+end
+EOM
+if def_node.is_a?(RuboCop::AST::DefNode)
+  args_node = def_node.arguments
+  if args_node.is_a?(RuboCop::AST::ArgsNode)
+    args_node.empty_and_without_delimiters?
+    args_node.argument_list
+  end
+end
+
 array_node = RuboCop::AST::ProcessedSource.new('[1,2,3]', RUBY_VERSION.to_f).ast
 if array_node.is_a?(RuboCop::AST::ArrayNode)
   array_node.values

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -454,6 +454,18 @@ if int_node.is_a?(RuboCop::AST::IntNode)
   int_node.value
 end
 
+or_node = RuboCop::AST::ProcessedSource.new('1 or 2', RUBY_VERSION.to_f).ast
+if or_node.is_a?(RuboCop::AST::OrNode)
+  or_node.lhs
+  or_node.rhs
+  or_node.conditions
+  or_node.operator
+  or_node.logical_operator?
+  or_node.semantic_operator?
+  or_node.alternate_operator
+  or_node.inverse_operator
+end
+
 send_node = RuboCop::AST::ProcessedSource.new('puts("hello")', RUBY_VERSION.to_f).ast
 if send_node.is_a?(RuboCop::AST::SendNode)
   send_node.first_argument

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -631,3 +631,43 @@ if while_node.is_a?(RuboCop::AST::WhileNode)
   while_node.inverse_keyword
   while_node.do?
 end
+
+yield_node = RuboCop::AST::ProcessedSource.new('yield 1', RUBY_VERSION.to_f).ast
+if yield_node.is_a?(RuboCop::AST::YieldNode)
+  yield_node.parenthesized?
+  yield_node.first_argument
+  yield_node.last_argument
+  yield_node.arguments?
+  yield_node.splat_argument?
+  yield_node.rest_argument?
+  yield_node.block_argument?
+  yield_node.method?(:yield)
+  yield_node.receiver
+  yield_node.method_name
+  yield_node.selector
+  yield_node.block_node
+  yield_node.macro?
+  yield_node.access_modifier?
+  yield_node.bare_access_modifier?
+  yield_node.non_bare_access_modifier?
+  yield_node.special_modifier?
+  yield_node.command?(:yield)
+  yield_node.setter_method?
+  yield_node.assignment?
+  yield_node.dot?
+  yield_node.double_colon?
+  yield_node.safe_navigation?
+  yield_node.self_receiver?
+  yield_node.const_receiver?
+  yield_node.implicit_call?
+  yield_node.block_literal?
+  yield_node.arithmetic_operation?
+  yield_node.def_modifier?
+  yield_node.def_modifier
+  yield_node.lambda?
+  yield_node.lambda_literal?
+  yield_node.unary_operation?
+  yield_node.binary_operation?
+  yield_node.node_parts
+  yield_node.arguments
+end

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -394,6 +394,18 @@ if casgn_node.is_a?(RuboCop::AST::CasgnNode)
   casgn_node.expression
 end
 
+class_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
+class Foo < Super
+  def test
+  end
+end
+EOM
+if class_node.is_a?(RuboCop::AST::ClassNode)
+  class_node.identifier
+  class_node.parent_class
+  class_node.body
+end
+
 const_node = RuboCop::AST::ProcessedSource.new('::Foo::Bar::BAZ', RUBY_VERSION.to_f).ast
 if const_node.is_a?(RuboCop::AST::ConstNode)
   const_node.namespace

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -351,6 +351,13 @@ if case_node.is_a?(RuboCop::AST::CaseNode)
   end
 end
 
+casgn_node = RuboCop::AST::ProcessedSource.new('::Foo::Bar::BAZ = 1', RUBY_VERSION.to_f).ast
+if casgn_node.is_a?(RuboCop::AST::CasgnNode)
+  casgn_node.namespace
+  casgn_node.name
+  casgn_node.expression
+end
+
 const_node = RuboCop::AST::ProcessedSource.new('::Foo::Bar::BAZ', RUBY_VERSION.to_f).ast
 if const_node.is_a?(RuboCop::AST::ConstNode)
   const_node.namespace

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -644,6 +644,11 @@ if regexp_node.is_a?(RuboCop::AST::RegexpNode)
   regexp_node.loc.end
 end
 
+return_node = RuboCop::AST::ProcessedSource.new('return 1', RUBY_VERSION.to_f).ast
+if return_node.is_a?(RuboCop::AST::ReturnNode)
+  return_node.arguments
+end
+
 until_node = RuboCop::AST::ProcessedSource.new('1 until true', RUBY_VERSION.to_f).ast
 if until_node.is_a?(RuboCop::AST::UntilNode)
   until_node.single_line_condition?

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -560,3 +560,15 @@ if regexp_node.is_a?(RuboCop::AST::RegexpNode)
   regexp_node.loc.begin
   regexp_node.loc.end
 end
+
+until_node = RuboCop::AST::ProcessedSource.new('1 until true', RUBY_VERSION.to_f).ast
+if until_node.is_a?(RuboCop::AST::UntilNode)
+  until_node.single_line_condition?
+  until_node.multiline_condition?
+  until_node.condition
+  until_node.body
+  until_node.modifier_form?
+  until_node.keyword
+  until_node.inverse_keyword
+  until_node.do?
+end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -348,6 +348,12 @@ module RuboCop
       def expression: () -> Node
     end
 
+    class ClassNode < Node
+      def identifier: () -> Node
+      def parent_class: () -> Node?
+      def body: () -> Node?
+    end
+
     class ConstNode < Node
       def namespace: () -> Node?
       def short_name: () -> Symbol

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -106,6 +106,10 @@ module RuboCop
       def body: () -> Node?
     end
 
+    module ModifierNode
+      def modifier_form?: () -> bool
+    end
+
     module NumericNode
       def sign?: () -> bool
     end
@@ -442,6 +446,14 @@ module RuboCop
       def value: () -> Symbol
       attr_reader location: Parser::Source::Map::Collection
       alias loc location
+    end
+
+    class UntilNode < Node
+      include ConditionalNode
+      include ModifierNode
+      def keyword: () -> 'until'
+      def inverse_keyword: () -> 'while'
+      def do?: () -> bool
     end
 
     class WhenNode < Node

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -319,6 +319,12 @@ module RuboCop
       def else?: () -> bool
     end
 
+    class CasgnNode < Node
+      def namespace: () -> Node?
+      def name: () -> Symbol
+      def expression: () -> Node
+    end
+
     class ConstNode < Node
       def namespace: () -> Node?
       def short_name: () -> Symbol

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -502,6 +502,13 @@ module RuboCop
       alias loc location
     end
 
+    class SuperNode < Node
+      include ParameterizedNode
+      include MethodDispatchNode
+      def node_parts: () -> Array[untyped]
+      alias arguments children
+    end
+
     class SymbolNode < Node
       include BasicLiteralNode
       def value: () -> Symbol

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -419,6 +419,17 @@ module RuboCop
       include NumericNode
     end
 
+    class OpAsgnNode < Node
+      def assignment_node: () -> AsgnNode
+      def name: () -> Symbol
+      def operator: () -> Symbol
+      def expression: () -> Node
+    end
+
+    class OrAsgnNode < OpAsgnNode
+      def operator: () -> :'||'
+    end
+
     class OrNode < Node
       include BinaryOperatorNode
       include PredicateOperatorNode

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -303,6 +303,16 @@ module RuboCop
       def else?: () -> bool
     end
 
+    class ConstNode < Node
+      def namespace: () -> Node?
+      def short_name: () -> Symbol
+      def module_name?: () -> bool
+      alias class_name? module_name?
+      def absolute?: () -> bool
+      def relative?: () -> bool
+      def each_path: () { (Node) -> void } -> self
+    end
+
     class CsendNode < SendNode
       def send_type?: () -> false
     end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -277,6 +277,11 @@ module RuboCop
       def right_siblings: () -> Array[Node]
     end
 
+    class ArgsNode < Node
+      def empty_and_without_delimiters?: () -> bool
+      def argument_list: () -> Array[Node]
+    end
+
     class ArrayNode < Node
       alias values children
       def each_value: () { (Node) -> void } -> self
@@ -349,7 +354,7 @@ module RuboCop
       def void_context?: () -> bool
       def argument_forwarding?: () -> bool
       def method_name: () -> Symbol
-      def arguments: () -> Array[Node]
+      def arguments: () -> ArgsNode
       def body: () -> Node
       def receiver: () -> (Node | nil)
       def endless?: () -> bool

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -462,5 +462,13 @@ module RuboCop
       def then?: () -> bool
       def body: () -> Node?
     end
+
+    class WhileNode < Node
+      include ConditionalNode
+      include ModifierNode
+      def keyword: () -> 'while'
+      def inverse_keyword: () -> 'until'
+      def do?: () -> bool
+    end
   end
 end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -288,6 +288,11 @@ module RuboCop
       alias loc location
     end
 
+    class AsgnNode < Node
+      def name: () -> Symbol
+      def expression: () -> Node
+    end
+
     class BlockNode < Node
       def send_node: () -> SendNode
       def first_argument: () -> Node?

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -99,6 +99,12 @@ module RuboCop
       def value: () -> untyped
     end
 
+    module BinaryOperatorNode
+      def lhs: () -> Node
+      def rhs: () -> Node
+      def conditions: () -> Array[Node]
+    end
+
     module ConditionalNode
       def single_line_condition?: () -> bool
       def multiline_condition?: () -> bool
@@ -112,6 +118,12 @@ module RuboCop
 
     module NumericNode
       def sign?: () -> bool
+    end
+
+    module PredicateOperatorNode
+      def operator: () -> String
+      def logical_operator?: () -> bool
+      def semantic_operator?: () -> bool
     end
 
     class Node < Parser::AST::Node
@@ -394,6 +406,13 @@ module RuboCop
     class IntNode < Node
       include BasicLiteralNode
       include NumericNode
+    end
+
+    class OrNode < Node
+      include BinaryOperatorNode
+      include PredicateOperatorNode
+      def alternate_operator: () -> String
+      def inverse_operator: () -> String
     end
 
     class PairNode < Node

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -520,5 +520,12 @@ module RuboCop
       def inverse_keyword: () -> 'until'
       def do?: () -> bool
     end
+
+    class YieldNode < Node
+      include ParameterizedNode
+      include MethodDispatchNode
+      def node_parts: () -> Array[untyped]
+      alias arguments children
+    end
   end
 end

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -492,6 +492,10 @@ module RuboCop
       alias loc location
     end
 
+    class ReturnNode < Node
+      include ParameterizedNode::WrappedArguments
+    end
+
     class SendNode < Node
       include ParameterizedNode::RestArguments
       include MethodDispatchNode

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -277,6 +277,12 @@ module RuboCop
       def right_siblings: () -> Array[Node]
     end
 
+    class ArgNode < Node
+      def name: () -> Symbol?
+      def default_value: () -> Node?
+      def default?: () -> bool
+    end
+
     class ArgsNode < Node
       def empty_and_without_delimiters?: () -> bool
       def argument_list: () -> Array[Node]

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -443,6 +443,11 @@ module RuboCop
       include NumericNode
     end
 
+    class ModuleNode < Node
+      def identifier: () -> Node
+      def body: () -> Node?
+    end
+
     class OpAsgnNode < Node
       def assignment_node: () -> AsgnNode
       def name: () -> Symbol

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -277,6 +277,13 @@ module RuboCop
       def right_siblings: () -> Array[Node]
     end
 
+    class AndNode < Node
+      include BinaryOperatorNode
+      include PredicateOperatorNode
+      def alternate_operator: () -> String
+      def inverse_operator: () -> String
+    end
+
     class ArgNode < Node
       def name: () -> Symbol?
       def default_value: () -> Node?

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -345,6 +345,15 @@ module RuboCop
       include NumericNode
     end
 
+    class ForNode < Node
+      def keyword: () -> 'for'
+      def do?: () -> bool
+      def void_context?: () -> true
+      def variable: () -> Node
+      def collection: () -> Node
+      def body: () -> Node?
+    end
+
     class HashNode < Node
       def pairs: () -> Array[PairNode]
       def empty?: () -> bool


### PR DESCRIPTION
Added:

- rubocop-ast
    - `RuboCop::AST::AndNode`
    - `RuboCop::AST::ArgNode`
    - `RuboCop::AST::ArgsNode`
    - `RuboCop::AST::AsgnNode`
    - `RuboCop::AST::CasgnNode`
    - `RuboCop::AST::ClassNode`
    - `RuboCop::AST::ConstNode`
    - `RuboCop::AST::ForNode`
    - `RuboCop::AST::ModuleNode`
    - `RuboCop::AST::OrAsgnNode`
    - `RuboCop::AST::OrNode`
    - `RuboCop::AST::ReturnNode`
    - `RuboCop::AST::SuperNode`
    - `RuboCop::AST::UntilNode`
    - `RuboCop::AST::WhileNode`
    - `RuboCop::AST::YieldNode`
