### PR TITLE
Bugfix and regressiontest for `Engine.routes`

### DIFF
--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -65,12 +65,14 @@ module ActionDispatch
   module Routing
     class RouteSet
       def draw: () { () [self: Mapper] -> untyped } -> nil
-    end
-  end
-end
 
-module ActionDispatch
-  module Routing
+      class RouteSet_AnonymousModule
+        include ActiveSupport::Concern
+        include UrlFor
+        # https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L478
+      end
+    end
+
     class Mapper
       module HttpHelpers
         # Define a route that only recognizes HTTP GET.

--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -63,8 +63,15 @@ end
 
 module ActionDispatch
   module Routing
+    module PolymorphicRoutes
+      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
+      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
+    end
+
     class RouteSet
       def draw: () { () [self: Mapper] -> untyped } -> nil
+
+      def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
       class RouteSet_AnonymousModule
         include ActiveSupport::Concern

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -9995,6 +9995,12 @@ module ActionDispatch
         def define_url_helper: (untyped mod, untyped route, untyped name, untyped opts, untyped route_key, untyped url_strategy) -> untyped
       end
 
+      class RouteSet_AnonymousModule
+        include ActiveSupport::Concern
+        include UrlFor
+        # https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L478
+      end
+
       # strategy for building URLs to send to the client
       PATH: untyped
 
@@ -10078,7 +10084,7 @@ module ActionDispatch
 
       def define_mounted_helper: (untyped name, ?untyped? script_namer) -> (nil | untyped)
 
-      def url_helpers: (?bool supports_path) -> untyped
+      def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
       def empty?: () -> untyped
 

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -9747,10 +9747,10 @@ module ActionDispatch
       #   # the class of a record will also map to the collection
       #   polymorphic_url(Comment) # same as comments_url()
       #
-      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
+      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
 
       # Returns the path component of a URL for the given record.
-      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
+      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
 
       private
 

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -9995,12 +9995,6 @@ module ActionDispatch
         def define_url_helper: (untyped mod, untyped route, untyped name, untyped opts, untyped route_key, untyped url_strategy) -> untyped
       end
 
-      class RouteSet_AnonymousModule
-        include ActiveSupport::Concern
-        include UrlFor
-        # https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L478
-      end
-
       # strategy for building URLs to send to the client
       PATH: untyped
 

--- a/gems/actionpack/6.0/actionpack-generated.rbs
+++ b/gems/actionpack/6.0/actionpack-generated.rbs
@@ -9704,54 +9704,6 @@ module ActionDispatch
     #   form_for([blog, @post])         # => "/blog/posts/1"
     #
     module PolymorphicRoutes
-      # Constructs a call to a named RESTful route for the given record and returns the
-      # resulting URL string. For example:
-      #
-      #   # calls post_url(post)
-      #   polymorphic_url(post) # => "http://example.com/posts/1"
-      #   polymorphic_url([blog, post]) # => "http://example.com/blogs/1/posts/1"
-      #   polymorphic_url([:admin, blog, post]) # => "http://example.com/admin/blogs/1/posts/1"
-      #   polymorphic_url([user, :blog, post]) # => "http://example.com/users/1/blog/posts/1"
-      #   polymorphic_url(Comment) # => "http://example.com/comments"
-      #
-      # ==== Options
-      #
-      # * <tt>:action</tt> - Specifies the action prefix for the named route:
-      #   <tt>:new</tt> or <tt>:edit</tt>. Default is no prefix.
-      # * <tt>:routing_type</tt> - Allowed values are <tt>:path</tt> or <tt>:url</tt>.
-      #   Default is <tt>:url</tt>.
-      #
-      # Also includes all the options from <tt>url_for</tt>. These include such
-      # things as <tt>:anchor</tt> or <tt>:trailing_slash</tt>. Example usage
-      # is given below:
-      #
-      #   polymorphic_url([blog, post], anchor: 'my_anchor')
-      #     # => "http://example.com/blogs/1/posts/1#my_anchor"
-      #   polymorphic_url([blog, post], anchor: 'my_anchor', script_name: "/my_app")
-      #     # => "http://example.com/my_app/blogs/1/posts/1#my_anchor"
-      #
-      # For all of these options, see the documentation for {url_for}[rdoc-ref:ActionDispatch::Routing::UrlFor].
-      #
-      # ==== Functionality
-      #
-      #   # an Article record
-      #   polymorphic_url(record)  # same as article_url(record)
-      #
-      #   # a Comment record
-      #   polymorphic_url(record)  # same as comment_url(record)
-      #
-      #   # it recognizes new records and maps to the collection
-      #   record = Comment.new
-      #   polymorphic_url(record)  # same as comments_url()
-      #
-      #   # the class of a record will also map to the collection
-      #   polymorphic_url(Comment) # same as comments_url()
-      #
-      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
-
-      # Returns the path component of a URL for the given record.
-      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
-
       private
 
       def polymorphic_url_for_action: (untyped action, untyped record_or_hash, untyped options) -> untyped
