### PR TITLE
rubocop: Fix the patch for Parser::Source::Comment

### DIFF
--- a/gems/rubocop/1.57/rubocop.rbs
+++ b/gems/rubocop/1.57/rubocop.rbs
@@ -193,16 +193,20 @@ module RuboCop
   end
 end
 
-# Patch to RuboCop::AST::*
+# Patch to RuboCop::AST::* and Parser::Source::Comment
 
 module RuboCop
   module AST
-    class Comment
-      include Ext::Comment
-    end
-
     class ProcessedSource
       include Ext::ProcessedSource
+    end
+  end
+end
+
+module Parser
+  class Source
+    class Comment
+      include RuboCop::Ext::Comment
     end
   end
 end


### PR DESCRIPTION
RuboCop::Ext::Comment should be included into Parser::Source::Comment, not RuboCop::AST::Comment.  The current patch is incorrect.  This fixes the patch to be applied to the correct class.

ref:

* #1020
* https://github.com/rubocop/rubocop/blob/master/lib/rubocop/ext/comment.rb