### PR TITLE
Add Rails types for `Engine.routes` and `ActiveRecord::Relation::MULTI_VALUE_METHODS`

### DIFF
--- a/gems/activerecord/6.0/activerecord-6.0.rbs
+++ b/gems/activerecord/6.0/activerecord-6.0.rbs
@@ -161,9 +161,9 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
 
   # https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/query_methods.rb#L93
   # https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation.rb#L7
-  attr_reader order_values: Array[String | Symbol]?
-  attr_reader joins_values: Array[String | Symbol]?
-  attr_reader left_outer_joins_values: Array[String | Symbol]?
+  def order_values: () -> Array[String | Symbol]?
+  def joins_values: () -> Array[String | Symbol]?
+  def left_outer_joins_values: () -> Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/6.0/activerecord-6.0.rbs
+++ b/gems/activerecord/6.0/activerecord-6.0.rbs
@@ -159,8 +159,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
 
-  # https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/query_methods.rb#L93
-  # https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation.rb#L7
   def order_values: () -> Array[String | Symbol]?
   def joins_values: () -> Array[String | Symbol]?
   def left_outer_joins_values: () -> Array[String | Symbol]?

--- a/gems/activerecord/6.0/activerecord-6.0.rbs
+++ b/gems/activerecord/6.0/activerecord-6.0.rbs
@@ -158,6 +158,12 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
   def count: () -> ::Integer
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
+
+  # https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/query_methods.rb#L93
+  # https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation.rb#L7
+  attr_reader order_values: Array[String | Symbol]?
+  attr_reader joins_values: Array[String | Symbol]?
+  attr_reader left_outer_joins_values: Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -207,9 +207,9 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
 
   # https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation/query_methods.rb#L102
   # https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation.rb#L7
-  attr_reader order_values: Array[String | Symbol]?
-  attr_reader joins_values: Array[String | Symbol]?
-  attr_reader left_outer_joins_values: Array[String | Symbol]?
+  def order_values: () -> Array[String | Symbol]?
+  def joins_values: () -> Array[String | Symbol]?
+  def left_outer_joins_values: () -> Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -204,6 +204,12 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
   def count: () -> ::Integer
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
+
+  # https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation/query_methods.rb#L102
+  # https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation.rb#L7
+  attr_reader order_values: Array[String | Symbol]?
+  attr_reader joins_values: Array[String | Symbol]?
+  attr_reader left_outer_joins_values: Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/6.1/activerecord-6.1.rbs
+++ b/gems/activerecord/6.1/activerecord-6.1.rbs
@@ -205,8 +205,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
 
-  # https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation/query_methods.rb#L102
-  # https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation.rb#L7
   def order_values: () -> Array[String | Symbol]?
   def joins_values: () -> Array[String | Symbol]?
   def left_outer_joins_values: () -> Array[String | Symbol]?

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -249,6 +249,12 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
+
+  # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation/query_methods.rb#L151
+  # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation.rb#L7 
+  attr_reader order_values: Array[String | Symbol]?
+  attr_reader joins_values: Array[String | Symbol]?
+  attr_reader left_outer_joins_values: Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -251,10 +251,10 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
   def sole: () -> Model
 
   # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation/query_methods.rb#L151
-  # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation.rb#L7 
-  attr_reader order_values: Array[String | Symbol]?
-  attr_reader joins_values: Array[String | Symbol]?
-  attr_reader left_outer_joins_values: Array[String | Symbol]?
+  # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation.rb#L7
+  def order_values: () -> Array[String | Symbol]?
+  def joins_values: () -> Array[String | Symbol]?
+  def left_outer_joins_values: () -> Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/7.0/activerecord-7.0.rbs
+++ b/gems/activerecord/7.0/activerecord-7.0.rbs
@@ -250,8 +250,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
 
-  # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation/query_methods.rb#L151
-  # https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation.rb#L7
   def order_values: () -> Array[String | Symbol]?
   def joins_values: () -> Array[String | Symbol]?
   def left_outer_joins_values: () -> Array[String | Symbol]?

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -316,8 +316,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
 
-  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation/query_methods.rb#L159
-  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation.rb#L7
   def order_values: () -> Array[String | Symbol]?
   def joins_values: () -> Array[String | Symbol]?
   def left_outer_joins_values: () -> Array[String | Symbol]?

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -316,11 +316,11 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
 
-  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation/query_methods.rb#L159 
-  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation.rb#L7 
-  attr_reader order_values: Array[String | Symbol]?
-  attr_reader joins_values: Array[String | Symbol]?
-  attr_reader left_outer_joins_values: Array[String | Symbol]?
+  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation/query_methods.rb#L159
+  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation.rb#L7
+  def order_values: () -> Array[String | Symbol]?
+  def joins_values: () -> Array[String | Symbol]?
+  def left_outer_joins_values: () -> Array[String | Symbol]?
 
 end
 