@@ -10077,8 +10029,6 @@ module ActionDispatch
       def mounted_helpers: () -> untyped
 
       def define_mounted_helper: (untyped name, ?untyped? script_namer) -> (nil | untyped)
-
-      def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
       def empty?: () -> untyped
 

--- a/gems/actionpack/7.2/actiondispatch.rbs
+++ b/gems/actionpack/7.2/actiondispatch.rbs
@@ -65,12 +65,14 @@ module ActionDispatch
   module Routing
     class RouteSet
       def draw: () { () [self: Mapper] -> untyped } -> nil
-    end
-  end
-end
 
-module ActionDispatch
-  module Routing
+      class RouteSet_AnonymousModule
+        include ActiveSupport::Concern
+        include UrlFor
+        # https://github.com/rails/rails/blob/v7.2.2.2/actionpack/lib/action_dispatch/routing/route_set.rb#L518
+      end
+    end
+
     class Mapper
       module HttpHelpers
         # Define a route that only recognizes HTTP GET.

--- a/gems/actionpack/7.2/actiondispatch.rbs
+++ b/gems/actionpack/7.2/actiondispatch.rbs
@@ -63,8 +63,15 @@ end
 
 module ActionDispatch
   module Routing
+    module PolymorphicRoutes
+      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
+      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
+    end
+
     class RouteSet
       def draw: () { () [self: Mapper] -> untyped } -> nil
+
+      def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
       class RouteSet_AnonymousModule
         include ActiveSupport::Concern

--- a/gems/actionpack/7.2/actionpack-generated.rbs
+++ b/gems/actionpack/7.2/actionpack-generated.rbs
@@ -9747,10 +9747,10 @@ module ActionDispatch
       #   # the class of a record will also map to the collection
       #   polymorphic_url(Comment) # same as comments_url()
       #
-      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
+      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
 
       # Returns the path component of a URL for the given record.
-      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
+      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
 
       private
 

--- a/gems/actionpack/7.2/actionpack-generated.rbs
+++ b/gems/actionpack/7.2/actionpack-generated.rbs
@@ -9704,54 +9704,6 @@ module ActionDispatch
     #   form_for([blog, @post])         # => "/blog/posts/1"
     #
     module PolymorphicRoutes
