### PR TITLE
Fix kaminari-activerecord relation type

### DIFF
--- a/gems/kaminari-activerecord/1.2/kaminari-activerecord.rbs
+++ b/gems/kaminari-activerecord/1.2/kaminari-activerecord.rbs
@@ -25,10 +25,9 @@ module ActiveRecord
   end
 
   class Relation
-    module Methods[Model, PrimaryKey]
-      include Kaminari::ActiveRecordRelationMethods
-      include Kaminari::PageScopeMethods
-      def page: (?_ToI num) -> self
-    end
+    include Kaminari::ActiveRecordRelationMethods
+    include Kaminari::PageScopeMethods
+
+    def page: (?_ToI num) -> self
   end
 end


### PR DESCRIPTION
Previously, we needed to add our own handwritten type to AR model.

```rbs
class Talk < ApplicationRecord
  class ActiveRecord_Relation
    def page: (untyped) -> self
    def per: (Integer) -> self
  end
end
```

This is fixed by this Pull Request.