### PR TITLE
activerecord: Add filter keyword argument to in_order_of

### DIFF
--- a/gems/activerecord/8.0/_test/activerecord-generated.rb
+++ b/gems/activerecord/8.0/_test/activerecord-generated.rb
@@ -38,6 +38,7 @@ User.eager_load(:address, friends: [:address, :followers])
 User.includes(:address, :friends).to_a
 User.preload(:address, friends: [:address, { followers: :users }])
 User.in_order_of(:id, [1, 5, 3])
+User.in_order_of(:id, [1, 5, 3], filter: false)
 User.offset(5).limit(10)
 User.count
 User.create_with(name: 'name', age: 1)

--- a/gems/activerecord/8.0/activerecord-8.0.rbs
+++ b/gems/activerecord/8.0/activerecord-8.0.rbs
@@ -255,7 +255,7 @@ interface _ActiveRecord_Relation[Model, PrimaryKey] # rubocop:disable RBS/Lint/T
   def exists?: (*untyped) -> bool
   def order: (*untyped) -> self
   def group: (*Symbol | String) -> untyped
-  def in_order_of: (Symbol, Array[untyped]) -> self
+  def in_order_of: (Symbol, Array[untyped], ?filter: bool) -> self
   def reorder: (*untyped args) -> self
   def unscope: (*untyped args) -> self
   def distinct: () -> self
@@ -355,7 +355,7 @@ interface _ActiveRecord_Relation_ClassMethods[Model, Relation, PrimaryKey] # rub
           | () { (Model) -> boolish } -> bool
   def order: (*untyped) -> Relation
   def group: (*Symbol | String) -> untyped
-  def in_order_of: (Symbol, Array[untyped]) -> Relation
+  def in_order_of: (Symbol, Array[untyped], ?filter: bool) -> Relation
   def reorder: (*untyped args) -> Relation
   def unscope: (*untyped args) -> Relation
   def distinct: () -> Relation

--- a/gems/activerecord/8.0/activerecord.rbs
+++ b/gems/activerecord/8.0/activerecord.rbs
@@ -429,7 +429,7 @@ module ActiveRecord
       def exists?: (*untyped) -> bool
       def order: (*untyped) -> self
       def group: (*Symbol | String) -> untyped
-      def in_order_of: (Symbol, Array[untyped]) -> self
+      def in_order_of: (Symbol, Array[untyped], ?filter: bool) -> self
       def distinct: () -> self
       def or: (::ActiveRecord::Relation) -> self
       def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> self
@@ -528,7 +528,7 @@ module ActiveRecord
               | () { (Model) -> boolish } -> bool
       def order: (*untyped) -> Relation
       def group: (*Symbol | String) -> untyped
-      def in_order_of: (Symbol, Array[untyped]) -> Relation
+      def in_order_of: (Symbol, Array[untyped], ?filter: bool) -> Relation
       def distinct: () -> Relation
       def or: (::ActiveRecord::Relation) -> Relation
       def merge: (Array[untyped] | Hash[untyped, untyped] | ActiveRecord::Relation | Proc) -> Relation


### PR DESCRIPTION
`in_order_of` accepts an optional `filter:` keyword, but the activerecord 8.0 signatures didn't allow it. 
Add `?filter: bool` to both definitions and a test case.

https://github.com/rails/rails/pull/51761
https://github.com/rails/rails/releases/tag/v8.0.0