### PR TITLE
Add types for rubocop ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -838,6 +838,17 @@ if return_node.is_a?(RuboCop::AST::ReturnNode)
   return_node.arguments
 end
 
+self_class_node = RuboCop::AST::ProcessedSource.new(<<EOM, RUBY_VERSION.to_f).ast
+class << self
+  def foo
+  end
+end
+EOM
+if self_class_node.is_a?(RuboCop::AST::SelfClassNode)
+  self_class_node.identifier
+  self_class_node.body
+end
+
 until_node = RuboCop::AST::ProcessedSource.new('1 until true', RUBY_VERSION.to_f).ast
 if until_node.is_a?(RuboCop::AST::UntilNode)
   until_node.single_line_condition?

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -672,6 +672,11 @@ module RuboCop
       include ParameterizedNode::WrappedArguments
     end
 
+    class SelfClassNode < Node
+      def identifier: () -> Node
+      def body: () -> Node?
+    end
+
     class SendNode < Node
       include ParameterizedNode::RestArguments
       include MethodDispatchNode


### PR DESCRIPTION
Added:

- rubocop-ast
    - `RuboCop::AST::NextNode`
    - `RuboCop::AST::Procarg0Node`
    - `RuboCop::AST::RescueNode`
    - `RuboCop::AST::ResbodyNode`
    - `RuboCop::AST::SelfClassNode`