### PR TITLE
Add types for rubocop ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -608,7 +608,7 @@ ensure
 end
 EOM
 if ensure_node.is_a?(RuboCop::AST::EnsureNode)
-  ensure_node.body
+  ensure_node.child_nodes
 end
 
 float_node = RuboCop::AST::ProcessedSource.new('1.1', RUBY_VERSION.to_f).ast
@@ -635,6 +635,17 @@ int_node = RuboCop::AST::ProcessedSource.new('+1', RUBY_VERSION.to_f).ast
 if int_node.is_a?(RuboCop::AST::IntNode)
   int_node.sign?
   int_node.value
+end
+
+keyword_splat_node = RuboCop::AST::ProcessedSource.new('a(**{a: 1})', RUBY_VERSION.to_f).ast&.child_nodes&.first&.child_nodes&.first
+if keyword_splat_node.is_a?(RuboCop::AST::KeywordSplatNode)
+  keyword_splat_node.key
+  keyword_splat_node.value
+  keyword_splat_node.hash_rocket?
+  keyword_splat_node.colon?
+  keyword_splat_node.operator
+  keyword_splat_node.node_parts
+  keyword_splat_node.kwsplat_type?
 end
 
 module_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -563,6 +563,14 @@ if def_node.is_a?(RuboCop::AST::DefNode)
   def_node.loc.assignment
 end
 
+defined_node = RuboCop::AST::ProcessedSource.new('defined? print', RUBY_VERSION.to_f).ast
+if defined_node.is_a?(RuboCop::AST::DefinedNode)
+  defined_node.parenthesized?
+  defined_node.method_name
+  defined_node.node_parts
+  defined_node.arguments
+end
+
 dstr_node = RuboCop::AST::ProcessedSource.new('"dstr#{123}dstr"', RUBY_VERSION.to_f).ast
 if dstr_node.is_a?(RuboCop::AST::DstrNode)
   dstr_node.value

--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -598,6 +598,19 @@ if dstr_node.is_a?(RuboCop::AST::DstrNode)
   end
 end
 
+ensure_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast&.child_nodes&.first
+begin
+  do_something
+rescue
+  recover
+ensure
+  must_to_do
+end
+EOM
+if ensure_node.is_a?(RuboCop::AST::EnsureNode)
+  ensure_node.body
+end
+
 float_node = RuboCop::AST::ProcessedSource.new('1.1', RUBY_VERSION.to_f).ast
 if float_node.is_a?(RuboCop::AST::FloatNode)
   float_node.sign?

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -463,6 +463,13 @@ module RuboCop
       alias loc location
     end
 
+    class DefinedNode < Node
+      include ParameterizedNode
+      include MethodDispatchNode
+      def node_parts: () -> Array[Node | nil]
+      alias arguments children
+    end
+
     class DstrNode < Node
       def value: () -> String
       attr_reader location: (Parser::Source::Map::Collection | Parser::Source::Map::Heredoc)

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -476,6 +476,10 @@ module RuboCop
       alias loc location
     end
 
+    class EnsureNode < Node
+      def body: () -> Node?
+    end
+
     class FloatNode < Node
       include BasicLiteralNode
       include NumericNode

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -574,6 +574,17 @@ module RuboCop
       def kwsplat_type?: () -> true
     end
 
+    class LambdaNode < Node
+      include ParameterizedNode::RestArguments
+      include MethodDispatchNode
+      def lambda?: () -> true
+      def lambda_literal?: () -> true
+      def attribute_accessor?: () -> false
+      def assignment_method?: () -> false
+      def receiver: () -> nil
+      def method_name: () -> :lambda
+    end
+
     class ModuleNode < Node
       def identifier: () -> Node
       def body: () -> Node?

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -544,6 +544,14 @@ module RuboCop
       def body: () -> Node?
     end
 
+    class IndexNode < Node
+      include ParameterizedNode::RestArguments
+      include MethodDispatchNode
+      def attribute_accessor?: () -> false
+      def assignment_method?: () -> false
+      def method_name: () -> :[]
+    end
+
     class IntNode < Node
       include BasicLiteralNode
       include NumericNode

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -552,6 +552,14 @@ module RuboCop
       def method_name: () -> :[]
     end
 
+    class IndexasgnNode < Node
+      include ParameterizedNode::RestArguments
+      include MethodDispatchNode
+      def attribute_accessor?: () -> false
+      def assignment_method?: () -> true
+      def method_name: () -> :[]=
+    end
+
     class IntNode < Node
       include BasicLiteralNode
       include NumericNode

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -494,6 +494,10 @@ module RuboCop
       def body: () -> Node?
     end
 
+    class ForwardArgsNode < Node
+      def to_a: () -> [self]
+    end
+
     class HashNode < Node
       def pairs: () -> Array[PairNode]
       def empty?: () -> bool

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -565,6 +565,15 @@ module RuboCop
       include NumericNode
     end
 
+    class KeywordSplatNode < Node
+      include HashElementNode
+      def hash_rocket?: () -> false
+      def colon?: () -> false
+      def operator: () -> String
+      def node_parts: () -> [self, self]
+      def kwsplat_type?: () -> true
+    end
+
     class ModuleNode < Node
       def identifier: () -> Node
       def body: () -> Node?


### PR DESCRIPTION
Added:

- rubocop-ast
    - `RuboCop::AST::DefinedNode`
    - `RuboCop::AST::EnsureNode`
    - `RuboCop::AST::ForwardArgsNode`
    - `RuboCop::AST::IndexNode`
    - `RuboCop::AST::IndexasgnNode`
    - `RuboCop::AST::KeywordSplatNode`
    - `RuboCop::AST::LambdaNode`