### PR TITLE
activerecord: refine create/create! RBS signatures and update tests

### DIFF
--- a/gems/activerecord/7.2/_test/activerecord-7.2.rb
+++ b/gems/activerecord/7.2/_test/activerecord-7.2.rb
@@ -91,4 +91,18 @@ module Test
   User.order(id: :asc).reorder(id: :desc)
 
   User.all.table_name
+
+  user = User.create(name: 'James')
+  user.articles
+  User.create(name: 'James') { |user| user.articles }
+  users = User.create([{name: 'James'}, {name: 'John'}])
+  users.first.articles
+  User.create([{name: 'James'}, {name: 'John'}]) { |user| user.articles }
+
+  user = User.create!(name: 'James')
+  user.articles
+  User.create!(name: 'James') { |user| user.articles }
+  users = User.create!([{name: 'James'}, {name: 'John'}])
+  users.first.articles
+  User.create!([{name: 'James'}, {name: 'John'}]) { |user| user.articles }
 end

--- a/gems/activerecord/7.2/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/activerecord-7.2.rbs
@@ -156,6 +156,43 @@ module ActiveRecord
 
   module Persistence
     def previously_persisted?: () -> bool
+
+    module ClassMethods
+      # Creates an object (or multiple objects) and saves it to the database, if validations pass.
+      # The resulting object is returned whether the object was saved successfully to the database or not.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
+      # attributes on the objects that are to be created.
+      #
+      # ==== Examples
+      #   # Create a single new object
+      #   User.create(first_name: 'Jamie')
+      #
+      #   # Create an Array of new objects
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
+      #
+      #   # Create a single object and pass it into a block to set other attributes.
+      #   User.create(first_name: 'Jamie') do |u|
+      #     u.is_admin = false
+      #   end
+      #
+      #   # Creating an Array of new objects using a block, where the block is executed for each object:
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
+      #     u.is_admin = false
+      #   end
+      def create: (Array[untyped] attributes) ?{ (instance) -> void } -> Array[instance]
+                | (?untyped? attributes) ?{ (instance) -> void } -> instance
+
+      # Creates an object (or multiple objects) and saves it to the database,
+      # if validations pass. Raises a RecordInvalid error if validations fail,
+      # unlike Base#create.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes.
+      # These describe which attributes to be created on the object, or
+      # multiple objects when given an Array of Hashes.
+      def create!: (Array[untyped] attributes) ?{ (instance) -> void } -> Array[instance]
+                 | (?untyped? attributes) ?{ (instance) -> void } -> instance
+    end
   end
 
   class InsertAll

--- a/gems/activerecord/7.2/activerecord-generated.rbs
+++ b/gems/activerecord/7.2/activerecord-generated.rbs
@@ -16121,39 +16121,6 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Creates an object (or multiple objects) and saves it to the database, if validations pass.
-      # The resulting object is returned whether the object was saved successfully to the database or not.
-      #
-      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
-      # attributes on the objects that are to be created.
-      #
-      # ==== Examples
-      #   # Create a single new object
-      #   User.create(first_name: 'Jamie')
-      #
-      #   # Create an Array of new objects
-      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
-      #
-      #   # Create a single object and pass it into a block to set other attributes.
-      #   User.create(first_name: 'Jamie') do |u|
-      #     u.is_admin = false
-      #   end
-      #
-      #   # Creating an Array of new objects using a block, where the block is executed for each object:
-      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
-      #     u.is_admin = false
-      #   end
-      def create: (?untyped? attributes) ?{ () -> untyped } -> untyped
-
-      # Creates an object (or multiple objects) and saves it to the database,
-      # if validations pass. Raises a RecordInvalid error if validations fail,
-      # unlike Base#create.
-      #
-      # The +attributes+ parameter can be either a Hash or an Array of Hashes.
-      # These describe which attributes to be created on the object, or
-      # multiple objects when given an Array of Hashes.
-      def create!: (?untyped? attributes) ?{ () -> untyped } -> untyped
-
       # Given an attributes hash, +instantiate+ returns a new instance of
       # the appropriate class. Accepts only keys as strings.
       #

--- a/gems/activerecord/7.2/activerecord.rbs
+++ b/gems/activerecord/7.2/activerecord.rbs
@@ -49,8 +49,6 @@ module ActiveRecord
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped
     def self.transaction: [T] (?requires_new: boolish, ?isolation: (:read_uncommitted | :read_committed | :repeatable_read | :serializable)?, ?joinable: boolish) { () -> T } -> T
-    def self.create: (**untyped) -> instance
-    def self.create!: (**untyped) -> instance
     def self.validate: (*untyped, ?if: conditions[instance], ?unless: conditions[instance], **untyped) -> void
     def self.validates: (*untyped, ?if: conditions[instance], ?unless: conditions[instance], **untyped) -> void
 

--- a/gems/activerecord/8.0/_test/activerecord-8.0.rb
+++ b/gems/activerecord/8.0/_test/activerecord-8.0.rb
@@ -91,4 +91,18 @@ module Test
   User.order(id: :asc).reorder(id: :desc)
 
   User.all.table_name
