### PR TITLE
graphql: Add GraphQL::Schema::Resolver.null method signature

### DIFF
--- a/gems/graphql/1.12/_test/test.rb
+++ b/gems/graphql/1.12/_test/test.rb
@@ -73,6 +73,7 @@ module Mutations
 
   # sample mutation
   class Ping < BaseMutation
+    null true
     description "ping"
     argument :arg1, String, required: true, description: "arg1"
     argument :arg2, Boolean, required: true, description: "arg2"

--- a/gems/graphql/1.12/graphql.rbs
+++ b/gems/graphql/1.12/graphql.rbs
@@ -122,6 +122,7 @@ module GraphQL
       extend Member::HasArguments
       extend Member::HasArguments::ArgumentClassAccessor
       extend _Argument
+      def self.null: (?bool allow_null) -> untyped
       def self.type: (?(Class | Array[Class] | nil) new_type, ?null: bool null) -> void
 
       attr_reader object: untyped


### PR DESCRIPTION
Add GraphQL::Schema::Resolver.null method signature

References:
- https://graphql-ruby.org/api-doc/1.12.0/GraphQL/Schema/Resolver.html#null-class_method
- https://github.com/rmosolgo/graphql-ruby/blob/v1.12.0/lib/graphql/schema/resolver.rb#L221-L230
