### PR TITLE
Add llhttp gem

### DIFF
--- a/gems/llhttp/0.6/_test/test.rb
+++ b/gems/llhttp/0.6/_test/test.rb
@@ -1,0 +1,8 @@
+require "llhttp"
+
+parser = LLHttp::Parser.new(LLHttp::Delegate.new, type: :response)
+parser.reset
+parser << "HTTP/1.1 200 OK\r\n\r\n"
+parser.status_code
+parser.http_major
+parser.http_minor

--- a/gems/llhttp/0.6/llhttp.rbs
+++ b/gems/llhttp/0.6/llhttp.rbs
@@ -1,0 +1,17 @@
+module LLHttp
+  class Error < StandardError
+  end
+
+  class Parser
+    def initialize: (untyped delegate, ?type: Symbol) -> void
+    def reset: () -> void
+    def <<: (String data) -> void
+    def status_code: () -> Integer
+    def http_major: () -> Integer
+    def http_minor: () -> Integer
+  end
+
+  class Delegate
+    def initialize: () -> void
+  end
+end


### PR DESCRIPTION
## Summary

- Adds minimal RBS stubs for the [`llhttp`](https://rubygems.org/gems/llhttp) gem at `gems/llhttp/0.6/`.
- Sibling to #1030 (`llhttp-ffi`): the [`http`](https://rubygems.org/gems/http) gem 6.x's gemspec runtime-depends on `llhttp` (`~> 0.6.1`), not `llhttp-ffi`, so most consumers of `http`'s RBS need this one to satisfy `Cannot find type \`LLHttp::Delegate\`` errors raised from `gems/http/.../sig/http.rbs`.
- The two gems expose an identical public `LLHttp` namespace, so the stub here is verbatim what was merged in #1030.

## Stub surface

Intentionally minimal — limited to what `gems/http/.../sig/http.rbs` references (`LLHttp::Delegate`, `LLHttp::Parser`, plus the parser methods `Response::Parser` calls). Not an attempt to type the whole gem.

## Test plan

- [x] `bin/test gems/llhttp/0.6` passes (rbs validate, steep check, untyped-call check).