### PR TITLE
Fix CGI::Util method definition locations in core.rbs

### DIFF
--- a/gems/cgi/0.5/core.rbs
+++ b/gems/cgi/0.5/core.rbs
@@ -6,6 +6,10 @@ class CGI
 
   extend CGI::Util
 
+  include CGI::Escape
+
+  extend CGI::Escape
+
   # <!--
   #   rdoc-file=lib/cgi/core.rb
   #   - CGI.new(tag_maker) { block }
@@ -886,7 +890,12 @@ class CGI
     #       # Sat, 01 Jan 2000 00:00:00 GMT
     #
     def rfc1123_date: (Time time) -> String
+  end
 
+  # <!-- rdoc-file=lib/cgi/escape.rb -->
+  # Escape/unescape for CGI, HTML, URI.
+  #
+  module Escape
     def escape: (String) -> String
     def unescape: (String, ?encoding: Encoding) -> String
 
@@ -907,9 +916,17 @@ class CGI
     alias escape_element escapeElement
     alias unescape_element unescapeElement
 
-    # <!-- rdoc-file=lib/cgi/util.rb -->
+    # <!-- rdoc-file=lib/cgi/escape.rb -->
     # The set of special characters and their escaped values
     #
     TABLE_FOR_ESCAPE_HTML__: Hash[String, String]
+  end
+
+  # <!-- rdoc-file=lib/cgi/escape.rb -->
+  # Internal module that provides a C-accelerated implementation of some
+  # CGI::Escape methods. Left empty here since it is an implementation
+  # detail and its public interface is already covered by CGI::Escape.
+  #
+  module EscapeExt
   end
 end

--- a/gems/cgi/0.5/core.rbs
+++ b/gems/cgi/0.5/core.rbs
@@ -907,12 +907,6 @@ class CGI
     alias escape_element escapeElement
     alias unescape_element unescapeElement
 
-    # Abbreviated day-of-week names specified by RFC 822
-    RFC822_DAYS: Array[String]
-
-    # Abbreviated month names specified by RFC 822
-    RFC822_MONTHS: Array[String]
-
     # <!-- rdoc-file=lib/cgi/util.rb -->
     # The set of special characters and their escaped values
     #

--- a/gems/cgi/0.5/core.rbs
+++ b/gems/cgi/0.5/core.rbs
@@ -892,9 +892,6 @@ class CGI
     def rfc1123_date: (Time time) -> String
   end
 
-  # <!-- rdoc-file=lib/cgi/escape.rb -->
-  # Escape/unescape for CGI, HTML, URI.
-  #
   module Escape
     def escape: (String) -> String
     def unescape: (String, ?encoding: Encoding) -> String
@@ -923,11 +920,6 @@ class CGI
     TABLE_FOR_ESCAPE_HTML__: Hash[String, String]
   end
 
-  # <!-- rdoc-file=lib/cgi/escape.rb -->
-  # Internal module that provides a C-accelerated implementation of some
-  # CGI::Escape methods. Left empty here since it is an implementation
-  # detail and its public interface is already covered by CGI::Escape.
-  #
   module EscapeExt
   end
 end

--- a/gems/cgi/0.5/core.rbs
+++ b/gems/cgi/0.5/core.rbs
@@ -908,6 +908,7 @@ class CGI
     def unescapeHTML: (String) -> String
     alias escape_html escapeHTML
     alias unescape_html unescapeHTML
+    alias h escapeHTML
 
     def escapeElement: (String, *String) -> String
                      | (String, Array[String]) -> String

--- a/gems/cgi/_reviewers.yaml
+++ b/gems/cgi/_reviewers.yaml
@@ -1,0 +1,2 @@
+reviewers:
+  - ksss


### PR DESCRIPTION
## Summary

`gems/cgi/0.5/core.rbs` incorrectly places several escape-related methods and a constant under `CGI::Util`. Checking against the actual `cgi` gem source (0.5.2) shows `CGI::Util` only defines `pretty` and `rfc1123_date`; everything else lives in `CGI::Escape` (with `CGI::EscapeExt` providing an optional C-accelerated override for a subset of methods).

- `escape`, `unescape`, `escapeURIComponent`, `unescapeURIComponent`, `escapeHTML`, `unescapeHTML`, `escapeElement`, `unescapeElement`, and `TABLE_FOR_ESCAPE_HTML__` are defined in `CGI::Escape` (`lib/cgi/escape.rb`), not `CGI::Util`. `CGI::EscapeExt` is added as an empty module — it's an internal implementation detail whose public surface is already covered by `CGI::Escape`.
- `RFC822_DAYS` and `RFC822_MONTHS` do not exist anywhere in the gem's source and are removed.
- `h`, an alias for `escapeHTML` defined in `lib/cgi/escape.rb`, was missing from `core.rbs` and is added.

Verified method ownership directly against a locally installed `cgi` 0.5.2 via `CGI.instance_method(:escape).owner` etc., and cross-checked the C extension (`ext/cgi/escape/escape.c`) for what `CGI::EscapeExt` actually defines at runtime.

- gems/cgi/_reviewers.yaml: adds ksss as a reviewer for the cgi gem.

## Test plan

- [x] `bin/test gems/cgi/0.5` passes (`rbs validate` + `steep check`) after each commit