+
+  user = User.create(name: 'James')
+  user.articles
+  User.create(name: 'James') { |user| user.articles }
+  users = User.create([{name: 'James'}, {name: 'John'}])
+  users.first.articles
+  User.create([{name: 'James'}, {name: 'John'}]) { |user| user.articles }
+
+  user = User.create!(name: 'James')
+  user.articles
+  User.create!(name: 'James') { |user| user.articles }
+  users = User.create!([{name: 'James'}, {name: 'John'}])
+  users.first.articles
+  User.create!([{name: 'James'}, {name: 'John'}]) { |user| user.articles }
 end

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -156,6 +156,43 @@ module ActiveRecord
 
   module Persistence
     def previously_persisted?: () -> bool
+
+    module ClassMethods
+      # Creates an object (or multiple objects) and saves it to the database, if validations pass.
+      # The resulting object is returned whether the object was saved successfully to the database or not.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
+      # attributes on the objects that are to be created.
+      #
+      # ==== Examples
+      #   # Create a single new object
+      #   User.create(first_name: 'Jamie')
+      #
+      #   # Create an Array of new objects
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
+      #
+      #   # Create a single object and pass it into a block to set other attributes.
+      #   User.create(first_name: 'Jamie') do |u|
+      #     u.is_admin = false
+      #   end
+      #
+      #   # Creating an Array of new objects using a block, where the block is executed for each object:
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
+      #     u.is_admin = false
+      #   end
+      def create: (Array[untyped] attributes) ?{ (instance) -> void } -> Array[instance]
+                | (?untyped? attributes) ?{ (instance) -> void } -> instance
+
+      # Creates an object (or multiple objects) and saves it to the database,
+      # if validations pass. Raises a RecordInvalid error if validations fail,
+      # unlike Base#create.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes.
+      # These describe which attributes to be created on the object, or
+      # multiple objects when given an Array of Hashes.
+      def create!: (Array[untyped] attributes) ?{ (instance) -> void } -> Array[instance]
+                 | (?untyped? attributes) ?{ (instance) -> void } -> instance
+    end
   end
 
   class InsertAll

--- a/gems/activerecord/8.0/activerecord-generated.rbs
+++ b/gems/activerecord/8.0/activerecord-generated.rbs
@@ -16121,39 +16121,6 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Creates an object (or multiple objects) and saves it to the database, if validations pass.
-      # The resulting object is returned whether the object was saved successfully to the database or not.
-      #
-      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
-      # attributes on the objects that are to be created.
-      #
-      # ==== Examples
-      #   # Create a single new object
-      #   User.create(first_name: 'Jamie')
-      #
-      #   # Create an Array of new objects
-      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
-      #
-      #   # Create a single object and pass it into a block to set other attributes.
-      #   User.create(first_name: 'Jamie') do |u|
-      #     u.is_admin = false
-      #   end
-      #
-      #   # Creating an Array of new objects using a block, where the block is executed for each object:
-      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
-      #     u.is_admin = false
-      #   end
-      def create: (?untyped? attributes) ?{ () -> untyped } -> untyped
-
-      # Creates an object (or multiple objects) and saves it to the database,
-      # if validations pass. Raises a RecordInvalid error if validations fail,
-      # unlike Base#create.
-      #
-      # The +attributes+ parameter can be either a Hash or an Array of Hashes.
-      # These describe which attributes to be created on the object, or
-      # multiple objects when given an Array of Hashes.
-      def create!: (?untyped? attributes) ?{ () -> untyped } -> untyped
-
       # Given an attributes hash, +instantiate+ returns a new instance of
       # the appropriate class. Accepts only keys as strings.
       #

--- a/gems/activerecord/8.0/activerecord.rbs
+++ b/gems/activerecord/8.0/activerecord.rbs
@@ -49,8 +49,6 @@ module ActiveRecord
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped
     def self.transaction: [T] (?requires_new: boolish, ?isolation: (:read_uncommitted | :read_committed | :repeatable_read | :serializable)?, ?joinable: boolish) { () -> T } -> T
-    def self.create: (**untyped) -> instance
-    def self.create!: (**untyped) -> instance
     def self.validate: (*untyped, ?if: conditions[instance], ?unless: conditions[instance], **untyped) -> void
     def self.validates: (*untyped, ?if: conditions[instance], ?unless: conditions[instance], **untyped) -> void
 


### PR DESCRIPTION
- Allow passing a block to `create` / `create!` .
- Add overloads for `attributes` as an Array of hashes and array return types.
- Add tests for `create` / `create!` .

## Note on file placement

The `create` / `create!` signatures are defined in `activerecord-8.0.rbs` rather than `activerecord.rbs`, because these methods are statically defined in Ruby source, not dynamically generated at runtime. The `activerecord.rbs` file already declares `extend ::ActiveRecord::Persistence::ClassMethods` on `ActiveRecord::Base`, so the type checker resolves them through that module naturally. Is this reasoning correct?