### PR TITLE
rubocop-ast: Add types for rubocop-ast

### DIFF
--- a/gems/rubocop-ast/1.30/_test/test.rb
+++ b/gems/rubocop-ast/1.30/_test/test.rb
@@ -718,6 +718,26 @@ if send_node.is_a?(RuboCop::AST::SendNode)
   send_node.lambda_literal?
   send_node.unary_operation?
   send_node.binary_operation?
+  send_node.method?(:puts)
+  send_node.operator_method?
+  send_node.nonmutating_binary_operator_method?
+  send_node.nonmutating_unary_operator_method?
+  send_node.nonmutating_operator_method?
+  send_node.nonmutating_array_method?
+  send_node.nonmutating_hash_method?
+  send_node.nonmutating_string_method?
+  send_node.comparison_method?
+  send_node.assignment_method?
+  send_node.enumerator_method?
+  send_node.enumerable_method?
+  send_node.predicate_method?
+  send_node.bang_method?
+  send_node.camel_case_method?
+  send_node.self_receiver?
+  send_node.const_receiver?
+  send_node.negation_method?
+  send_node.prefix_not?
+  send_node.prefix_bang?
   send_node.send_type?
   send_node.location.dot
   send_node.location.selector

--- a/gems/rubocop-ast/1.30/rubocop-ast.rbs
+++ b/gems/rubocop-ast/1.30/rubocop-ast.rbs
@@ -97,6 +97,25 @@ module RuboCop
 
     module MethodIdentifierPredicates
       def method?: ((Symbol | String) name) -> bool
+      def operator_method?: () -> bool
+      def nonmutating_binary_operator_method?: () -> bool
+      def nonmutating_unary_operator_method?: () -> bool
+      def nonmutating_operator_method?: () -> bool
+      def nonmutating_array_method?: () -> bool
+      def nonmutating_hash_method?: () -> bool
+      def nonmutating_string_method?: () -> bool
+      def comparison_method?: () -> bool
+      def assignment_method?: () -> bool
+      def enumerator_method?: () -> bool
+      def enumerable_method?: () -> bool
+      def predicate_method?: () -> bool
+      def bang_method?: () -> bool
+      def camel_case_method?: () -> boolish
+      def self_receiver?: () -> boolish
+      def const_receiver?: () -> boolish
+      def negation_method?: () -> boolish
+      def prefix_not?: () -> boolish
+      def prefix_bang?: () -> boolish
     end
 
     module ModifierNode


### PR DESCRIPTION
- Added
    - `RuboCop::AST::CollectionNode`
- Modified
    - `RuboCop::AST::HashElementNode`
    - `RuboCOp::AST::MethodIdentifierPredicates`