### PR TITLE
http: Add type signatures for HTTP verbs and chainable methods

### DIFF
--- a/gems/http/5.1/_test/test.rb
+++ b/gems/http/5.1/_test/test.rb
@@ -1,5 +1,6 @@
 require "http"
 
+# Test HTTP::Response initialization and methods
 response = HTTP::Response.new(
   status: 200,
   version: "1.1",
@@ -7,3 +8,78 @@ response = HTTP::Response.new(
 )
 
 response.code == 200
+response.reason
+response.flush
+response.to_s
+response.to_str
+
+# Test HTTP module singleton methods (verb methods)
+HTTP.get("https://example.com")
+HTTP.head("https://example.com")
+HTTP.post("https://example.com", { json: { key: "value" } })
+HTTP.put("https://example.com", { json: { key: "value" } })
+HTTP.patch("https://example.com", { json: { key: "value" } })
+HTTP.delete("https://example.com")
+HTTP.options("https://example.com")
+HTTP.trace("https://example.com")
+HTTP.connect("https://example.com")
+
+# Test HTTP module singleton chainable methods
+HTTP.headers({"Accept" => "application/json"}).get("https://example.com")
+HTTP["Accept" => "application/json"].get("https://example.com")
+HTTP.basic_auth(user: "username", pass: "password").get("https://example.com")
+HTTP.auth("Bearer token").get("https://example.com")
+HTTP.cookies(session: "value").get("https://example.com")
+HTTP.follow.get("https://example.com")
+HTTP.follow(max_hops: 3).get("https://example.com")
+HTTP.timeout(5).get("https://example.com")
+HTTP.timeout(connect: 2, read: 5, write: 2).get("https://example.com")
+HTTP.via("proxy.example.com", 8080).get("https://example.com")
+HTTP.via("proxy.example.com", 8080, "user", "pass").get("https://example.com")
+HTTP.use(:auto_inflate).get("https://example.com")
+
+# Test HTTP.persistent
+client = HTTP.persistent("https://example.com")
+client.get("/path1")
+client.get("/path2")
+client.close
+
+# Test HTTP.persistent with block
+HTTP.persistent("https://example.com") do |http|
+  http.get("/path1")
+  http.get("/path2")
+end
+
+# Test HTTP::Client methods
+client = HTTP::Client.new
+client.get("https://example.com")
+client.head("https://example.com")
+client.post("https://example.com", { json: { key: "value" } })
+client.put("https://example.com", { json: { key: "value" } })
+client.patch("https://example.com", { json: { key: "value" } })
+client.delete("https://example.com")
+client.options("https://example.com")
+client.trace("https://example.com")
+client.connect("https://example.com")
+
+# Test HTTP::Client chainable methods
+client.headers({"Accept" => "application/json"})
+client["Accept" => "application/json"]
+client.basic_auth(user: "username", pass: "password")
+client.auth("Bearer token")
+client.cookies(session: "value")
+client.follow
+client.follow(max_hops: 3)
+client.timeout(5)
+client.timeout(connect: 2, read: 5, write: 2)
+client.via("proxy.example.com", 8080)
+client.via("proxy.example.com", 8080, "user", "pass")
+client.use(:auto_inflate)
+client.persistent?
+
+# Test chaining
+HTTP.headers("Accept" => "application/json")
+    .basic_auth(user: "user", pass: "pass")
+    .timeout(5)
+    .follow
+    .get("https://example.com")

--- a/gems/http/5.1/http.rbs
+++ b/gems/http/5.1/http.rbs
@@ -5,6 +5,36 @@ module HTTP
 
   def self.auth: (_ToS) -> HTTP::Client
 
+  def self.get: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.head: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.post: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.put: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.patch: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.delete: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.options: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.trace: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+  def self.connect: (String uri, ?Hash[Symbol, untyped] opts) -> Response
+
+  def self.headers: (Hash[String, String?]) -> Client
+  def self.[]: (Hash[String, String?]) -> Client
+
+  def self.basic_auth: (Hash[Symbol, String] credentials) -> Client
+
+  def self.cookies: (Hash[String | Symbol, String]) -> Client
+
+  def self.follow: (?Hash[Symbol, untyped] options) -> Client
+
+  def self.timeout: (?connect: Numeric, ?write: Numeric, ?read: Numeric) -> Client
+                  | (Numeric timeout) -> Client
+
+  def self.via: (String host, Integer port, ?String username, ?String password) -> Client
+              | (String host, Integer port, Hash[String, String] headers) -> Client
+
+  def self.use: (*untyped args, **untyped kwargs) -> Client
+
+  def self.persistent: (String host) -> Client
+                     | (String host) { (Client) -> untyped } -> untyped
+
   class Options
   end
 
@@ -14,6 +44,36 @@ module HTTP
     def close: () -> void
 
     def request: (_ToS verb, HTTP::URI | _ToS uri, ?Hash[Symbol, untyped] opts) -> Response
+
+    def get: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def head: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def post: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def put: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def patch: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def delete: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def options: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def trace: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+    def connect: (String | URI uri, ?Hash[Symbol, untyped] opts) -> Response
+
+    def headers: (Hash[String, String?]) -> Client
+    def []: (Hash[String, String?]) -> Client
+
+    def auth: (_ToS) -> Client
+    def basic_auth: (Hash[Symbol, String] credentials) -> Client
+
+    def cookies: (Hash[String | Symbol, String]) -> Client
+
+    def follow: (?Hash[Symbol, untyped] options) -> Client
+
+    def timeout: (?connect: Numeric, ?write: Numeric, ?read: Numeric) -> Client
+               | (Numeric timeout) -> Client
+
+    def via: (String host, Integer port, ?String username, ?String password) -> Client
+           | (String host, Integer port, Hash[String, String] headers) -> Client
+
+    def use: (*untyped args, **untyped kwargs) -> Client
+
+    def persistent?: () -> bool
   end
 
   class Headers
@@ -217,6 +277,9 @@ module HTTP
     def code: () -> Integer
     def reason: () -> String?
     def flush: () -> self
+    def parse: (?String type) -> untyped
+    def to_s: () -> String
+    def to_str: () -> String
   end
 
   class URI


### PR DESCRIPTION
Add missing method signatures for:
- HTTP verb methods (get, head, post, put, patch, delete, options, trace, connect)
- Chainable configuration methods (headers, auth, cookies, follow, timeout, via, use, persistent)
- HTTP::Response methods (parse, to_s, to_str)

All methods follow the existing pattern using `?Hash[Symbol, untyped] opts` for consistency with the request method.

References:
- https://github.com/httprb/http/blob/v5.1.0/lib/http/client.rb
- https://github.com/httprb/http/wiki/Making-Requests