### PR TITLE
activerecord: Remove redundant `steep:ignore FallbackAny` comments

### DIFF
--- a/gems/activerecord/7.2/_test/activerecord-generated.rb
+++ b/gems/activerecord/7.2/_test/activerecord-generated.rb
@@ -36,7 +36,7 @@ user.articles.build(ActionController::Parameters.new)
 
 User.eager_load(:address, friends: [:address, :followers])
 User.includes(:address, :friends).to_a
-User.preload(:address, friends: [:address, { followers: :users }]) # steep:ignore FallbackAny
+User.preload(:address, friends: [:address, { followers: :users }])
 User.in_order_of(:id, [1, 5, 3])
 User.offset(5).limit(10)
 User.count

--- a/gems/activerecord/8.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/8.0/_test/activerecord-generated.rb
@@ -36,7 +36,7 @@ user.articles.build(ActionController::Parameters.new)
 
 User.eager_load(:address, friends: [:address, :followers])
 User.includes(:address, :friends).to_a
-User.preload(:address, friends: [:address, { followers: :users }]) # steep:ignore FallbackAny
+User.preload(:address, friends: [:address, { followers: :users }])
 User.in_order_of(:id, [1, 5, 3])
 User.offset(5).limit(10)
 User.count


### PR DESCRIPTION
steep 2.0.0 reports these as `Ruby::RedundantIgnoreComment` errors.

```
activerecord-generated.rb:39:69: [error] Redundant ignore comment
│ Diagnostic ID: Ruby::RedundantIgnoreComment
│
└ User.preload(:address, friends: [:address, { followers: :users }]) # steep:ignore FallbackAny
```

The ignore comments were no longer needed, so they were removed.