### PR TITLE
Add types for rubocop

### DIFF
--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -44,6 +44,12 @@ module RuboCop
       def swap: ((Parser::Source::Range | RuboCop::AST::Node) node_or_range1, (Parser::Source::Range | RuboCop::AST::Node) node_or_range2) -> self
     end
 
+    module Alignment
+      def configured_indentation_width: () -> Integer
+      def indentation: (RuboCop::AST::Node node) -> String
+      def offset: (RuboCop::AST::Node node) -> String
+    end
+
     module ConfigurableEnforcedStyle
       def style: () -> Symbol
     end


### PR DESCRIPTION
Added:

- rubocop
    - `RuboCop::Cop::Alignemtn`

Modified:

- rubocop
    - `RuboCop::Config`
    - `RuboCop::Cop::Base`
    - `RuboCop::Cop::RangeHelp`
