### PR TITLE
activerecord: Instance self type for the `:default` option argument in `belongs_to` 

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -42,9 +42,11 @@ module ActiveRecord
     extend ::ActiveRecord::Validations::ClassMethods
     extend ::ActiveSupport::Callbacks::ClassMethods
 
+    type belongs_to_default[T] = ^(T) [self: T] -> ::ActiveRecord::Base?
+
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void
-    def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
+    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: belongs_to_default[instance]) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped

--- a/gems/activerecord/7.2/_test/activerecord-7.2.rb
+++ b/gems/activerecord/7.2/_test/activerecord-7.2.rb
@@ -34,6 +34,11 @@ module Test
   end
 
   class Article < ApplicationRecord
+    belongs_to :user, default: -> { default_user }
+
+    def default_user
+      User.first
+    end
   end
 
   User.where.missing.to_sql

--- a/gems/activerecord/7.2/_test/activerecord-7.2.rbs
+++ b/gems/activerecord/7.2/_test/activerecord-7.2.rbs
@@ -21,5 +21,7 @@ module Test
     class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
       include ::ActiveRecord::Relation::Methods[Article, Integer]
     end
+
+    def default_user: () -> User?
   end
 end

--- a/gems/activerecord/7.2/activerecord.rbs
+++ b/gems/activerecord/7.2/activerecord.rbs
@@ -42,9 +42,11 @@ module ActiveRecord
     extend ::ActiveRecord::Validations::ClassMethods
     extend ::ActiveSupport::Callbacks::ClassMethods
 
+    type belongs_to_default[T] = ^(T) [self: T] -> ::ActiveRecord::Base?
+
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void
-    def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
+    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: belongs_to_default[instance]) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped

--- a/gems/activerecord/8.0/_test/activerecord-8.0.rb
+++ b/gems/activerecord/8.0/_test/activerecord-8.0.rb
@@ -34,6 +34,11 @@ module Test
   end
 
   class Article < ApplicationRecord
+    belongs_to :user, default: -> { default_user }
+
+    def default_user
+      User.first
+    end
   end
 
   User.where.missing.to_sql

--- a/gems/activerecord/8.0/_test/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/_test/activerecord-8.0.rbs
@@ -21,5 +21,7 @@ module Test
     class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
       include ::ActiveRecord::Relation::Methods[Article, Integer]
     end
+
+    def default_user: () -> User?
   end
 end

--- a/gems/activerecord/8.0/activerecord.rbs
+++ b/gems/activerecord/8.0/activerecord.rbs
@@ -42,9 +42,11 @@ module ActiveRecord
     extend ::ActiveRecord::Validations::ClassMethods
     extend ::ActiveSupport::Callbacks::ClassMethods
 
+    type belongs_to_default[T] = ^(T) [self: T] -> ::ActiveRecord::Base?
+
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void
-    def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
+    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: belongs_to_default[instance]) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped


### PR DESCRIPTION
In Active Record `belongs_to` option `:default`, the self type in block is the instance type instead the singleton type. Doc: https://apidock.com/rails/ActiveRecord/Associations/ClassMethods/belongs_to#:~:text=belongs%5Fto%20%3Aaccount%2C%20default%3A%20%2D%3E%20%7B%20company%2Eaccount%20%7D

In applications like Fizzy, it's a [very common use](https://github.com/basecamp/fizzy/blob/de2be807bb43b34cd7f60968af2e490666d1acca/app/models/card.rb#L6).

Without this fix, we have this output error:
```
activerecord-8.0.rb:37:36: [error] Type `singleton(::Test::Article)` does not have method `default_user`
│ Diagnostic ID: Ruby::NoMethod
│
└     belongs_to :user, default: -> { default_user }
                                      ~~~~~~~~~~~~

Detected 1 problem from 1 file

```