### PR TITLE
Automatically use the latest Ruby for CI

### DIFF
--- a/.github/workflows/generate_comment_body_on_review.yml
+++ b/.github/workflows/generate_comment_body_on_review.yml
@@ -29,7 +29,7 @@ jobs:
           ref: main
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: ruby
           bundler-cache: false
       - name: Changed gems and non gem files
         id: changes

--- a/.github/workflows/merge_on_comment.yml
+++ b/.github/workflows/merge_on_comment.yml
@@ -35,7 +35,7 @@ jobs:
           ref: main
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: ruby
           bundler-cache: false
       - name: Fetch PR information
         id: pr_info

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
         bundler-cache: true
     - name: 'Install dependencies'
       run: 'bundle install'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
         bundler-cache: true
     - name: 'Install dependencies'
       run: 'gem install rbs'
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
         bundler-cache: true
     - name: Run bin/setup
       run: bin/setup
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
         bundler-cache: true
     - name: Run bin/setup
       run: bin/setup
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
         bundler-cache: true
     - name: Check .rubocop.yml
       run: ruby .github/workflows/pr_bot/strict_rubocop_config.rb

--- a/.github/workflows/welcome_comment.yml
+++ b/.github/workflows/welcome_comment.yml
@@ -27,7 +27,7 @@ jobs:
           ref: main
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: ruby
           bundler-cache: false
       - name: Changed gems and non gem files
         id: changes


### PR DESCRIPTION
Currently, Ruby 3.3 is used in various places on CI, but there are no processes that depend on 3.3.
We will make corrections so that the latest Ruby is automatically selected.