### PR TITLE
Fix type definition for `ActionDispatch::Routing::RouteSet#url_helpers`

### DIFF
--- a/gems/actionpack/6.0/actiondispatch.rbs
+++ b/gems/actionpack/6.0/actiondispatch.rbs
@@ -73,7 +73,7 @@ module ActionDispatch
 
       def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
-      class RouteSet_AnonymousModule
+      module RouteSet_AnonymousModule
         include ActiveSupport::Concern
         include UrlFor
         # https://github.com/rails/rails/blob/v6.0.6.1/actionpack/lib/action_dispatch/routing/route_set.rb#L478

--- a/gems/actionpack/7.2/actiondispatch.rbs
+++ b/gems/actionpack/7.2/actiondispatch.rbs
@@ -73,7 +73,7 @@ module ActionDispatch
 
       def url_helpers: (?bool supports_path) -> RouteSet_AnonymousModule
 
-      class RouteSet_AnonymousModule
+      module RouteSet_AnonymousModule
         include ActiveSupport::Concern
         include UrlFor
         # https://github.com/rails/rails/blob/v7.2.2.2/actionpack/lib/action_dispatch/routing/route_set.rb#L518


### PR DESCRIPTION
Fix the type definition for `ActionDispatch::Routing::RouteSet#url_helpers` to `Module`

references

- https://github.com/rails/rails/blob/9204eb520c2784ca7a1da9a4884aad21c59088fd/actionpack/lib/action_dispatch/routing/route_set.rb#L518-L529
- https://github.com/rails/rails/blob/28bb76d3efc39b2ef663dfe2346f7c2621343cd6/actionpack/lib/action_dispatch/routing/route_set.rb#L478-L481