### PR TITLE
rubocop-ast: Add types for rubocop-ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -435,6 +435,36 @@ if break_node.is_a?(RuboCop::AST::BreakNode)
   break_node.arguments
 end
 
+_, case_match_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast&.child_nodes
+config = {db: {user: 'admin', password: 'abc123'}}
+case config
+in db: {user:}
+  puts "Connect with user " + user
+in connection: {username: }
+  puts "Connect with user " + username
+else
+  puts "Unrecognized structure of config"
+end
+EOM
+if case_match_node.is_a?(RuboCop::AST::CaseMatchNode)
+  case_match_node.single_line_condition?
+  case_match_node.multiline_condition?
+  case_match_node.condition
+  case_match_node.body
+  case_match_node.keyword
+  case_match_node.in_pattern_branches
+  case_match_node.branches
+  case_match_node.else_branch
+  case_match_node.else?
+  in_pattern_node = case_match_node.in_pattern_branches.first
+  if in_pattern_node.is_a?(RuboCop::AST::InPatternNode)
+    in_pattern_node.pattern
+    in_pattern_node.branch_index
+    in_pattern_node.then?
+    in_pattern_node.body
+  end
+end
+
 case_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
 case num
 when 1

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -406,6 +406,15 @@ module RuboCop
       include ParameterizedNode::WrappedArguments
     end
 
+    class CaseMatchNode < Node
+      include ConditionalNode
+      def keyword: () -> 'case'
+      def in_pattern_branches: () -> Array[InPatternNode]
+      def branches: () -> Array[Node | nil]
+      def else_branch: () -> Node?
+      def else?: () -> bool
+    end
+
     class CaseNode < Node
       include ConditionalNode
       def keyword: () -> 'case'
@@ -511,6 +520,13 @@ module RuboCop
       def branches: () -> Array[Node]
       attr_reader location: (Parser::Source::Map::Condition | Parser::Source::Map::Keyword | Parser::Source::Map::Ternary)
       alias loc location
+    end
+
+    class InPatternNode < Node
+      def pattern: () -> Node
+      def branch_index: () -> Integer
+      def then?: () -> bool
+      def body: () -> Node?
     end
 
     class IntNode < Node


### PR DESCRIPTION
Added:

- rubocop-ast
    - `RuboCop::AST::CaseMatchNode`
    - `RuboCop::AST::InPatternNode`