### PR TITLE
Add stringio to manifest.yml

### DIFF
--- a/gems/activesupport/7.0/manifest.yaml
+++ b/gems/activesupport/7.0/manifest.yaml
@@ -13,3 +13,4 @@ dependencies:
   - name: time
   - name: securerandom
   - name: erb
+  - name: stringio

--- a/gems/caxlsx/4.2/manifest.yaml
+++ b/gems/caxlsx/4.2/manifest.yaml
@@ -1,3 +1,2 @@
 dependencies:
-  - name: pathname
   - name: stringio

--- a/gems/fcm/2.0/manifest.yaml
+++ b/gems/fcm/2.0/manifest.yaml
@@ -1,3 +1,2 @@
 dependencies:
-  - name: pathname
   - name: stringio


### PR DESCRIPTION
**stringio** is scheduled to be moved to stdlib, so it should be listed in manifest.yml.
stringio is already set up in **csv**, and no problems have been reported.
This change requires rbs v3.7 or higher, but since it has been more than 7 months since its release, we consider it to have become widely accepted.

Please let us know if you have any problems.

ref: https://github.com/ruby/rbs/issues/1549