### PR TITLE
Add bolshakov as concurrent-ruby reviewer

### DIFF
--- a/gems/concurrent-ruby/_reviewers.yaml
+++ b/gems/concurrent-ruby/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - bolshakov


### PR DESCRIPTION
Adding myself as a Gem Reviewer for concurrent-ruby, per [Become a Gem Reviewer](https://github.com/ruby/gem_rbs_collection/blob/main/docs/CONTRIBUTING.md#become-a-gem-reviewer) in CONTRIBUTING.md. I've contributed several signatures to this gem (`AtomicReference`, `Map#delete`/`#delete_pair`, `TimerTask`, `FixedThreadPool`, `ImmediateExecutor`).