-      # Constructs a call to a named RESTful route for the given record and returns the
-      # resulting URL string. For example:
-      #
-      #   # calls post_url(post)
-      #   polymorphic_url(post) # => "http://example.com/posts/1"
-      #   polymorphic_url([blog, post]) # => "http://example.com/blogs/1/posts/1"
-      #   polymorphic_url([:admin, blog, post]) # => "http://example.com/admin/blogs/1/posts/1"
-      #   polymorphic_url([user, :blog, post]) # => "http://example.com/users/1/blog/posts/1"
-      #   polymorphic_url(Comment) # => "http://example.com/comments"
-      #
-      # ==== Options
-      #
-      # * <tt>:action</tt> - Specifies the action prefix for the named route:
-      #   <tt>:new</tt> or <tt>:edit</tt>. Default is no prefix.
-      # * <tt>:routing_type</tt> - Allowed values are <tt>:path</tt> or <tt>:url</tt>.
-      #   Default is <tt>:url</tt>.
-      #
-      # Also includes all the options from <tt>url_for</tt>. These include such
-      # things as <tt>:anchor</tt> or <tt>:trailing_slash</tt>. Example usage
-      # is given below:
-      #
-      #   polymorphic_url([blog, post], anchor: 'my_anchor')
-      #     # => "http://example.com/blogs/1/posts/1#my_anchor"
-      #   polymorphic_url([blog, post], anchor: 'my_anchor', script_name: "/my_app")
-      #     # => "http://example.com/my_app/blogs/1/posts/1#my_anchor"
-      #
-      # For all of these options, see the documentation for {url_for}[rdoc-ref:ActionDispatch::Routing::UrlFor].
-      #
-      # ==== Functionality
-      #
-      #   # an Article record
-      #   polymorphic_url(record)  # same as article_url(record)
-      #
-      #   # a Comment record
-      #   polymorphic_url(record)  # same as comment_url(record)
-      #
-      #   # it recognizes new records and maps to the collection
-      #   record = Comment.new
-      #   polymorphic_url(record)  # same as comments_url()
-      #
-      #   # the class of a record will also map to the collection
-      #   polymorphic_url(Comment) # same as comments_url()
-      #
-      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
-
-      # Returns the path component of a URL for the given record.
-      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> String
-
       private
 
       def polymorphic_url_for_action: (untyped action, untyped record_or_hash, untyped options) -> untyped
@@ -10077,8 +10029,6 @@ module ActionDispatch
       def mounted_helpers: () -> untyped
 
       def define_mounted_helper: (untyped name, ?untyped? script_namer) -> (nil | untyped)
-
-      def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
       def empty?: () -> untyped
 

--- a/gems/actionpack/7.2/actionpack-generated.rbs
+++ b/gems/actionpack/7.2/actionpack-generated.rbs
@@ -9995,6 +9995,12 @@ module ActionDispatch
         def define_url_helper: (untyped mod, untyped route, untyped name, untyped opts, untyped route_key, untyped url_strategy) -> untyped
       end
 
+      class RouteSet_AnonymousModule
+        include ActiveSupport::Concern
+        include UrlFor
+        # https://github.com/rails/rails/blob/v7.2.2.2/actionpack/lib/action_dispatch/routing/route_set.rb#L518
+      end
+
       # strategy for building URLs to send to the client
       PATH: untyped
 
@@ -10078,7 +10084,7 @@ module ActionDispatch
 
       def define_mounted_helper: (untyped name, ?untyped? script_namer) -> (nil | untyped)
 
-      def url_helpers: (?bool supports_path) -> untyped
+      def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
       def empty?: () -> untyped
 

--- a/gems/actionpack/7.2/actionpack-generated.rbs
+++ b/gems/actionpack/7.2/actionpack-generated.rbs
@@ -9995,12 +9995,6 @@ module ActionDispatch
         def define_url_helper: (untyped mod, untyped route, untyped name, untyped opts, untyped route_key, untyped url_strategy) -> untyped
       end
 
-      class RouteSet_AnonymousModule
-        include ActiveSupport::Concern
-        include UrlFor
-        # https://github.com/rails/rails/blob/v7.2.2.2/actionpack/lib/action_dispatch/routing/route_set.rb#L518
-      end
-
       # strategy for building URLs to send to the client
       PATH: untyped
 

--- a/gems/railties/6.0/_test/test.rb
+++ b/gems/railties/6.0/_test/test.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :test1_models
 end
 
