### PR TITLE
Add types for rubocop

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -350,6 +350,11 @@ if alias_node.is_a?(RuboCop::AST::AliasNode)
   alias_node.new_identifier
 end
 
+and_asgn_node = RuboCop::AST::ProcessedSource.new('a &&= 1', RUBY_VERSION.to_f).ast
+if and_asgn_node.is_a?(RuboCop::AST::AndAsgnNode)
+  and_asgn_node.operator
+end
+
 and_node = RuboCop::AST::ProcessedSource.new('1 and 2', RUBY_VERSION.to_f).ast
 if and_node.is_a?(RuboCop::AST::AndNode)
   and_node.lhs

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -344,6 +344,12 @@ node&.each_node(:send) { |node| node.send_type? }
 node&.each_node&.each { |node| node.send_type? }
 node&.each_node(:send)&.each { |node| node.send_type? }
 
+alias_node = RuboCop::AST::ProcessedSource.new('alias :new :old', RUBY_VERSION.to_f).ast
+if alias_node.is_a?(RuboCop::AST::AliasNode)
+  alias_node.old_identifier
+  alias_node.new_identifier
+end
+
 and_node = RuboCop::AST::ProcessedSource.new('1 and 2', RUBY_VERSION.to_f).ast
 if and_node.is_a?(RuboCop::AST::AndNode)
   and_node.lhs

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -430,6 +430,11 @@ if block_node.is_a?(RuboCop::AST::BlockNode)
   block_node.loc.end
 end
 
+break_node = RuboCop::AST::ProcessedSource.new('break 1, 2', RUBY_VERSION.to_f).ast
+if break_node.is_a?(RuboCop::AST::BreakNode)
+  break_node.arguments
+end
+
 case_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
 case num
 when 1

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -402,6 +402,10 @@ module RuboCop
       alias loc location
     end
 
+    class BreakNode < Node
+      include ParameterizedNode::WrappedArguments
+    end
+
     class CaseNode < Node
       include ConditionalNode
       def keyword: () -> 'case'

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -480,6 +480,8 @@ module RuboCop
     end
 
     class IfNode < Node
+      include ConditionalNode
+      include ModifierNode
       def if?: () -> bool
       def unless?: () -> bool
       def elsif?: () -> bool

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -337,6 +337,11 @@ module RuboCop
       def right_siblings: () -> Array[Node]
     end
 
+    class AliasNode < Node
+      def old_identifier: () -> SymbolNode
+      def new_identifier: () -> SymbolNode
+    end
+
     class AndNode < Node
       include BinaryOperatorNode
       include PredicateOperatorNode

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -342,6 +342,10 @@ module RuboCop
       def new_identifier: () -> SymbolNode
     end
 
+    class AndAsgnNode < OpAsgnNode
+      def operator: () -> :'&&'
+    end
+
     class AndNode < Node
       include BinaryOperatorNode
       include PredicateOperatorNode

--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -15,6 +15,7 @@ module RuboCop
       extend AST::NodePattern::Macros
       include Util
       include IgnoredNode
+      include AutocorrectLogic
 
       def self.exclude_from_registry: () -> void
       def self.department: () -> Symbol
@@ -30,6 +31,16 @@ module RuboCop
       def target_ruby_version: () -> Float
       def processed_source: () -> AST::ProcessedSource
       def target_gem_version: (String gem_name) -> Gem::Version
+    end
+
+    module AutocorrectLogic
+      def autocorrect?: () -> bool
+      def autocorrect_with_disable_uncorrectable?: () -> bool
+      def autocorrect_requested?: () -> bool
+      def correctable?: () -> bool
+      def disable_uncorrectable?: () -> bool
+      def safe_autocorrect?: () -> bool
+      def autocorrect_enabled?: () -> bool
     end
 
     class Corrector < Parser::Source::TreeRewriter


### PR DESCRIPTION
Added:

- rubocop
    - `RuboCop::Cop::AutocorrectLogic`
- rubocop-ast
    - `RuboCop::AST::AliasNode`
    - `RuboCop::AST::AndAsgnNode`
    - `RuboCop::AST::BreakNode`

Modified:

- rubocop-ast
     - `RuboCop::AST::IfNode`