### PR TITLE
feat(ancestry): Update types for v5.0

### DIFF
--- a/gems/ancestry/4.3/ancestry.rbs
+++ b/gems/ancestry/4.3/ancestry.rbs
@@ -1,4 +1,6 @@
 module Ancestry
+  VERSION: String
+
   type depth_options = Hash[:before_depth | :to_depth | :at_depth | :from_depth | :after_depth, Integer]
 
   def self.default_update_strategy: () -> (:sql | :ruby)

--- a/gems/ancestry/5.0/ancestry.rbs
+++ b/gems/ancestry/5.0/ancestry.rbs
@@ -1,4 +1,6 @@
 module Ancestry
+  VERSION: String
+
   type depth_options = Hash[:before_depth | :to_depth | :at_depth | :from_depth | :after_depth, Integer]
 
   def self.default_update_strategy: () -> (:sql | :ruby)

--- a/gems/ancestry/5.0/ancestry/instance_methods.rbs
+++ b/gems/ancestry/5.0/ancestry/instance_methods.rbs
@@ -4,8 +4,6 @@ module Ancestry
 
     def update_descendants_with_new_ancestry: () -> void
 
-    def apply_orphan_strategy: () -> void
-
     def apply_orphan_strategy_rootify: () -> void
 
     def apply_orphan_strategy_destroy: () -> void

--- a/gems/ancestry/5.0/ancestry/materialized_path.rbs
+++ b/gems/ancestry/5.0/ancestry/materialized_path.rbs
@@ -42,7 +42,7 @@ module Ancestry
 
     def concat: (*String args) -> String
 
-    def self.construct_depth_sql: (String table_name, String ancestry_column, String ancestry_delimiter) -> String
+    def self.construct_depth_sql: (String table_name, String | Symbol ancestry_column, String ancestry_delimiter) -> String
 
     private
 

--- a/gems/ancestry/5.0/ancestry/materialized_path2.rbs
+++ b/gems/ancestry/5.0/ancestry/materialized_path2.rbs
@@ -16,7 +16,7 @@ module Ancestry
 
     def generate_ancestry: (Array[PrimaryKey]? ancestor_ids) -> String
 
-    def self.construct_depth_sql: (String table_name, String ancestry_column, String ancestry_delimiter) -> String
+    def self.construct_depth_sql: (String table_name, String | Symbol ancestry_column, String ancestry_delimiter) -> String
 
     private
 


### PR DESCRIPTION
- Add Ancestry::Version
- Remove apply_orphan_strategy from v5.0
  - cf. https://github.com/stefankroes/ancestry/blob/v5.0.0/lib/ancestry/has_ancestry.rb#L64
- Allow Symbol in the ancestry_column of `construct_depth_sql`
  - cf. https://github.com/stefankroes/ancestry/blob/v5.0.0/lib/ancestry/has_ancestry.rb#L24-L25
  - cf. Ancestry::HasAncestry#has_ancestry