--- a/gems/activerecord/7.1/activerecord-7.1.rbs
+++ b/gems/activerecord/7.1/activerecord-7.1.rbs
@@ -315,6 +315,13 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
+
+  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation/query_methods.rb#L159 
+  # https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation.rb#L7 
+  attr_reader order_values: Array[String | Symbol]?
+  attr_reader joins_values: Array[String | Symbol]?
+  attr_reader left_outer_joins_values: Array[String | Symbol]?
+
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -324,6 +324,12 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
+
+  # https://github.com/rails/rails/blob/v7.2.2.2/activerecord/lib/active_record/relation/query_methods.rb#L175
+  # https://github.com/rails/rails/blob/v7.2.2.2/activerecord/lib/active_record/relation.rb#L55
+  def order_values: () -> Array[String | Symbol]?
+  def joins_values: () -> Array[String | Symbol]?
+  def left_outer_joins_values: () -> Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -325,8 +325,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
 
-  # https://github.com/rails/rails/blob/v7.2.2.2/activerecord/lib/active_record/relation/query_methods.rb#L175
-  # https://github.com/rails/rails/blob/v7.2.2.2/activerecord/lib/active_record/relation.rb#L55
   def order_values: () -> Array[String | Symbol]?
   def joins_values: () -> Array[String | Symbol]?
   def left_outer_joins_values: () -> Array[String | Symbol]?

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -327,9 +327,9 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
 
   # https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation.rb#L55
   # https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation/query_methods.rb#L178
-  attr_reader order_values: Array[String | Symbol]?
-  attr_reader joins_values: Array[String | Symbol]?
-  attr_reader left_outer_joins_values: Array[String | Symbol]?
+  def order_values: () -> Array[String | Symbol]?
+  def joins_values: () -> Array[String | Symbol]?
+  def left_outer_joins_values: () -> Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -325,8 +325,6 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
 
-  # https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation.rb#L55
-  # https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation/query_methods.rb#L178
   def order_values: () -> Array[String | Symbol]?
   def joins_values: () -> Array[String | Symbol]?
   def left_outer_joins_values: () -> Array[String | Symbol]?

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -324,6 +324,12 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
            | () { (Model) -> boolish } -> ::Integer
            | (Symbol | String column_name) -> ::Integer
   def sole: () -> Model
+
+  # https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation.rb#L55
+  # https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation/query_methods.rb#L178
+  attr_reader order_values: Array[String | Symbol]?
+  attr_reader joins_values: Array[String | Symbol]?
+  attr_reader left_outer_joins_values: Array[String | Symbol]?
 end
 
 interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rubocop:disable RBS/Lint/TopLevelInterface

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -23,8 +23,6 @@ module Rails
     # Defines the routes for this engine. If a block is given to
     # routes, it is appended to the engine.
     def routes: () ?{ () [self: Mapper] -> void } -> ActionDispatch::Routing::RouteSet
-    # https://github.com/rails/rails/blob/v6.0.6.1/railties/lib/rails/engine.rb#L537
-    # https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L421
   end
 end
 

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -22,7 +22,9 @@ module Rails
   class Engine
     # Defines the routes for this engine. If a block is given to
     # routes, it is appended to the engine.
-    def routes: () ?{ () -> untyped } -> untyped
+    def routes: () ?{ () [self: Mapper] -> void } -> ActionDispatch::Routing::RouteSet
+    # https://github.com/rails/rails/blob/v6.0.6.1/railties/lib/rails/engine.rb#L537
+    # https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L421
   end
 end
 


### PR DESCRIPTION
This allows the use of e.g. `.order_values` etc. as specified by https://api.rubyonrails.org/classes/ActiveRecord/Relation.html

`.order_values` and `.join_values` have been available since at least Rails 3.0 https://github.com/rails/rails/blob/v3.0.0/activerecord/lib/active_record/relation/query_methods.rb#L9 and `.left_outer_joins_values` was added in Rails 5.0 https://api.rubyonrails.org/v5.0.0/classes/ActiveRecord/Relation.html

But the signatures are the same for all versions since then.


### railties

`Engine.routes` types are defined by  
- https://github.com/rails/rails/blob/v6.0.6.1/railties/lib/rails/engine.rb#L537
  - via https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L421
- and remain unchanged through at least
  - https://github.com/rails/rails/blob/v7.2.2.2/railties/lib/rails/engine.rb#L545
  - https://github.com/rails/rails/blob/v7.2.2.2/actionpack/lib/action_dispatch/routing/route_set.rb#L462

…to the best of our knowledge.

### activerecord

`ActiveRecord::Relation::MULTI_VALUE_METHODS` types haven't changed in 9 years, and are still the same today
- https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation/query_methods.rb#L178 calls https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/relation.rb#L55
- https://github.com/rails/rails/blob/v7.2.2.2/activerecord/lib/active_record/relation/query_methods.rb#L175 calls https://github.com/rails/rails/blob/v7.2.2.2/activerecord/lib/active_record/relation.rb#L55
- https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation/query_methods.rb#L159 calls https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/relation.rb#L7
- https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation/query_methods.rb#L151 calls https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/relation.rb#L7
- https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation/query_methods.rb#L102 calls https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/relation.rb#L7
- https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation/query_methods.rb#L93 calls https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/relation.rb#L7

etc.