### PR TITLE
Sinatra: Make erb block param optional

### DIFF
--- a/gems/sinatra/4.0/_test/test.rb
+++ b/gems/sinatra/4.0/_test/test.rb
@@ -46,6 +46,10 @@ class MyApp < Sinatra::Base
     json(status: 'ok')
   end
 
+  get '/test_erb' do
+    erb :index, locals: {foo: 42, bar: "baz"}
+  end
+
   get '/fail' do
     halt 500
   end

--- a/gems/sinatra/4.0/base.rbs
+++ b/gems/sinatra/4.0/base.rbs
@@ -343,7 +343,7 @@ module Sinatra
 
     def initialize: () -> void
 
-    def erb: (untyped template, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] locals) { () -> untyped } -> untyped
+    def erb: (untyped template, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] locals) ?{ () -> untyped } -> untyped
 
     def haml: (untyped template, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] locals) { () -> untyped } -> untyped
 


### PR DESCRIPTION
In Sinatra's templates the `erb` method block parameter is optional