-raise <<~HEREDOC unless Rails.application.routes.url_helpers.polymorphic_path(:new_test1_model).instance_of?(String)
+raise <<~HEREDOC unless Rails.application.routes.url_helpers.polymorphic_path(:new_test1_model) == '/test1_models/new'
   But it should work, since:
   >>> Rails.application.routes.method(:url_helpers).source_location
   ["/usr/local/bundle/gems/actionpack-6.0.6.1/lib/action_dispatch/routing/route_set.rb", 478]

--- a/gems/railties/6.0/_test/test.rb
+++ b/gems/railties/6.0/_test/test.rb
@@ -1,0 +1,10 @@
+Rails.application.routes.draw do
+  resources :test1_models
+end
+
+raise <<~HEREDOC unless Rails.application.routes.url_helpers.polymorphic_path(TestModel2.new).instance_of?(String)
+  But it should work, since:
+  >>> Rails.application.routes.method(:url_helpers).source_location
+  ["/usr/local/bundle/gems/actionpack-6.0.6.1/lib/action_dispatch/routing/route_set.rb", 478]
+HEREDOC
+

--- a/gems/railties/6.0/_test/test.rb
+++ b/gems/railties/6.0/_test/test.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :test1_models
 end
 
-raise <<~HEREDOC unless Rails.application.routes.url_helpers.polymorphic_path(TestModel2.new).instance_of?(String)
+raise <<~HEREDOC unless Rails.application.routes.url_helpers.polymorphic_path(:new_test1_model).instance_of?(String)
   But it should work, since:
   >>> Rails.application.routes.method(:url_helpers).source_location
   ["/usr/local/bundle/gems/actionpack-6.0.6.1/lib/action_dispatch/routing/route_set.rb", 478]

--- a/gems/railties/6.0/_test/test.rbs
+++ b/gems/railties/6.0/_test/test.rbs
@@ -1,0 +1,5 @@
+class Test1Model < ActiveRecord::Base # ApplicationRecord
+end
+
+class Test2Model < Test1Model
+end

--- a/gems/railties/6.0/_test/test.rbs
+++ b/gems/railties/6.0/_test/test.rbs
@@ -1,5 +1,0 @@
-class Test1Model < ActiveRecord::Base # ApplicationRecord
-end
-
-class Test2Model < Test1Model
-end

--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -4774,7 +4774,7 @@ module Rails
 
   attr_accessor self.logger: untyped
 
-  def self.application: () -> untyped
+  def self.application: () -> Rails::Application
 
   # The Configuration instance used to configure the Rails environment
   def self.configuration: () -> untyped

--- a/gems/railties/6.0/railties-generated.rbs
+++ b/gems/railties/6.0/railties-generated.rbs
@@ -4774,8 +4774,6 @@ module Rails
 
   attr_accessor self.logger: untyped
 
-  def self.application: () -> Rails::Application
-
   # The Configuration instance used to configure the Rails environment
   def self.configuration: () -> untyped
 

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -22,7 +22,7 @@ module Rails
   class Engine
     # Defines the routes for this engine. If a block is given to
     # routes, it is appended to the engine.
-    def routes: () ?{ () [self: Mapper] -> void } -> ActionDispatch::Routing::RouteSet
+    def routes: () ?{ () [self: ActionDispatch::Routing::Mapper] -> void } -> ActionDispatch::Routing::RouteSet
   end
 end
 

--- a/gems/railties/6.0/railties.rbs
+++ b/gems/railties/6.0/railties.rbs
@@ -36,6 +36,8 @@ module Rails
 end
 
 module Rails
+  def self.application: () -> Rails::Application
+
   class Railties
     extend Initializable::ClassMethods
   end


### PR DESCRIPTION
Add a unit test to protect against future issues such as https://github.com/ruby/gem_rbs_collection/pull/931#discussion_r2298652222

RouteSet `def url_helpers` modelled after:
```
>>> Rails.application.routes.method(:url_helpers).source_location
["/usr/local/bundle/gems/actionpack-6.0.6.1/lib/action_dispatch/routing/route_set.rb", 478]
```