### PR TITLE
Add type for rubocop

### DIFF
--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -72,6 +72,23 @@ module RuboCop
 
     module Util
       include PathUtil
+      def line_range: (RuboCop::AST::Node node) -> ::Range[Integer]
+      def parentheses?: (RuboCop::AST::Node node) -> bool
+      def add_parentheses: (RuboCop::AST::Node node, Corrector corrector) -> void
+      def any_descendant?: (RuboCop::AST::Node node, *Symbol types) -> bool
+      def args_begin: (RuboCop::AST::Node node) -> Parser::Source::Range
+      def args_end: (RuboCop::AST::Node node) -> Parser::Source::Range
+      def begins_its_line?: (Parser::Source::Range range) -> bool
+      def first_part_of_call_chain: (RuboCop::AST::Node node) -> RuboCop::AST::Node
+      def double_quotes_required?: (String string) -> bool
+      def needs_escaping?: (String string) -> bool
+      def escape_string: (String string) -> String
+      def to_string_literal: (String string) -> String
+      def trim_string_interpolation_escape_character: (String str) -> String
+      def interpret_string_escapes: (String string) -> String
+      def line: ((RuboCop::AST::Node | Parser::Source::Range) node_or_range) -> Integer
+      def same_line?: ((RuboCop::AST::Node | Parser::Source::Range) node1, (RuboCop::AST::Node | Parser::Source::Range) node2) -> bool
+      def indent: (RuboCop::AST::Node node, ?offset: Integer) -> String
     end
   end
 

--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -43,6 +43,13 @@ module RuboCop
       def style: () -> Symbol
     end
 
+    module CommentsHelp
+      def source_range_with_comment: (RuboCop::AST::Node node) -> Parser::Source::Range
+      def contains_comments?: (RuboCop::AST::Node node) -> bool
+      def comments_in_range: (RuboCop::AST::Node node) -> Array[Parser::Source::Comment]
+      def comments_contain_disables?: (RuboCop::AST::Node node, String cop_name) -> bool
+    end
+
     module RangeHelp
       def source_range: (Parser::Source::Buffer source_buffer, Integer line_number, Integer column, ?Integer length) -> Parser::Source::Range
       def range_between: (Integer start_pos, Integer end_pos) -> Parser::Source::Range

--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -12,6 +12,7 @@ module RuboCop
     class Base
       extend AST::NodePattern::Macros
       include Util
+      include IgnoredNode
 
       def self.exclude_from_registry: () -> void
       def self.department: () -> Symbol
@@ -54,6 +55,7 @@ module RuboCop
     module IgnoredNode
       def ignore_node: (RuboCop::AST::Node node) -> void
       def part_of_ignored_node?: (RuboCop::AST::Node node) -> bool
+      def ignored_node?: (RuboCop::AST::Node node) -> bool
     end
 
     module TargetRubyVersion


### PR DESCRIPTION
- Modified:
    - `RuboCop::Cop::Base`
    - `RuboCop::Cop::IgnoredNode`
    - `RuboCop::Cop::Util`
- Added:
    - `RuboCop::Cop::CommentsHelp`