### PR TITLE
Add dry-container signatures

### DIFF
--- a/gems/dry-container/.rubocop.yml
+++ b/gems/dry-container/.rubocop.yml
@@ -1,0 +1,19 @@
+# This configuration inherits from /.rubocop.yml.
+# You can configure RBS style of this gem.
+# This file is used on CI. It is configured to automatically
+# make rubocop suggestions on pull requests for this gem.
+# If you do not like the style enforcement, you should remove this file.
+inherit_from: ../../.rubocop.yml
+
+##
+# If you want to customize the style, please consult with the gem reviewers.
+# You can see the list of cops at https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops.adoc
+
+RBS/Layout:
+  Enabled: true
+
+RBS/Lint:
+  Enabled: true
+
+RBS/Style:
+  Enabled: true

--- a/gems/dry-container/0.11/_test/metadata.yaml
+++ b/gems/dry-container/0.11/_test/metadata.yaml
@@ -1,0 +1,4 @@
+# If the test needs gem's RBS files, declare them here.
+#
+# additional_gems:
+#   - GEM_NAME

--- a/gems/dry-container/0.11/_test/test.rb
+++ b/gems/dry-container/0.11/_test/test.rb
@@ -1,0 +1,39 @@
+require "dry-container"
+
+module TestContainer
+  extend Dry::Container::Mixin
+
+  register(:item) { "item" }
+  register(:memoized, memoize: true) { "memoized" }
+
+  namespace(:nested) do
+    register(:item) { "nested item" }
+  end
+end
+
+TestContainer.resolve(:item) #=> "item"
+TestContainer[:memoized] #=> "memoized"
+TestContainer.key?(:item) #=> true
+TestContainer.keys #=> ["item", "memoized", "nested.item"]
+
+TestContainer.each_key { |key| key }
+TestContainer.each { |key, value| [key, value] }
+
+module OtherContainer
+  extend Dry::Container::Mixin
+
+  register(:other_item) { "other" }
+end
+TestContainer.merge(OtherContainer, namespace: :other)
+
+ns = Dry::Container::Namespace.new(:imported) do
+  register(:item) { "imported item" }
+end
+TestContainer.import(ns)
+
+TestContainer.freeze
+TestContainer.frozen? #=> true
+
+container = Dry::Container.new
+container.register(:item) { "item" }
+container.resolve(:item) #=> "item"

--- a/gems/dry-container/0.11/_test/test.rbs
+++ b/gems/dry-container/0.11/_test/test.rbs
@@ -1,0 +1,7 @@
+module TestContainer
+  extend Dry::Container::Mixin
+end
+
+module OtherContainer
+  extend Dry::Container::Mixin
+end

--- a/gems/dry-container/0.11/dry-container.rbs
+++ b/gems/dry-container/0.11/dry-container.rbs
@@ -1,0 +1,51 @@
+module Dry
+  class Container
+    class Namespace
+      attr_reader name: Symbol | String
+
+      attr_reader block: Proc
+
+      def initialize: (Symbol | String name) { () [self: Mixin] -> void } -> void
+    end
+
+    # Mixin to expose Inversion of Control (IoC) container behaviour
+    module Mixin
+      def register: (Symbol | String key, ?untyped contents, ?Hash[Symbol, bool] options) -> self
+                  | (Symbol | String key, ?Hash[Symbol, bool] options) { () -> untyped } -> self
+
+      def resolve: (Symbol | String key) -> untyped
+                 | (Symbol | String key) { (Symbol | String) -> untyped } -> untyped
+
+      def []: (Symbol | String key) -> untyped
+
+      def merge: (Mixin other, ?namespace: Symbol | String | nil) -> self
+
+      def key?: (Symbol | String key) -> bool
+
+      def keys: () -> Array[String]
+
+      def each_key: () { (String) -> void } -> self
+                  | () -> Enumerator[String, self]
+
+      def each: () { ([String, untyped]) -> void } -> void
+              | () -> Enumerator[[String, untyped], void]
+
+      def decorate: (Symbol | String key, ?with: untyped) -> self
+                  | (Symbol | String key, ?with: untyped) { (untyped) -> untyped } -> self
+
+      def namespace: (Symbol | String namespace) { () [self: Mixin] -> void } -> self
+
+      def import: (Namespace namespace) -> self
+
+      def freeze: () -> self
+
+      def dup: () -> self
+
+      def clone: () -> self
+    end
+
+    include Mixin
+
+    def initialize: (*untyped) -> void
+  end
+end


### PR DESCRIPTION
Adds RBS signatures for `dry-container` 0.11: `Dry::Container`, `Dry::Container::Mixin`, and `Dry::Container::Namespace`.

Covers `register`, `resolve`, `[]`, `merge`, `key?`, `keys`, `each`/`each_key`, `namespace`, `import`, `freeze`, `dup`, and `clone`.