### PR TITLE
docs: fix 'directory' typo in CONTRIBUTING

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Before you start💎
 
 **If you are the owner of the gem:**
-Adding RBS files directory in your gem would be a better option.
+Adding RBS files directly in your gem would be a better option.
 Write RBS files, put them in `sig` directory, and included the directory in the gem package.
 
 **If you are not the owner of the gem:**


### PR DESCRIPTION
Tiny typo: 'Adding RBS files directory in your gem' → 'directly' (the intended adverb).